### PR TITLE
ci: update checkout to v4

### DIFF
--- a/.github/workflows/docker-image-ci.yml
+++ b/.github/workflows/docker-image-ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3

--- a/.github/workflows/docker-image-manual.yml
+++ b/.github/workflows/docker-image-manual.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3

--- a/.github/workflows/eco-goinfra-bump.yml
+++ b/.github/workflows/eco-goinfra-bump.yml
@@ -8,7 +8,7 @@ jobs:
     name: Eco-goinfra module bump
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup agent and add repo ssh key
         run: |

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           go-version: 1.22.3
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Run lint
         run: make lint


### PR DESCRIPTION
`checkout` is out of date and should be updated to v4.

https://github.com/actions/checkout 