### PR TITLE
lca: cnf: wait for ibu idle stage after finalize cgu

### DIFF
--- a/tests/lca/imagebasedupgrade/cnf/upgrade-talm/tests/e2e-upgrade-test.go
+++ b/tests/lca/imagebasedupgrade/cnf/upgrade-talm/tests/e2e-upgrade-test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/openshift-kni/eco-goinfra/pkg/cgu"
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/openshift-kni/eco-goinfra/pkg/lca"
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
 	"github.com/openshift-kni/eco-gotests/tests/lca/imagebasedupgrade/cnf/internal/cnfcluster"
 	"github.com/openshift-kni/eco-gotests/tests/lca/imagebasedupgrade/cnf/internal/cnfclusterinfo"
@@ -44,6 +45,8 @@ var _ = Describe(
 
 				tsparams.TargetSnoClusterName = cnfclusterinfo.PreUpgradeClusterInfo.Name
 
+				ibu, err = lca.PullImageBasedUpgrade(cnfinittools.TargetSNOAPIClient)
+				Expect(err).NotTo(HaveOccurred(), "error pulling ibu resource from cluster")
 			})
 		})
 
@@ -93,6 +96,9 @@ var _ = Describe(
 				finalizeCguBuilder, err := finalizeCguBuilder.Create()
 				Expect(err).ToNot(HaveOccurred(), "Failed to create finalize CGU.")
 
+				_, err = ibu.WaitUntilStageComplete("Idle")
+				Expect(err).NotTo(HaveOccurred(), "error waiting for idle stage to complete")
+
 				_, err = finalizeCguBuilder.WaitUntilComplete(5 * time.Minute)
 				Expect(err).ToNot(HaveOccurred(), "Finalize CGU did not complete in time.")
 			})
@@ -108,6 +114,11 @@ var _ = Describe(
 					tsparams.IbuCguNamespace)
 				Expect(err).ToNot(HaveOccurred(), "Failed to delete finalize cgu on target hub cluster")
 			})
+
+			// Sleep for 10 seconds to allow talm to reconcile state.
+			// Sometimes if the next test re-creates the CGUs too quickly,
+			// the policies compliance status is not updated correctly.
+			time.Sleep(10 * time.Second)
 		})
 
 		It("Upgrade end to end", reportxml.ID("68954"), func() {
@@ -136,6 +147,9 @@ var _ = Describe(
 
 				prepCguBuilder, err := prepCguBuilder.Create()
 				Expect(err).ToNot(HaveOccurred(), "Failed to create prep CGU.")
+
+				_, err = ibu.WaitUntilStageComplete("Prep")
+				Expect(err).NotTo(HaveOccurred(), "error waiting for prep stage to complete")
 
 				_, err = prepCguBuilder.WaitUntilComplete(25 * time.Minute)
 				Expect(err).ToNot(HaveOccurred(), "Prep CGU did not complete in time.")

--- a/tests/lca/imagebasedupgrade/cnf/upgrade-talm/tests/rollback-after-failed-upgrade-test.go
+++ b/tests/lca/imagebasedupgrade/cnf/upgrade-talm/tests/rollback-after-failed-upgrade-test.go
@@ -19,7 +19,6 @@ import (
 	. "github.com/openshift-kni/eco-gotests/tests/lca/imagebasedupgrade/cnf/internal/cnfinittools"
 	"github.com/openshift-kni/eco-gotests/tests/lca/imagebasedupgrade/cnf/upgrade-talm/internal/tsparams"
 	"github.com/openshift-kni/eco-gotests/tests/lca/imagebasedupgrade/internal/nodestate"
-	"github.com/openshift-kni/eco-gotests/tests/lca/imagebasedupgrade/internal/safeapirequest"
 	lcav1 "github.com/openshift-kni/lifecycle-agent/api/imagebasedupgrade/v1"
 )
 
@@ -91,6 +90,9 @@ var _ = Describe(
 				finalizeCguBuilder, err := finalizeCguBuilder.Create()
 				Expect(err).ToNot(HaveOccurred(), "Failed to create finalize CGU.")
 
+				_, err = ibu.WaitUntilStageComplete("Idle")
+				Expect(err).NotTo(HaveOccurred(), "error waiting for idle stage to complete")
+
 				_, err = finalizeCguBuilder.WaitUntilComplete(5 * time.Minute)
 				Expect(err).ToNot(HaveOccurred(), "Finalize CGU did not complete in time.")
 			})
@@ -100,6 +102,11 @@ var _ = Describe(
 					tsparams.IbuCguNamespace)
 				Expect(err).ToNot(HaveOccurred(), "Failed to delete finalize cgu on target hub cluster")
 			})
