### PR TITLE
ci: add eco-goinfra compatibility check

### DIFF
--- a/.github/workflows/eco-goinfra-integration.yml
+++ b/.github/workflows/eco-goinfra-integration.yml
@@ -1,0 +1,48 @@
+name: eco-goinfra integration
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+      - 'release-\d.\d\d'
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    env:
+      SHELL: /bin/bash
+      ECO_GOINFRA_PATH: goinfra
+      ECO_GOINFRA_REPO: openshift-kni/eco-goinfra
+
+    steps:
+      - name: Check out the eco-gotests code
+        if: ${{ !contains(github.event.*.labels.*.name, 'ignore-dep-check') }}
+        uses: actions/checkout@v4
+      
+      - name: Set up Go
+        if: ${{ !contains(github.event.*.labels.*.name, 'ignore-dep-check') }}
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Check out the eco-goinfra code
+        if: ${{ !contains(github.event.*.labels.*.name, 'ignore-dep-check') }}
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.ECO_GOINFRA_REPO }}
+          # check out the branch name that is targeted by the PR
+          ref:  ${{ github.base_ref }}
+          path: ${{ env.ECO_GOINFRA_PATH }}
+
+      # Update the go.mod file in eco-gotests to include the current eco-goinfra code
+      - name: Update go.mod in eco-gotests
+        if: ${{ !contains(github.event.*.labels.*.name, 'ignore-dep-check') }}
+        run: |
+          go mod edit -replace github.com/openshift-kni/eco-goinfra=${{ github.workspace }}/${{ env.ECO_GOINFRA_PATH }}
+          go mod tidy
+          go mod vendor
+
+      - name: eco-goinfra go vet
+        if: ${{ !contains(github.event.*.labels.*.name, 'ignore-dep-check') }}
+        run: make vet


### PR DESCRIPTION
Similar to: https://github.com/openshift-kni/eco-goinfra/pull/455 

Checks to make sure that your PR is compatible with the current version of eco-goinfra.