### PR TITLE
system-test: deploy workload with RBD volumes

### DIFF
--- a/tests/system-tests/rdscore/tests/00_validate_top_level.go
+++ b/tests/system-tests/rdscore/tests/00_validate_top_level.go
@@ -81,6 +81,9 @@ var _ = Describe(
 				By("Creating a workload with CephFS PVC")
 				rdscorecommon.DeployWorkflowCephFSPVC(ctx)
 
+				By("Creating a workload with CephRBD PVC")
+				rdscorecommon.DeployWorkloadCephRBDPVC(ctx)
+
 				By("Creating SR-IOV workloads on the same node")
 				rdscorecommon.VerifySRIOVWorkloadsOnSameNode(ctx)
 
@@ -188,6 +191,10 @@ var _ = Describe(
 				Label("persistent-storage", "verify-cephfs"), reportxml.ID("71873"),
 				rdscorecommon.VerifyDataOnCephFSPVC)
 
+			It("Verifies CephRBD PVC is still accessible",
+				Label("persistent-storage", "verify-cephrbd"), reportxml.ID("71990"),
+				rdscorecommon.VerifyDataOnCephRBDPVC)
+
 			It("Verifies CephFS workload is deployable after hard reboot",
 				Label("persistent-storage", "deploy-cephfs-pvc"), reportxml.ID("71851"), MustPassRepeatedly(3),
 				rdscorecommon.VerifyCephFSPVC)
@@ -217,6 +224,9 @@ var _ = Describe(
 			BeforeAll(func(ctx SpecContext) {
 				By("Creating a workload with CephFS PVC")
 				rdscorecommon.DeployWorkflowCephFSPVC(ctx)
+
+				By("Creating a workload with CephRBD PVC")
+				rdscorecommon.DeployWorkloadCephRBDPVC(ctx)
 
 				By("Creating SR-IOV worklods that run on same node")
 				rdscorecommon.VerifySRIOVWorkloadsOnSameNode(ctx)
@@ -274,6 +284,10 @@ var _ = Describe(
 			It("Verifies CephFS PVC is still accessible",
 				Label("persistent-storage", "verify-cephfs"), reportxml.ID("72042"),
 				rdscorecommon.VerifyDataOnCephFSPVC)
+
+			It("Verifies CephRBD PVC is still accessible",
+				Label("persistent-storage", "verify-cephrbd"), reportxml.ID("72044"),
+				rdscorecommon.VerifyDataOnCephRBDPVC)
 
 			It("Verifies CephFS workload is deployable after graceful reboot",
 				Label("persistent-storage", "deploy-cephfs-pvc"), reportxml.ID("72045"), MustPassRepeatedly(3),


### PR DESCRIPTION
Revert "system-test: remove RBD deployment pre-requisite (#42)"

This reverts commit 9b86c03c84cf734ebc8bf87f809b12cc0882b493.

Deploy workload with RBD volume to be used in post reboot tests.