### PR TITLE
lca: cnf: fix rollback-after-failed-upgrade-test

### DIFF
--- a/tests/lca/imagebasedupgrade/cnf/upgrade-talm/tests/rollback-after-failed-upgrade-test.go
+++ b/tests/lca/imagebasedupgrade/cnf/upgrade-talm/tests/rollback-after-failed-upgrade-test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openshift-kni/eco-gotests/tests/lca/imagebasedupgrade/cnf/upgrade-talm/internal/tsparams"
 	"github.com/openshift-kni/eco-gotests/tests/lca/imagebasedupgrade/internal/nodestate"
 	"github.com/openshift-kni/eco-gotests/tests/lca/imagebasedupgrade/internal/safeapirequest"
+	lcav1 "github.com/openshift-kni/lifecycle-agent/api/imagebasedupgrade/v1"
 )
 
 var (
@@ -52,6 +53,7 @@ var _ = Describe(
 				seedImageVersion = ibu.Definition.Spec.SeedImageRef.Version
 
 				By("Setting LCA init-monitor watchdog timer to 5 minutes")
+				ibu.Definition.Spec.AutoRollbackOnFailure = &lcav1.AutoRollbackOnFailure{}
 				ibu.Definition.Spec.AutoRollbackOnFailure.InitMonitorTimeoutSeconds = 300
 				ibu, err = ibu.Update()
 				Expect(err).NotTo(HaveOccurred(), "error updating ibu resource with custom lca init-monitor timeout value")


### PR DESCRIPTION
Currently the test panicks with the following error:

 runtime error: invalid memory address or nil pointer dereference

This change initializes the AutoRollbackOnFailure structure before setting the AutoRollbackOnFailure value.


```
  STEP: Setting LCA init-monitor watchdog timer to 5 minutes - /home/marius/git/eco-gotests/tests/lca/imagebasedupgrade/cnf/upgrade-talm/tests/rollback-after-failed-upgrade-test.go:54 @ 07/02/24 10:46:45.281
  END STEP: Retrieve seed image version and updating LCA init-monitor watchdog timer  - /home/marius/git/eco-gotests/tests/lca/imagebasedupgrade/cnf/upgrade-talm/tests/rollback-after-failed-upgrade-test.go:48 @ 07/02/24 10:46:45.281 (318ms)
  [PANICKED] Test Panicked
  In [BeforeEach] at: /usr/local/go/src/runtime/panic.go:261 @ 07/02/24 10:46:45.281

  runtime error: invalid memory address or nil pointer dereference

  Full Stack Trace
    github.com/openshift-kni/eco-gotests/tests/lca/imagebasedupgrade/cnf/upgrade-talm/tests.init.func3.1.3()
        /home/marius/git/eco-gotests/tests/lca/imagebasedupgrade/cnf/upgrade-talm/tests/rollback-after-failed-upgrade-test.go:55 +0x143
    github.com/openshift-kni/eco-gotests/tests/lca/imagebasedupgrade/cnf/upgrade-talm/tests.init.func3.1()
        /home/marius/git/eco-gotests/tests/lca/imagebasedupgrade/cnf/upgrade-talm/tests/rollback-after-failed-upgrade-test.go:48 +0xab
  < Exit [BeforeEach] Validating rollback stage after a failed upgrade - /home/marius/git/eco-gotests/tests/lca/imagebasedupgrade/cnf/upgrade-talm/tests/rollback-after-failed-upgrade-test.go:35 @ 07/02/24 10:46:45.281 (10.035s)
```