### PR TITLE
ibu mgmt: move the set to idle to after all.

### DIFF
--- a/tests/lca/imagebasedupgrade/mgmt/upgrade/tests/e2e-upgrade-test.go
+++ b/tests/lca/imagebasedupgrade/mgmt/upgrade/tests/e2e-upgrade-test.go
@@ -160,6 +160,13 @@ var _ = Describe(
 		})
 
 		AfterAll(func() {
+			if MGMTConfig.IdlePostUpgrade && !MGMTConfig.RollbackAfterUpgrade {
+				By("Set the IBU stage to Idle")
+
+				_, err = ibu.WithStage("Idle").Update()
+				Expect(err).NotTo(HaveOccurred(), "error setting ibu to idle stage")
+			}
+
 			if !MGMTConfig.IdlePostUpgrade && MGMTConfig.RollbackAfterUpgrade {
 				By("Revert IBU resource back to Idle stage")
 				ibu, err = lca.PullImageBasedUpgrade(APIClient)
@@ -451,13 +458,6 @@ func upgrade() {
 				}
 			}
 		}
-	}
-
-	if MGMTConfig.IdlePostUpgrade && !MGMTConfig.RollbackAfterUpgrade {
-		By("Set the IBU stage to Idle")
-
-		_, err = ibu.WithStage("Idle").Update()
-		Expect(err).NotTo(HaveOccurred(), "error setting ibu to idle stage")
 	}
 }
 


### PR DESCRIPTION
This will help ensuring an additional test is ran.