### PR TITLE
system-tests: ran-du: add tuned restarts check to stability tests

### DIFF
--- a/tests/system-tests/ran-du/tests/stability-no-workload.go
+++ b/tests/system-tests/ran-du/tests/stability-no-workload.go
@@ -41,6 +41,7 @@ var _ = Describe(
 			outputDir := RanDuTestConfig.StabilityOutputPath
 			policiesOutputFile := fmt.Sprintf("%s/stability_no_workload_policies.log", outputDir)
 			ptpOutputFile := fmt.Sprintf("%s/stability_no_workload_ptp.log", outputDir)
+			tunedRestartsOutputFile := fmt.Sprintf("%s/stability_tuned_restarts.log", outputDir)
 			namespaces := []string{"openshift-etcd", "openshift-apiserver"}
 
 			totalDuration := time.Duration(RanDuTestConfig.StabilityNoWorkloadDurMins) * time.Minute
@@ -69,6 +70,11 @@ var _ = Describe(
 						fmt.Printf("Error, could not save Pod restarts")
 					}
 
+				}
+
+				err = stability.SaveTunedRestarts(APIClient, tunedRestartsOutputFile)
+				if err != nil {
+					fmt.Printf("Error, could not save tuned restarts")
 				}
 
 				time.Sleep(interval)
@@ -103,6 +109,13 @@ var _ = Describe(
 				if err != nil {
 					stabilityErrors = append(stabilityErrors, err.Error())
 				}
+			}
+
+			// Verify tuned restarts
+			By("Check tuneds restarts")
+			_, err = stability.VerifyStabilityStatusChange(tunedRestartsOutputFile)
+			if err != nil {
+				stabilityErrors = append(stabilityErrors, err.Error())
 			}
 
 			By("Check if there been any error")

--- a/tests/system-tests/ran-du/tests/stability-workload.go
+++ b/tests/system-tests/ran-du/tests/stability-workload.go
@@ -62,6 +62,7 @@ var _ = Describe(
 			outputDir := RanDuTestConfig.StabilityOutputPath
 			policiesOutputFile := fmt.Sprintf("%s/stability_workload_policies.log", outputDir)
 			ptpOutputFile := fmt.Sprintf("%s/stability_workload_ptp.log", outputDir)
+			tunedRestartsOutputFile := fmt.Sprintf("%s/stability_tuned_restarts.log", outputDir)
 			namespaces := []string{"openshift-etcd", "openshift-apiserver"}
 
 			totalDuration := time.Duration(RanDuTestConfig.StabilityWorkloadDurMins) * time.Minute
@@ -88,6 +89,11 @@ var _ = Describe(
 					if err != nil {
 						fmt.Printf("Error, could not save pod restarts")
 					}
+				}
+
+				err = stability.SaveTunedRestarts(APIClient, tunedRestartsOutputFile)
+				if err != nil {
+					fmt.Printf("Error, could not save tuned restarts")
 				}
 
 				time.Sleep(interval)
@@ -120,6 +126,13 @@ var _ = Describe(
 				if err != nil {
 					stabilityErrors = append(stabilityErrors, err.Error())
 				}
+			}
+
+			// Verify tuned restarts
+			By("Check tuneds restarts")
+			_, err = stability.VerifyStabilityStatusChange(tunedRestartsOutputFile)
+			if err != nil {
+				stabilityErrors = append(stabilityErrors, err.Error())
 			}
 
 			By("Check if there been any error")


### PR DESCRIPTION
In order to catch issues such as [OCPBUGS-30813 ](https://issues.redhat.com/browse/OCPBUGS-30813)add a check to the stability test which validates that tuned does not continuously apply its configuration.