+
+			// Sleep for 10 seconds to allow talm to reconcile state.
+			// Sometimes if the next test re-creates the CGUs too quickly,
+			// the policies compliance status is not updated correctly.
+			time.Sleep(10 * time.Second)
 		})
 
 		It("Rollback after a failed upgrade", reportxml.ID("69054"), func() {
@@ -129,6 +136,9 @@ var _ = Describe(
 
 				prepCguBuilder, err = prepCguBuilder.Create()
 				Expect(err).NotTo(HaveOccurred(), "Failed to create prep CGU.")
+
+				_, err = ibu.WaitUntilStageComplete("Prep")
+				Expect(err).NotTo(HaveOccurred(), "error waiting for prep stage to complete")
 
 				_, err = prepCguBuilder.WaitUntilComplete(25 * time.Minute)
 				Expect(err).NotTo(HaveOccurred(), "Prep CGU did not complete in time.")
@@ -170,15 +180,6 @@ var _ = Describe(
 					Expect(err).To(BeNil(), "error waiting for %s node to become reachable", node.Object.Name)
 					Expect(reachable).To(BeTrue(), "error: node %s is still unreachable", node.Object.Name)
 				}
-
-				By("Wait until node is reporting as Ready")
-
-				err = safeapirequest.Do(func() error {
-					_, err := nodes.WaitForAllNodesAreReady(TargetSNOAPIClient, time.Minute*15)
-
-					return err
-				})
-				Expect(err).To(BeNil(), "error waiting for node to become ready")
 
 				By("Wait for IBU resource to be available")
 
@@ -239,15 +240,6 @@ var _ = Describe(
 						Expect(err).To(BeNil(), "error waiting for %s node to become reachable", node.Object.Name)
 						Expect(reachable).To(BeTrue(), "error: node %s is still unreachable", node.Object.Name)
 					}
-
-					By("Wait until node is reporting as Ready")
-
-					err = safeapirequest.Do(func() error {
-						_, err := nodes.WaitForAllNodesAreReady(TargetSNOAPIClient, time.Minute*15)
-
-						return err
-					})
-					Expect(err).To(BeNil(), "error waiting for node to become ready")
 
 					By("Wait for IBU resource to be available")
 

--- a/tests/lca/imagebasedupgrade/cnf/upgrade-talm/tests/upgrade-abort-test.go
+++ b/tests/lca/imagebasedupgrade/cnf/upgrade-talm/tests/upgrade-abort-test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/openshift-kni/eco-goinfra/pkg/cgu"
+	"github.com/openshift-kni/eco-goinfra/pkg/lca"
 	"github.com/openshift-kni/eco-goinfra/pkg/ocm"
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
 	"github.com/openshift-kni/eco-gotests/tests/lca/imagebasedupgrade/cnf/internal/cnfclusterinfo"
@@ -28,6 +29,9 @@ var _ = Describe(
 				Expect(err).ToNot(HaveOccurred(), "Failed to extract target sno cluster name")
 
 				tsparams.TargetSnoClusterName = cnfclusterinfo.PreUpgradeClusterInfo.Name
+
+				ibu, err = lca.PullImageBasedUpgrade(cnfinittools.TargetSNOAPIClient)
+				Expect(err).NotTo(HaveOccurred(), "error pulling ibu resource from cluster")
 			})
 		})
 
@@ -45,17 +49,16 @@ var _ = Describe(
 				Expect(err).ToNot(HaveOccurred(), "Failed to delete prep cgu on target hub cluster")
 			})
 
-			By("Deleting upgrade cgu created on target hub cluster", func() {
-				err := cnfhelper.DeleteIbuTestCguOnTargetHub(cnfinittools.TargetHubAPIClient, tsparams.UpgradeCguName,
-					tsparams.IbuCguNamespace)
-				Expect(err).ToNot(HaveOccurred(), "Failed to delete upgrade cgu on target hub cluster")
-			})
-
 			By("Deleting finalize cgu created on target hub cluster", func() {
 				err := cnfhelper.DeleteIbuTestCguOnTargetHub(cnfinittools.TargetHubAPIClient, tsparams.FinalizeCguName,
 					tsparams.IbuCguNamespace)
 				Expect(err).ToNot(HaveOccurred(), "Failed to delete finalize cgu on target hub cluster")
 			})
