### PR TITLE
cnf ran: remove cat hack from powersave

### DIFF
--- a/tests/cnf/ran/powermanagement/internal/helper/helper.go
+++ b/tests/cnf/ran/powermanagement/internal/helper/helper.go
@@ -128,9 +128,6 @@ func SetCPUFreq(
 	// Wait for Isolated CPU Frequency to be updated.
 	err = wait.PollUntilContextTimeout(
 		context.TODO(), 2*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
-			if err != nil {
-				return false, err
-			}
 			// Get current isolated core frequency from spoke cluster and compare to desired frequency
 			cmdOut, err := cluster.ExecCommandOnSNO(Spoke1APIClient, 3, spokeCommandIsolatedCPUs)
 
@@ -138,10 +135,13 @@ func SetCPUFreq(
 				return false, fmt.Errorf("command failed: %s", cmdOut)
 			}
 
-			currIsolatedCoreFreq, err := strconv.Atoi(strings.TrimSpace(cmdOut))
+			cmdOut = strings.TrimSpace(cmdOut)
+			currIsolatedCoreFreq, err := strconv.Atoi(cmdOut)
 
 			if err != nil {
-				return false, fmt.Errorf("string conversion failed failed: %w", err)
+				glog.V(tsparams.LogLevel).Infof("converting cpu frequency %s to an int failed: %w", cmdOut, err)
+
+				return false, nil
 			}
 
 			if currIsolatedCoreFreq != int(*desiredIsolatedCoreFreq) {
@@ -155,9 +155,13 @@ func SetCPUFreq(
 				return false, fmt.Errorf("command failed: %s", cmdOut)
 			}
 
-			currReservedFreq, err := strconv.Atoi(strings.TrimSpace(cmdOut))
+			cmdOut = strings.TrimSpace(cmdOut)
+			currReservedFreq, err := strconv.Atoi(cmdOut)
+
 			if err != nil {
-				return false, fmt.Errorf("string conversion failed failed: %w", err)
+				glog.V(tsparams.LogLevel).Infof("converting cpu frequency %s to an int failed: %w", cmdOut, err)
+
+				return false, nil
 			}
 
 			if currReservedFreq != int(*desiredReservedCoreFreq) {

--- a/tests/cnf/ran/powermanagement/tests/cpufreq.go
+++ b/tests/cnf/ran/powermanagement/tests/cpufreq.go
@@ -1,9 +1,11 @@
 package tests
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -14,6 +16,7 @@ import (
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/powermanagement/internal/helper"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/powermanagement/internal/tsparams"
 	performancev2 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v2"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/cpuset"
 )
 
@@ -29,7 +32,6 @@ var _ = Describe("CPU frequency tuning tests change the core frequencies of isol
 		)
 
 		BeforeEach(func() {
-
 			perfProfile, err = helper.GetPerformanceProfileWithCPUSet()
 			Expect(err).ToNot(HaveOccurred(), "Failed to get performance profile")
 
@@ -46,13 +48,10 @@ var _ = Describe("CPU frequency tuning tests change the core frequencies of isol
 			reservedCPUNumber := reservedCPUsList[0]
 
 			By("getting original isolated core frequency")
-			originalIsolatedCPUFreq, err = getCPUFreq(isolatedCPUNumber)
-			Expect(err).ToNot(HaveOccurred(), "Failed to get original isolated core frequency")
+			originalIsolatedCPUFreq = getCPUFreq(isolatedCPUNumber)
 
 			By("getting original reserved core frequency")
-			originalReservedCPUFreq, err = getCPUFreq(reservedCPUNumber)
-			Expect(err).ToNot(HaveOccurred(), "Failed to get original reserved core frequency")
-
+			originalReservedCPUFreq = getCPUFreq(reservedCPUNumber)
 		})
 
 		AfterEach(func() {
@@ -62,7 +61,6 @@ var _ = Describe("CPU frequency tuning tests change the core frequencies of isol
 		})
 
 		When("reserved and isolated core frequency is configured via PerformanceProfile", func() {
-
 			It("sets the reserved and isolated core frequency correctly on the DUT", func() {
 
 				versionInRange, err := ranhelper.IsVersionStringInRange(RANConfig.Spoke1OCPVersion, "4.16", "")
@@ -80,15 +78,30 @@ var _ = Describe("CPU frequency tuning tests change the core frequencies of isol
 	})
 
 // getCPUFreq gets the current frequency of a given CPU core.
-func getCPUFreq(coreID int) (performancev2.CPUfrequency, error) {
+func getCPUFreq(coreID int) performancev2.CPUfrequency {
 	spokeCommand := fmt.Sprintf("cat /sys/devices/system/cpu/cpufreq/policy%v/scaling_max_freq",
 		coreID)
-	cmdOut, err := cluster.ExecCommandOnSNO(Spoke1APIClient, 3, spokeCommand)
-	Expect(err).ToNot(HaveOccurred(), "Failed to %s, error:%s", spokeCommand, cmdOut)
-	freqAsInt, err := strconv.Atoi(strings.TrimSpace(cmdOut))
-	Expect(err).ToNot(HaveOccurred(), "strconv.Atoi Failed")
 
-	cpuFreq := performancev2.CPUfrequency(freqAsInt)
+	var frequency int
 
-	return cpuFreq, err
+	// Retry if we cannot convert the frequency to an int, since this usually means malformed output. Errors in
+	// command execution are actual errors though and are returned immediately.
+	err := wait.PollUntilContextTimeout(
+		context.TODO(), time.Second, 10*time.Second, true, func(ctx context.Context) (bool, error) {
+			cmdOut, err := cluster.ExecCommandOnSNO(Spoke1APIClient, 3, spokeCommand)
+			if err != nil {
+				return false, err
+			}
+
+			frequency, err = strconv.Atoi(strings.TrimSpace(cmdOut))
+			if err != nil {
+				return false, nil
+			}
+
+			return true, nil
+		})
+
+	Expect(err).ToNot(HaveOccurred(), "Failed to check cpu %d frequency", coreID)
+
+	return performancev2.CPUfrequency(frequency)
 }


### PR DESCRIPTION
The powersave test cases would pipe the output from cat into `cat -` which causes errors to be ignored as a workaround for ocassional malformed output. This has been converted to us Eventually to allow for retrying on malformed output.