### PR TITLE
Update Go to v1.22.4

### DIFF
--- a/.github/workflows/eco-goinfra-bump.yml
+++ b/.github/workflows/eco-goinfra-bump.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go 1.22
         uses: actions/setup-go@v3
         with:
-          go-version: 1.22.3
+          go-version: 1.22.4
 
       - name: Check for eco-goinfra module updates
         id: new_mods

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go 1.22
         uses: actions/setup-go@v3
         with:
-          go-version: 1.22.3
+          go-version: 1.22.4
 
       - uses: actions/checkout@v3
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi9/ubi:latest
 
-ARG GO_VER=go1.22.3
+ARG GO_VER=go1.22.4
 ARG GINKGO_VER=ginkgo@v2.15.0
 ARG CONTAINERUSER=testuser
 


### PR DESCRIPTION
Related to: 
- https://github.com/test-network-function/cnf-certification-test/pull/2134
- https://github.com/openshift-kni/eco-goinfra/pull/459

https://groups.google.com/g/golang-announce/c/XbxouI9gY7k