### PR TITLE
cnf ran: update pod security label for test namespace

### DIFF
--- a/tests/cnf/ran/powermanagement/powermanagement_suite_test.go
+++ b/tests/cnf/ran/powermanagement/powermanagement_suite_test.go
@@ -26,7 +26,8 @@ func TestPowerSave(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	// Cleanup and create test namespace
-	testNamespace := namespace.NewBuilder(Spoke1APIClient, tsparams.TestingNamespace)
+	testNamespace := namespace.NewBuilder(Spoke1APIClient, tsparams.TestingNamespace).
+		WithLabel("pod-security.kubernetes.io/enforce", "baseline")
 
 	glog.V(ranparam.LogLevel).Infof("Deleting test namespace ", tsparams.TestingNamespace)
 	err := testNamespace.DeleteAndWait(tsparams.PowerSaveTimeout)


### PR DESCRIPTION
In the powermanagement test suite, there is a failure due to the stressng pods not meeting the restricted security standard. This updates the namespace to only enforce the baseline standard, which should allow the stressng pods to be created.