### PR TITLE
lca: cnf exclude operators and sriov nnp from post validation checks

### DIFF
--- a/tests/lca/imagebasedupgrade/cnf/internal/cnfclusterinfo/cnfclusterinfo.go
+++ b/tests/lca/imagebasedupgrade/cnf/internal/cnfclusterinfo/cnfclusterinfo.go
@@ -59,6 +59,8 @@ type ClusterStruct struct {
 }
 
 // SaveClusterInfo is a dedicated func to save cluster info.
+//
+//nolint:funlen
 func (upgradeVar *ClusterStruct) SaveClusterInfo() error {
 	clusterVersion, err := cluster.GetOCPClusterVersion(cnfinittools.TargetSNOAPIClient)
 
@@ -88,7 +90,11 @@ func (upgradeVar *ClusterStruct) SaveClusterInfo() error {
 
 	for _, csv := range csvList {
 		if !slices.Contains(installedCSV, csv.Object.Name) {
-			installedCSV = append(installedCSV, csv.Object.Name)
+			if !strings.Contains(csv.Object.Name, "oadp-operator") &&
+				!strings.Contains(csv.Object.Name, "packageserver") &&
+				!strings.Contains(csv.Object.Name, "sriov-fec") {
+				installedCSV = append(installedCSV, csv.Object.Name)
+			}
 		}
 	}
 
@@ -116,7 +122,9 @@ func (upgradeVar *ClusterStruct) SaveClusterInfo() error {
 	sriovPolicy, err := sriov.ListPolicy(cnfinittools.TargetSNOAPIClient, cnfinittools.CNFConfig.SriovOperatorNamespace)
 
 	for _, policy := range sriovPolicy {
-		upgradeVar.SriovNetworkNodePolicies = append(upgradeVar.SriovNetworkNodePolicies, policy.Object.Name)
+		if !strings.Contains(policy.Object.Name, "default") {
+			upgradeVar.SriovNetworkNodePolicies = append(upgradeVar.SriovNetworkNodePolicies, policy.Object.Name)
+		}
 	}
 
 	upgradeVar.Version = clusterVersion.Object.Status.Desired.Version

--- a/tests/lca/imagebasedupgrade/cnf/internal/validations/post_ibu_validations.go
+++ b/tests/lca/imagebasedupgrade/cnf/internal/validations/post_ibu_validations.go
@@ -228,7 +228,7 @@ func ValidateSeedHostnameRefEtcd() {
 
 			etcdCmd := fmt.Sprintf(
 				"for key in $(etcdctl get --prefix / --keys-only | grep -v ^$); do"+
-					"  value=$(etcdctl get --print-value-only $key); "+
+					"  value=$(etcdctl get --print-value-only $key | tr -d '\\0'); "+
 					"  if [[ $value == *%s* ]]; then"+
 					"    echo Key: $key contains seed reference;"+
 					"    break; "+


### PR DESCRIPTION
- exclude operators whose version does not change during upgrade
- exclude default sriov nnp which is not present in 4.16
- exclude null characters when validating seed entries in etcd for a cleaner output