### PR TITLE
cnf ran: talm precache excluded image fix

### DIFF
--- a/tests/cnf/ran/talm/internal/tsparams/consts.go
+++ b/tests/cnf/ran/talm/internal/tsparams/consts.go
@@ -115,11 +115,20 @@ const (
 	PreCacheSpokeNS = "openshift-talo-pre-cache"
 	// PreCacheOverrideName is the name of the config map for excluding images from precaching.
 	PreCacheOverrideName = "cluster-group-upgrade-overrides"
-	// PreCacheExcludedImage is the name of the image to be excluded from pre caching.
-	PreCacheExcludedImage = "openshift/ose-prometheus"
 	// PreCacheInvalidImage is a nonexistent image to use for pre caching tests.
 	PreCacheInvalidImage = `quay.io/openshift-release-dev/ocp-v4.0-art-dev@` +
 		`sha256:0000000000000000000000000000000000000000000000000000000000000000`
+	// SpokeImageDeleteCommand is the command to delete the excluded pre cache image.
+	SpokeImageDeleteCommand = `podman images --noheading  --filter "label=name=%s" --format {{.ID}}|` +
+		`xargs podman rmi --force`
+	// SpokeImageListCommand is the command to generate a list of cached images on the spoke cluster.
+	SpokeImageListCommand = `podman images  --noheading --filter "label=name=%s"`
+	// SpokeImageGetNameCommand is the command to get the name of an image.
+	SpokeImageGetNameCommand = `podman images --noheading %s --format {{.Labels.name}}`
+	// PrometheusPodName is the name of the prometheus pod.
+	PrometheusPodName = "prometheus-k8s-0"
+	// PrometheusNamespace is the namespace for prometheus.
+	PrometheusNamespace = "openshift-monitoring"
 
 	// MasterNodeSelector when used in a label selector finds all master nodes.
 	MasterNodeSelector = "node-role.kubernetes.io/master="

--- a/tests/cnf/ran/talm/internal/tsparams/talmvars.go
+++ b/tests/cnf/ran/talm/internal/tsparams/talmvars.go
@@ -28,14 +28,6 @@ var (
 	// TalmNonExistentPolicyMessage is the condition message for when a policy is non-existent.
 	TalmNonExistentPolicyMessage = fmt.Sprintf("Missing managed policies: [%s]", NonExistentPolicyName)
 
-	// SpokeImageListCommand is the command to generate a list of cached images on the spoke cluster.
-	SpokeImageListCommand = fmt.Sprintf(`podman images  --noheading --filter "label=name=%s"`, PreCacheExcludedImage)
-
-	// SpokeImageDeleteCommand is the command to delete PreCacheExcludedImage.
-	SpokeImageDeleteCommand = fmt.Sprintf(
-		`podman images --noheading  --filter "label=name=%s" --format {{.ID}}|xargs podman rmi --force`,
-		PreCacheExcludedImage)
-
 	// Spoke1Name is the name of the first spoke cluster.
 	Spoke1Name string
 	// Spoke2Name is the name of the second spoke cluster.

--- a/tests/cnf/ran/talm/tests/talm_precache.go
+++ b/tests/cnf/ran/talm/tests/talm_precache.go
@@ -103,9 +103,40 @@ var _ = Describe("TALM precache", Label(tsparams.LabelPreCacheTestCases), func()
 		})
 
 		Context("precache OCP with image", func() {
+			var (
+				excludedPreCacheImage string
+				imageListCommand      string
+				imageDeleteCommand    string
+			)
+
 			BeforeEach(func() {
-				By("wiping any existing images from spoke 1 master")
-				_ = cluster.ExecCmd(raninittools.Spoke1APIClient, 3, tsparams.MasterNodeSelector, tsparams.SpokeImageDeleteCommand)
+				By("finding image to exclude")
+				prometheusPod, err := pod.Pull(
+					raninittools.Spoke1APIClient, tsparams.PrometheusPodName, tsparams.PrometheusNamespace)
+				Expect(err).ToNot(HaveOccurred(), "Failed to pull prometheus pod")
+
+				getImageNameCommand := fmt.Sprintf(
+					tsparams.SpokeImageGetNameCommand, prometheusPod.Definition.Spec.Containers[0].Image)
+				excludedPreCacheImages, err := cluster.ExecCmdWithStdout(
+					raninittools.Spoke1APIClient,
+					3,
+					getImageNameCommand,
+					metav1.ListOptions{LabelSelector: tsparams.MasterNodeSelector})
+				Expect(err).ToNot(HaveOccurred(), "Failed to get name of prometheus pod image")
+				Expect(excludedPreCacheImages).ToNot(BeEmpty(), "Failed to get name of prometheus pod image on any nodes")
+
+				for _, image := range excludedPreCacheImages {
+					excludedPreCacheImage = strings.Trim(image, "\r\n ")
+					imageListCommand = fmt.Sprintf(tsparams.SpokeImageListCommand, excludedPreCacheImage)
+					imageDeleteCommand = fmt.Sprintf(tsparams.SpokeImageDeleteCommand, excludedPreCacheImage)
+
+					break
+				}
+
+				if excludedPreCacheImage != "" {
+					By("wiping any existing images from spoke 1 master")
+					_ = cluster.ExecCmd(raninittools.Spoke1APIClient, 3, tsparams.MasterNodeSelector, imageDeleteCommand)
+				}
 			})
 
 			AfterEach(func() {
@@ -138,7 +169,7 @@ var _ = Describe("TALM precache", Label(tsparams.LabelPreCacheTestCases), func()
 				preCachedImages, err := cluster.ExecCmdWithStdout(
 					raninittools.Spoke1APIClient,
 					3,
-					tsparams.SpokeImageListCommand,
+					imageListCommand,
 					metav1.ListOptions{LabelSelector: tsparams.MasterNodeSelector})
 				Expect(err).ToNot(HaveOccurred(), "Failed to generate list of precached images on spoke 1")
 				Expect(preCachedImages).ToNot(BeEmpty(), "Failed to find a master node for spoke 1")
@@ -182,7 +213,7 @@ var _ = Describe("TALM precache", Label(tsparams.LabelPreCacheTestCases), func()
 				preCachedImages, err := cluster.ExecCmdWithStdout(
 					raninittools.Spoke1APIClient,
 					3,
-					tsparams.SpokeImageListCommand,
+					imageListCommand,
 					metav1.ListOptions{LabelSelector: tsparams.MasterNodeSelector})
 				Expect(err).ToNot(HaveOccurred(), "Failed to generate list of precached images on spoke 1")
 				Expect(preCachedImages).ToNot(BeEmpty(), "Failed to find a master node for spoke 1")


### PR DESCRIPTION
To support different image names as they change across versions, the excluded image is now pulled from the Prometheus pod on the cluster. It also only deletes the excluded image if it is found to avoid deleting all spoke images when it is not found.

cc: @yliu127 @josclark42