### PR TITLE
cnf ran: fixed some talm robustness issues

### DIFF
--- a/tests/cnf/ran/internal/cluster/cluster.go
+++ b/tests/cnf/ran/internal/cluster/cluster.go
@@ -76,5 +76,6 @@ func isErrorExecuting(err error) bool {
 		return false
 	}
 
-	return strings.Contains(err.Error(), "error executing command in container")
+	return strings.Contains(err.Error(), "error executing command in container") ||
+		strings.Contains(err.Error(), "container not found")
 }

--- a/tests/cnf/ran/talm/internal/helper/cleanup.go
+++ b/tests/cnf/ran/talm/internal/helper/cleanup.go
@@ -19,7 +19,8 @@ func CleanupTestResourcesOnHub(client *clients.Settings, namespace, suffix strin
 	// Only errors that come from deletions are kept since an error pulling usually means it doesn't exist.
 	cgu, err := cgu.Pull(client, tsparams.CguName+suffix, namespace)
 	if err == nil {
-		_, err = cgu.Delete()
+		// CGUs often take a few seconds to delete, so make sure it is actually gone before moving on.
+		_, err = cgu.DeleteAndWait(5 * time.Minute)
 		if err != nil {
 			errorList = append(errorList, err)
 		}


### PR DESCRIPTION
While testing the talm test suite, two robustness issues came up. One was related to the MCO daemon pod restarting mid-test, so a new error message was added to the list for retries. There was also an issue with the CGU not being deleted before the next test started, resulting in an issue similar to openshift-kni/eco-goinfra#402.