### PR TITLE
Add Version Check to Reserved Core Freqency Tuning Test. Fix and move CompareOCPVersionWithCurrent() 

### DIFF
--- a/tests/cnf/ran/powermanagement/internal/helper/helper.go
+++ b/tests/cnf/ran/powermanagement/internal/helper/helper.go
@@ -89,6 +89,10 @@ func SetCPUFreq(
 	desiredReservedCoreFreq *performancev2.CPUfrequency) error {
 	glog.V(tsparams.LogLevel).Infof("Set Reserved and Isolated CPU Frequency on performance profile")
 
+	if perfProfile.Definition.Spec.HardwareTuning == nil {
+		perfProfile.Definition.Spec.HardwareTuning = &performancev2.HardwareTuning{}
+	}
+
 	// Update PerfProfile with new CPU Frequencies
 	perfProfile.Definition.Spec.HardwareTuning.IsolatedCpuFreq = desiredIsolatedCoreFreq
 	perfProfile.Definition.Spec.HardwareTuning.ReservedCpuFreq = desiredReservedCoreFreq

--- a/tests/cnf/ran/powermanagement/tests/cpufreq.go
+++ b/tests/cnf/ran/powermanagement/tests/cpufreq.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/openshift-kni/eco-goinfra/pkg/nto" //nolint:misspell
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/cluster"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/ranhelper"
 	. "github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/raninittools"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/powermanagement/internal/helper"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/powermanagement/internal/tsparams"
@@ -63,7 +64,15 @@ var _ = Describe("CPU frequency tuning tests change the core frequencies of isol
 		When("reserved and isolated core frequency is configured via PerformanceProfile", func() {
 
 			It("sets the reserved and isolated core frequency correctly on the DUT", func() {
-				err := helper.SetCPUFreq(perfProfile, &desiredIsolatedCoreFreq, &desiredReservedCoreFreq)
+
+				versionInRange, err := ranhelper.IsVersionStringInRange(RANConfig.Spoke1OCPVersion, "4.16", "")
+				Expect(err).ToNot(HaveOccurred(), "Failed to compare OCP version string")
+
+				if !versionInRange {
+					Skip("OCP 4.16 or higher required for this test")
+				}
+
+				err = helper.SetCPUFreq(perfProfile, &desiredIsolatedCoreFreq, &desiredReservedCoreFreq)
 				Expect(err).ToNot(HaveOccurred(), "Failed to set CPU Freq")
 
 			})


### PR DESCRIPTION
- This PR adds an OCP version check to the Reserved Core Freqency Tuning test, ensuring it only runs on OCP 4.16 or greater.

- CompareOCPVersionWithCurrent() was moved from  tests/system-tests/internal/platform/platform.go to tests/internal/cluster/config.go so it could be imported into tests/cnf/ran/tests
 
- tests/system-tests/vcore/internal/vcorecommon/cgroup-operator.go was updated to reflect the new location of CompareOCPVersionWithCurrent()
 
- Finally, a bug was found and fixed in CompareOCPVersionWithCurrent(). Previously, in the case where isGreater=true and the check failed, the LessThan function would still run and the function would return true erroneously. Essentially the function was testing for both greater than and less than at the same time.  I added an if !greater block around the final check to fix this.

 