+
+			// Sleep for 10 seconds to allow talm to reconcile state.
+			// Sometimes if the next test re-creates the CGUs too quickly,
+			// the policies compliance status is not updated correctly.
+			time.Sleep(10 * time.Second)
 		})
 
 		It("Abort at IBU upgrade stage", reportxml.ID("69055"), func() {
@@ -85,6 +88,9 @@ var _ = Describe(
 				prepCguBuilder, err := prepCguBuilder.Create()
 				Expect(err).ToNot(HaveOccurred(), "Failed to create prep CGU.")
 
+				_, err = ibu.WaitUntilStageComplete("Prep")
+				Expect(err).NotTo(HaveOccurred(), "error waiting for prep stage to complete")
+
 				_, err = prepCguBuilder.WaitUntilComplete(25 * time.Minute)
 				Expect(err).ToNot(HaveOccurred(), "Prep CGU did not complete in time.")
 			})
@@ -99,9 +105,11 @@ var _ = Describe(
 
 				_, err := upgradeCguBuilder.Create()
 				Expect(err).ToNot(HaveOccurred(), "Failed to create upgrade CGU.")
+				// Wait for 10 seconds to avoid upgrade and finalize CGUs getting created simultaneously.
+				time.Sleep(10 * time.Second)
 			})
 
-			By("Waiting for the upgrade-stage-policy to report NonCompliant state", func() {
+			By("Waiting for the upgrade and finalize policies to report NonCompliant state", func() {
 				upgradeStagePolicy, err := ocm.PullPolicy(cnfinittools.TargetHubAPIClient,
 					tsparams.UpgradePolicyName,
 					tsparams.IbuPolicyNamespace)
@@ -109,6 +117,14 @@ var _ = Describe(
 
 				err = upgradeStagePolicy.WaitUntilComplianceState(policiesv1.NonCompliant, 5*time.Minute)
 				Expect(err).ToNot(HaveOccurred(), "Upgrade-stage-policy failed to report NonCompliant state")
+
+				finalizeStagePolicy, err := ocm.PullPolicy(cnfinittools.TargetHubAPIClient,
+					tsparams.FinalizePolicyName,
+					tsparams.IbuPolicyNamespace)
+				Expect(err).ToNot(HaveOccurred(), "Failed to pull finalize stage policy")
+
+				err = finalizeStagePolicy.WaitUntilComplianceState(policiesv1.NonCompliant, 5*time.Minute)
+				Expect(err).ToNot(HaveOccurred(), "Finalize-stage-policy failed to report NonCompliant state")
 			})
 
 			By("Creating, enabling ibu finalize CGU and waiting for CGU status to report completed", func() {
@@ -119,8 +135,18 @@ var _ = Describe(
 					WithCanary(tsparams.TargetSnoClusterName)
 				finalizeCguBuilder.Definition.Spec.Enable = ptr.To(true)
 
+				// Delete the upgrade CGU so that it does not interfere with the finalize CGU.
+				By("Deleting upgrade cgu created on target hub cluster", func() {
+					err := cnfhelper.DeleteIbuTestCguOnTargetHub(cnfinittools.TargetHubAPIClient, tsparams.UpgradeCguName,
+						tsparams.IbuCguNamespace)
+					Expect(err).ToNot(HaveOccurred(), "Failed to delete upgrade cgu on target hub cluster")
+				})
+
 				finalizeCguBuilder, err := finalizeCguBuilder.Create()
 				Expect(err).ToNot(HaveOccurred(), "Failed to create finalize CGU.")
+
+				_, err = ibu.WaitUntilStageComplete("Idle")
+				Expect(err).NotTo(HaveOccurred(), "error waiting for idle stage to complete")
 
 				_, err = finalizeCguBuilder.WaitUntilComplete(5 * time.Minute)
 				Expect(err).ToNot(HaveOccurred(), "Finalize CGU did not complete in time.")


### PR DESCRIPTION
After the finalize CGU reports Completed state wait for the IBU Idle condition to report True as well. Also remove 'Wait until node is reporting as Ready' as it can sometimes prematurely fail if the kube api is not available.  In addition wait 10 seconds after the CGUs deletion as it seems that if we delete and re-create the CGUs too quickly the policies do not have enough time to reconciliate their status.