### PR TITLE
ibu cnf: add 'rollback after a successful upgrade' test

### DIFF
--- a/tests/lca/imagebasedupgrade/cnf/upgrade-talm/internal/tsparams/const.go
+++ b/tests/lca/imagebasedupgrade/cnf/upgrade-talm/internal/tsparams/const.go
@@ -35,4 +35,9 @@ const (
 
 	// IbuPolicyNamespace is the namespace where IBU policies created on target hub.
 	IbuPolicyNamespace = "ztp-group"
+
+	// RollbackCguName is the name of rollback cgu.
+	RollbackCguName = "cgu-ibu-rollback"
+	// RollbackPolicyName is the name of managed policy for ibu rollback stage validation.
+	RollbackPolicyName = "group-ibu-rollback-stage-policy"
 )


### PR DESCRIPTION
@mcornea , @klaskosk , Please review this PR when you have a moment. Thanks!

adding 'rollback after a successful upgrade' test steps within e2e-upgrade-test.go file which serves below purposes.

1. covering test case - rollback after a successful upgrade, 
2. removing dependency other test functional test cases exists within "upgrade-talm" test suite.

**High-level test automation code change summary:-**
updating e2e-upgrade-test.go file to include below steps in AfterAll()
func1
create rollback cgu and wait until the cgu report completed. 
func2
create finalize cgu and wait until the cgu report completed. 
func3
delete rollback cgu
func4
delete finalize cgu

