### PR TITLE
Revise Polarion Test Case IDs in TALM tests

### DIFF
--- a/tests/cnf/ran/talm/tests/talm-backup.go
+++ b/tests/cnf/ran/talm/tests/talm-backup.go
@@ -150,7 +150,7 @@ var _ = Describe("TALM backup tests", Label(tsparams.LabelBackupTestCases), func
 			Expect(errorList).To(BeEmpty(), "Failed to clean up test resources on spokes")
 		})
 
-		// Unblock Backup in Batch OCP Upgrade
+		// 74752 Unblock Backup in Batch OCP Upgrade
 		It("should not affect backup on second spoke in same batch", reportxml.ID("74752"), func() {
 			By("applying all the required CRs for backup")
 			// max concurrency of 2 so both spokes are in the same batch

--- a/tests/cnf/ran/talm/tests/talm-backup.go
+++ b/tests/cnf/ran/talm/tests/talm-backup.go
@@ -150,6 +150,7 @@ var _ = Describe("TALM backup tests", Label(tsparams.LabelBackupTestCases), func
 			Expect(errorList).To(BeEmpty(), "Failed to clean up test resources on spokes")
 		})
 
+		// Unblock Backup in Batch OCP Upgrade
 		It("should not affect backup on second spoke in same batch", reportxml.ID("74752"), func() {
 			By("applying all the required CRs for backup")
 			// max concurrency of 2 so both spokes are in the same batch

--- a/tests/cnf/ran/talm/tests/talm-backup.go
+++ b/tests/cnf/ran/talm/tests/talm-backup.go
@@ -150,7 +150,7 @@ var _ = Describe("TALM backup tests", Label(tsparams.LabelBackupTestCases), func
 			Expect(errorList).To(BeEmpty(), "Failed to clean up test resources on spokes")
 		})
 
-		It("should not affect backup on second spoke in same batch", func() {
+		It("should not affect backup on second spoke in same batch", reportxml.ID("74752"), func() {
 			By("applying all the required CRs for backup")
 			// max concurrency of 2 so both spokes are in the same batch
 			cguBuilder := cgu.NewCguBuilder(HubAPIClient, tsparams.CguName, tsparams.TestNamespace, 2).

--- a/tests/cnf/ran/talm/tests/talm-batching.go
+++ b/tests/cnf/ran/talm/tests/talm-batching.go
@@ -199,10 +199,10 @@ var _ = Describe("TALM Batching Tests", Label(tsparams.LabelBatchingTestCases), 
 				Spoke2APIClient, tsparams.CatalogSourceName, tsparams.TemporaryNamespace).Exists()
 			Expect(catSrcExistsOnSpoke2).To(BeFalse(), "Catalog source exists on spoke 2")
 		})
+		
 		// 74753 upgrade failure of first batch would not affect second batch
 		It("should continue the CGU when the first batch fails with the Continue batch timeout"+
 			"action", reportxml.ID("74753"), func() {
-			// 74753 upgrade failure of first batch would not affect second batch
 			By("verifying the temporary namespace does not exist on spoke1")
 			tempExistsOnSpoke1 := namespace.NewBuilder(Spoke1APIClient, tsparams.TemporaryNamespace).Exists()
 			Expect(tempExistsOnSpoke1).To(BeFalse(), "Temporary namespace already exists on spoke 1")

--- a/tests/cnf/ran/talm/tests/talm-batching.go
+++ b/tests/cnf/ran/talm/tests/talm-batching.go
@@ -199,46 +199,47 @@ var _ = Describe("TALM Batching Tests", Label(tsparams.LabelBatchingTestCases), 
 				Spoke2APIClient, tsparams.CatalogSourceName, tsparams.TemporaryNamespace).Exists()
 			Expect(catSrcExistsOnSpoke2).To(BeFalse(), "Catalog source exists on spoke 2")
 		})
+		It("should continue the CGU when the first batch fails with the Continue batch timeout action",
+			reportxml.ID("74753"), func() {
+				// 74753 upgrade failure of first batch would not affect second batch
+				By("verifying the temporary namespace does not exist on spoke1")
+				tempExistsOnSpoke1 := namespace.NewBuilder(Spoke1APIClient, tsparams.TemporaryNamespace).Exists()
+				Expect(tempExistsOnSpoke1).To(BeFalse(), "Temporary namespace already exists on spoke 1")
 
-		It("should continue the CGU when the first batch fails with the Continue batch timeout action", func() {
-			By("verifying the temporary namespace does not exist on spoke1")
-			tempExistsOnSpoke1 := namespace.NewBuilder(Spoke1APIClient, tsparams.TemporaryNamespace).Exists()
-			Expect(tempExistsOnSpoke1).To(BeFalse(), "Temporary namespace already exists on spoke 1")
+				By("creating the temporary namespace on spoke2 only")
+				_, err = namespace.NewBuilder(Spoke2APIClient, tsparams.TemporaryNamespace).Create()
+				Expect(err).ToNot(HaveOccurred(), "Failed to create temporary namespace on spoke 2")
 
-			By("creating the temporary namespace on spoke2 only")
-			_, err = namespace.NewBuilder(Spoke2APIClient, tsparams.TemporaryNamespace).Create()
-			Expect(err).ToNot(HaveOccurred(), "Failed to create temporary namespace on spoke 2")
+				By("creating the CGU and associated resources")
+				// Max concurrency of one to ensure two batches are used.
+				cguBuilder := cgu.NewCguBuilder(HubAPIClient, tsparams.CguName, tsparams.TestNamespace, 1).
+					WithCluster(RANConfig.Spoke1Name).
+					WithCluster(RANConfig.Spoke2Name).
+					WithManagedPolicy(tsparams.PolicyName)
+				cguBuilder.Definition.Spec.RemediationStrategy.Timeout = 9
+				cguBuilder.Definition.Spec.Enable = ptr.To(false)
 
-			By("creating the CGU and associated resources")
-			// Max concurrency of one to ensure two batches are used.
-			cguBuilder := cgu.NewCguBuilder(HubAPIClient, tsparams.CguName, tsparams.TestNamespace, 1).
-				WithCluster(RANConfig.Spoke1Name).
-				WithCluster(RANConfig.Spoke2Name).
-				WithManagedPolicy(tsparams.PolicyName)
-			cguBuilder.Definition.Spec.RemediationStrategy.Timeout = 9
-			cguBuilder.Definition.Spec.Enable = ptr.To(false)
+				cguBuilder, err = helper.SetupCguWithCatSrc(cguBuilder)
+				Expect(err).ToNot(HaveOccurred(), "Failed to setup CGU")
 
-			cguBuilder, err = helper.SetupCguWithCatSrc(cguBuilder)
-			Expect(err).ToNot(HaveOccurred(), "Failed to setup CGU")
+				By("waiting to enable the CGU")
+				cguBuilder, err = helper.WaitToEnableCgu(cguBuilder)
+				Expect(err).ToNot(HaveOccurred(), "Failed to wait and enable the CGU")
 
-			By("waiting to enable the CGU")
-			cguBuilder, err = helper.WaitToEnableCgu(cguBuilder)
-			Expect(err).ToNot(HaveOccurred(), "Failed to wait and enable the CGU")
+				By("waiting for the CGU to timeout")
+				err = helper.WaitForCguTimeout(cguBuilder, 16*time.Minute)
+				Expect(err).ToNot(HaveOccurred(), "Failed to wait for CGU to timeout")
 
-			By("waiting for the CGU to timeout")
-			err = helper.WaitForCguTimeout(cguBuilder, 16*time.Minute)
-			Expect(err).ToNot(HaveOccurred(), "Failed to wait for CGU to timeout")
+				By("validating that the policy succeeded on spoke2")
+				catSrcExistsOnSpoke2 := olm.NewCatalogSourceBuilder(
+					Spoke2APIClient, tsparams.CatalogSourceName, tsparams.TemporaryNamespace).Exists()
+				Expect(catSrcExistsOnSpoke2).To(BeTrue(), "Catalog source doesn't exist on spoke 2")
 
-			By("validating that the policy succeeded on spoke2")
-			catSrcExistsOnSpoke2 := olm.NewCatalogSourceBuilder(
-				Spoke2APIClient, tsparams.CatalogSourceName, tsparams.TemporaryNamespace).Exists()
-			Expect(catSrcExistsOnSpoke2).To(BeTrue(), "Catalog source doesn't exist on spoke 2")
-
-			By("validating that the policy failed on spoke1")
-			catSrcExistsOnSpoke1 := olm.NewCatalogSourceBuilder(
-				Spoke1APIClient, tsparams.CatalogSourceName, tsparams.TemporaryNamespace).Exists()
-			Expect(catSrcExistsOnSpoke1).To(BeFalse(), "Catalog source exists on spoke 1")
-		})
+				By("validating that the policy failed on spoke1")
+				catSrcExistsOnSpoke1 := olm.NewCatalogSourceBuilder(
+					Spoke1APIClient, tsparams.CatalogSourceName, tsparams.TemporaryNamespace).Exists()
+				Expect(catSrcExistsOnSpoke1).To(BeFalse(), "Catalog source exists on spoke 1")
+			})
 
 		// 54296 - Batch Timeout Calculation
 		It("should continue the CGU when the second batch fails with the Continue batch timeout action",
@@ -304,7 +305,6 @@ var _ = Describe("TALM Batching Tests", Label(tsparams.LabelBatchingTestCases), 
 
 	When("there is a temporary namespace", Label(tsparams.LabelTempNamespaceTestCases), func() {
 		// 47954 - Tests upgrade aborted due to short timeout.
-		// 54292 - Test Policy Deletion Upon CGU Expiration
 		It("should report the timeout value when one cluster is in a batch and it times out", reportxml.ID("47954"), func() {
 			By("verifying the temporary namespace does not exist on spoke1")
 			tempExistsOnSpoke1 := namespace.NewBuilder(Spoke1APIClient, tsparams.TemporaryNamespace).Exists()
@@ -362,10 +362,6 @@ var _ = Describe("TALM Batching Tests", Label(tsparams.LabelBatchingTestCases), 
 		})
 
 		// 47947 - Tests successful ocp and operator upgrade with canaries and multiple batches.
-		// 54288 - Test Cluster Selection with K8s matchLabels selector
-		// 54289 - Test Cluster Selection with K8s matchExpressions selector
-		// 54559 - CGU Multiple Selection Criteria
-		// 54292 - Test Policy Deletion Upon CGU Expiration
 		It("should complete the CGU when two clusters are successful in a single batch", reportxml.ID("47947"), func() {
 			By("creating the CGU and associated resources")
 			cguBuilder := cgu.NewCguBuilder(HubAPIClient, tsparams.CguName, tsparams.TestNamespace, 1).

--- a/tests/cnf/ran/talm/tests/talm-batching.go
+++ b/tests/cnf/ran/talm/tests/talm-batching.go
@@ -199,8 +199,8 @@ var _ = Describe("TALM Batching Tests", Label(tsparams.LabelBatchingTestCases), 
 				Spoke2APIClient, tsparams.CatalogSourceName, tsparams.TemporaryNamespace).Exists()
 			Expect(catSrcExistsOnSpoke2).To(BeFalse(), "Catalog source exists on spoke 2")
 		})
-		It("should continue the CGU when the first batch fails with the Continue batch timeout 
-		   action", reportxml.ID("74753"), func() {
+		It("should continue the CGU when the first batch fails with the Continue batch timeout"+
+		   "action", reportxml.ID("74753"), func() {
 			// 74753 upgrade failure of first batch would not affect second batch
 			By("verifying the temporary namespace does not exist on spoke1")
 			tempExistsOnSpoke1 := namespace.NewBuilder(Spoke1APIClient, tsparams.TemporaryNamespace).Exists()

--- a/tests/cnf/ran/talm/tests/talm-batching.go
+++ b/tests/cnf/ran/talm/tests/talm-batching.go
@@ -201,7 +201,7 @@ var _ = Describe("TALM Batching Tests", Label(tsparams.LabelBatchingTestCases), 
 		})
 		// 74753 upgrade failure of first batch would not affect second batch
 		It("should continue the CGU when the first batch fails with the Continue batch timeout"+
-		   	"action", reportxml.ID("74753"), func() {
+			"action", reportxml.ID("74753"), func() {
 			// 74753 upgrade failure of first batch would not affect second batch
 			By("verifying the temporary namespace does not exist on spoke1")
 			tempExistsOnSpoke1 := namespace.NewBuilder(Spoke1APIClient, tsparams.TemporaryNamespace).Exists()

--- a/tests/cnf/ran/talm/tests/talm-batching.go
+++ b/tests/cnf/ran/talm/tests/talm-batching.go
@@ -200,7 +200,7 @@ var _ = Describe("TALM Batching Tests", Label(tsparams.LabelBatchingTestCases), 
 			Expect(catSrcExistsOnSpoke2).To(BeFalse(), "Catalog source exists on spoke 2")
 		})
 		It("should continue the CGU when the first batch fails with the Continue batch timeout"+
-		   "action", reportxml.ID("74753"), func() {
+		   	"action", reportxml.ID("74753"), func() {
 			// 74753 upgrade failure of first batch would not affect second batch
 			By("verifying the temporary namespace does not exist on spoke1")
 			tempExistsOnSpoke1 := namespace.NewBuilder(Spoke1APIClient, tsparams.TemporaryNamespace).Exists()

--- a/tests/cnf/ran/talm/tests/talm-batching.go
+++ b/tests/cnf/ran/talm/tests/talm-batching.go
@@ -199,47 +199,47 @@ var _ = Describe("TALM Batching Tests", Label(tsparams.LabelBatchingTestCases), 
 				Spoke2APIClient, tsparams.CatalogSourceName, tsparams.TemporaryNamespace).Exists()
 			Expect(catSrcExistsOnSpoke2).To(BeFalse(), "Catalog source exists on spoke 2")
 		})
-		It("should continue the CGU when the first batch fails with the Continue batch timeout action",
-			reportxml.ID("74753"), func() {
-				// 74753 upgrade failure of first batch would not affect second batch
-				By("verifying the temporary namespace does not exist on spoke1")
-				tempExistsOnSpoke1 := namespace.NewBuilder(Spoke1APIClient, tsparams.TemporaryNamespace).Exists()
-				Expect(tempExistsOnSpoke1).To(BeFalse(), "Temporary namespace already exists on spoke 1")
+		It("should continue the CGU when the first batch fails with the Continue batch timeout 
+		   action", reportxml.ID("74753"), func() {
+			// 74753 upgrade failure of first batch would not affect second batch
+			By("verifying the temporary namespace does not exist on spoke1")
+			tempExistsOnSpoke1 := namespace.NewBuilder(Spoke1APIClient, tsparams.TemporaryNamespace).Exists()
+			Expect(tempExistsOnSpoke1).To(BeFalse(), "Temporary namespace already exists on spoke 1")
 
-				By("creating the temporary namespace on spoke2 only")
-				_, err = namespace.NewBuilder(Spoke2APIClient, tsparams.TemporaryNamespace).Create()
-				Expect(err).ToNot(HaveOccurred(), "Failed to create temporary namespace on spoke 2")
+			By("creating the temporary namespace on spoke2 only")
+			_, err = namespace.NewBuilder(Spoke2APIClient, tsparams.TemporaryNamespace).Create()
+			Expect(err).ToNot(HaveOccurred(), "Failed to create temporary namespace on spoke 2")
 
-				By("creating the CGU and associated resources")
-				// Max concurrency of one to ensure two batches are used.
-				cguBuilder := cgu.NewCguBuilder(HubAPIClient, tsparams.CguName, tsparams.TestNamespace, 1).
-					WithCluster(RANConfig.Spoke1Name).
-					WithCluster(RANConfig.Spoke2Name).
-					WithManagedPolicy(tsparams.PolicyName)
-				cguBuilder.Definition.Spec.RemediationStrategy.Timeout = 9
-				cguBuilder.Definition.Spec.Enable = ptr.To(false)
+			By("creating the CGU and associated resources")
+			// Max concurrency of one to ensure two batches are used.
+			cguBuilder := cgu.NewCguBuilder(HubAPIClient, tsparams.CguName, tsparams.TestNamespace, 1).
+				WithCluster(RANConfig.Spoke1Name).
+				WithCluster(RANConfig.Spoke2Name).
+				WithManagedPolicy(tsparams.PolicyName)
+			cguBuilder.Definition.Spec.RemediationStrategy.Timeout = 9
+			cguBuilder.Definition.Spec.Enable = ptr.To(false)
 
-				cguBuilder, err = helper.SetupCguWithCatSrc(cguBuilder)
-				Expect(err).ToNot(HaveOccurred(), "Failed to setup CGU")
+			cguBuilder, err = helper.SetupCguWithCatSrc(cguBuilder)
+			Expect(err).ToNot(HaveOccurred(), "Failed to setup CGU")
 
-				By("waiting to enable the CGU")
-				cguBuilder, err = helper.WaitToEnableCgu(cguBuilder)
-				Expect(err).ToNot(HaveOccurred(), "Failed to wait and enable the CGU")
+			By("waiting to enable the CGU")
+			cguBuilder, err = helper.WaitToEnableCgu(cguBuilder)
+			Expect(err).ToNot(HaveOccurred(), "Failed to wait and enable the CGU")
 
-				By("waiting for the CGU to timeout")
-				err = helper.WaitForCguTimeout(cguBuilder, 16*time.Minute)
-				Expect(err).ToNot(HaveOccurred(), "Failed to wait for CGU to timeout")
+			By("waiting for the CGU to timeout")
+			err = helper.WaitForCguTimeout(cguBuilder, 16*time.Minute)
+			Expect(err).ToNot(HaveOccurred(), "Failed to wait for CGU to timeout")
 
-				By("validating that the policy succeeded on spoke2")
-				catSrcExistsOnSpoke2 := olm.NewCatalogSourceBuilder(
-					Spoke2APIClient, tsparams.CatalogSourceName, tsparams.TemporaryNamespace).Exists()
-				Expect(catSrcExistsOnSpoke2).To(BeTrue(), "Catalog source doesn't exist on spoke 2")
+			By("validating that the policy succeeded on spoke2")
+			catSrcExistsOnSpoke2 := olm.NewCatalogSourceBuilder(
+				Spoke2APIClient, tsparams.CatalogSourceName, tsparams.TemporaryNamespace).Exists()
+			Expect(catSrcExistsOnSpoke2).To(BeTrue(), "Catalog source doesn't exist on spoke 2")
 
-				By("validating that the policy failed on spoke1")
-				catSrcExistsOnSpoke1 := olm.NewCatalogSourceBuilder(
-					Spoke1APIClient, tsparams.CatalogSourceName, tsparams.TemporaryNamespace).Exists()
-				Expect(catSrcExistsOnSpoke1).To(BeFalse(), "Catalog source exists on spoke 1")
-			})
+			By("validating that the policy failed on spoke1")
+			catSrcExistsOnSpoke1 := olm.NewCatalogSourceBuilder(
+				Spoke1APIClient, tsparams.CatalogSourceName, tsparams.TemporaryNamespace).Exists()
+			Expect(catSrcExistsOnSpoke1).To(BeFalse(), "Catalog source exists on spoke 1")
+		})
 
 		// 54296 - Batch Timeout Calculation
 		It("should continue the CGU when the second batch fails with the Continue batch timeout action",

--- a/tests/cnf/ran/talm/tests/talm-batching.go
+++ b/tests/cnf/ran/talm/tests/talm-batching.go
@@ -52,7 +52,7 @@ var _ = Describe("TALM Batching Tests", Label(tsparams.LabelBatchingTestCases), 
 	})
 
 	When("a single spoke is missing", Label(tsparams.LabelMissingSpokeTestCases), func() {
-		// 47949 - Tests selected clusters must be non-compliant AND included in UOCR.
+		// 47949 - Tests selected clusters must be non-compliant AND included in CGU.
 		It("should report a missing spoke", reportxml.ID("47949"), func() {
 			By("creating the CGU with non-existent cluster and policy")
 			cguBuilder := cgu.NewCguBuilder(HubAPIClient, tsparams.CguName, tsparams.TestNamespace, 1).

--- a/tests/cnf/ran/talm/tests/talm-batching.go
+++ b/tests/cnf/ran/talm/tests/talm-batching.go
@@ -199,7 +199,7 @@ var _ = Describe("TALM Batching Tests", Label(tsparams.LabelBatchingTestCases), 
 				Spoke2APIClient, tsparams.CatalogSourceName, tsparams.TemporaryNamespace).Exists()
 			Expect(catSrcExistsOnSpoke2).To(BeFalse(), "Catalog source exists on spoke 2")
 		})
-		
+
 		// 74753 upgrade failure of first batch would not affect second batch
 		It("should continue the CGU when the first batch fails with the Continue batch timeout"+
 			"action", reportxml.ID("74753"), func() {

--- a/tests/cnf/ran/talm/tests/talm-batching.go
+++ b/tests/cnf/ran/talm/tests/talm-batching.go
@@ -199,6 +199,7 @@ var _ = Describe("TALM Batching Tests", Label(tsparams.LabelBatchingTestCases), 
 				Spoke2APIClient, tsparams.CatalogSourceName, tsparams.TemporaryNamespace).Exists()
 			Expect(catSrcExistsOnSpoke2).To(BeFalse(), "Catalog source exists on spoke 2")
 		})
+		// 74753 upgrade failure of first batch would not affect second batch
 		It("should continue the CGU when the first batch fails with the Continue batch timeout"+
 		   	"action", reportxml.ID("74753"), func() {
 			// 74753 upgrade failure of first batch would not affect second batch

--- a/tests/cnf/ran/talm/tests/talm-blockingcr.go
+++ b/tests/cnf/ran/talm/tests/talm-blockingcr.go
@@ -55,7 +55,7 @@ var _ = Describe("TALM Blocking CRs Tests", Label(tsparams.LabelBlockingCRTestCa
 		Expect(err).ToNot(HaveOccurred(), "Failed to delete namespace for blocking B on spoke 1")
 	})
 
-	When("a blocking CR passes", reportxml.ID("47948"), func() {
+	When("a blocking CR passes", func() {
 		// 47948 - Tests multiple UOCRs can be enabled in parallel with blocking CR.
 		It("verifies CGU succeeded with blocking CR", reportxml.ID("47948"), func() {
 			By("creating two sets of CRs where B will be blocked until A is done")
@@ -90,8 +90,8 @@ var _ = Describe("TALM Blocking CRs Tests", Label(tsparams.LabelBlockingCRTestCa
 	})
 
 	When("a blocking CR fails", func() {
-		// 47948 - Tests multiple UOCRs can be enabled in parallel with blocking CR.
-		It("verifies CGU fails with blocking CR", reportxml.ID("47948"), func() {
+		// 74768 - Tests multiple UOCRs can be enabled in parallel with blocking CR.
+		It("verifies CGU fails with blocking CR", reportxml.ID("74768"), func() {
 			By("creating two sets of CRs where B will be blocked until A is done")
 			cguA := getBlockingCGU(blockingA, 2)
 			cguB := getBlockingCGU(blockingB, 1)
@@ -137,8 +137,8 @@ var _ = Describe("TALM Blocking CRs Tests", Label(tsparams.LabelBlockingCRTestCa
 	})
 
 	When("a blocking CR is missing", reportxml.ID("47956"), func() {
-		// 47948 - Tests multiple UOCRs can be enabled in parallel with blocking CR.
-		It("verifies CGU is blocked until blocking CR created and succeeded", reportxml.ID("47948"), func() {
+		// 47956 - Tests multiple UOCRs can be enabled in parallel with missing blocking CR.
+		It("verifies CGU is blocked until blocking CR created and succeeded", reportxml.ID("47956"), func() {
 			By("creating two sets of CRs where B will be blocked until A is done")
 			cguA := getBlockingCGU(blockingA, 10)
 			cguB := getBlockingCGU(blockingB, 15)

--- a/tests/cnf/ran/talm/tests/talm-blockingcr.go
+++ b/tests/cnf/ran/talm/tests/talm-blockingcr.go
@@ -136,7 +136,7 @@ var _ = Describe("TALM Blocking CRs Tests", Label(tsparams.LabelBlockingCRTestCa
 		})
 	})
 
-	When("a blocking CR is missing", reportxml.ID("47956"), func() {
+	When("a blocking CR is missing", func() {
 		// 47956 - Tests multiple UOCRs can be enabled in parallel with missing blocking CR.
 		It("verifies CGU is blocked until blocking CR created and succeeded", reportxml.ID("47956"), func() {
 			By("creating two sets of CRs where B will be blocked until A is done")

--- a/tests/cnf/ran/talm/tests/talm-blockingcr.go
+++ b/tests/cnf/ran/talm/tests/talm-blockingcr.go
@@ -56,7 +56,7 @@ var _ = Describe("TALM Blocking CRs Tests", Label(tsparams.LabelBlockingCRTestCa
 	})
 
 	When("a blocking CR passes", func() {
-		// 47948 - Tests multiple UOCRs can be enabled in parallel with blocking CR.
+		// 47948 - Tests multiple CGUs can be enabled in parallel with blocking CR.
 		It("verifies CGU succeeded with blocking CR", reportxml.ID("47948"), func() {
 			By("creating two sets of CRs where B will be blocked until A is done")
 			cguA := getBlockingCGU(blockingA, 10)
@@ -90,7 +90,7 @@ var _ = Describe("TALM Blocking CRs Tests", Label(tsparams.LabelBlockingCRTestCa
 	})
 
 	When("a blocking CR fails", func() {
-		// 74768 - Tests multiple UOCRs can be enabled in parallel with blocking CR.
+		// 74768 - Tests multiple CGUs can be enabled in parallel with blocking CR.
 		It("verifies CGU fails with blocking CR", reportxml.ID("74768"), func() {
 			By("creating two sets of CRs where B will be blocked until A is done")
 			cguA := getBlockingCGU(blockingA, 2)
@@ -137,7 +137,7 @@ var _ = Describe("TALM Blocking CRs Tests", Label(tsparams.LabelBlockingCRTestCa
 	})
 
 	When("a blocking CR is missing", func() {
-		// 47956 - Tests multiple UOCRs can be enabled in parallel with missing blocking CR.
+		// 47956 - Tests multiple CGUs can be enabled in parallel with missing blocking CR.
 		It("verifies CGU is blocked until blocking CR created and succeeded", reportxml.ID("47956"), func() {
 			By("creating two sets of CRs where B will be blocked until A is done")
 			cguA := getBlockingCGU(blockingA, 10)

--- a/tests/cnf/ran/talm/tests/talm-blockingcr.go
+++ b/tests/cnf/ran/talm/tests/talm-blockingcr.go
@@ -55,7 +55,7 @@ var _ = Describe("TALM Blocking CRs Tests", Label(tsparams.LabelBlockingCRTestCa
 		Expect(err).ToNot(HaveOccurred(), "Failed to delete namespace for blocking B on spoke 1")
 	})
 
-	When("a blocking CR passes", func() {
+	When("a blocking CR passes", reportxml.ID("47948"), func() {
 		// 47948 - Tests multiple UOCRs can be enabled in parallel with blocking CR.
 		It("verifies CGU succeeded with blocking CR", reportxml.ID("47948"), func() {
 			By("creating two sets of CRs where B will be blocked until A is done")
@@ -136,7 +136,7 @@ var _ = Describe("TALM Blocking CRs Tests", Label(tsparams.LabelBlockingCRTestCa
 		})
 	})
 
-	When("a blocking CR is missing", func() {
+	When("a blocking CR is missing", reportxml.ID("47956"), func() {
 		// 47948 - Tests multiple UOCRs can be enabled in parallel with blocking CR.
 		It("verifies CGU is blocked until blocking CR created and succeeded", reportxml.ID("47948"), func() {
 			By("creating two sets of CRs where B will be blocked until A is done")

--- a/tests/cnf/ran/talm/tests/talm-precache.go
+++ b/tests/cnf/ran/talm/tests/talm-precache.go
@@ -57,7 +57,7 @@ var _ = Describe("TALM precache", Label(tsparams.LabelPreCacheTestCases), func()
 				}
 			})
 
-			It("tests for precache operator with multiple sources", func() {
+			It("tests for precache operator with multiple sources", reportxml.ID("48902"), func() {
 				var policies []string
 				for _, suffix := range suffixes {
 					policies = append(policies, tsparams.PolicyName+suffix)
@@ -84,7 +84,7 @@ var _ = Describe("TALM precache", Label(tsparams.LabelPreCacheTestCases), func()
 				Expect(errorList).To(BeEmpty(), "Failed to clean up test resources on hub")
 			})
 
-			It("tests for ocp cache with version", func() {
+			It("tests for ocp cache with version", reportxml.ID("47950"), func() {
 				By("creating and applying policy with clusterversion CR that defines the upgrade graph, channel, and version")
 				cguBuilder := getPrecacheCGU([]string{tsparams.PolicyName}, []string{RANConfig.Spoke1Name})
 
@@ -149,7 +149,7 @@ var _ = Describe("TALM precache", Label(tsparams.LabelPreCacheTestCases), func()
 				Expect(errList).To(BeEmpty(), "Failed to clean up test resources on hub")
 			})
 
-			It("tests for ocp cache with image", func() {
+			It("tests for ocp cache with image", reportxml.ID("48903"), func() {
 				By("creating and applying policy with clusterversion that defines the upgrade graph, channel, and version")
 				cguBuilder := getPrecacheCGU([]string{tsparams.PolicyName}, []string{RANConfig.Spoke1Name})
 

--- a/tests/cnf/ran/talm/tests/talm-precache.go
+++ b/tests/cnf/ran/talm/tests/talm-precache.go
@@ -57,6 +57,7 @@ var _ = Describe("TALM precache", Label(tsparams.LabelPreCacheTestCases), func()
 				}
 			})
 
+			// 48902 Tests image precaching - operators
 			It("tests for precache operator with multiple sources", reportxml.ID("48902"), func() {
 				var policies []string
 				for _, suffix := range suffixes {
@@ -84,6 +85,7 @@ var _ = Describe("TALM precache", Label(tsparams.LabelPreCacheTestCases), func()
 				Expect(errorList).To(BeEmpty(), "Failed to clean up test resources on hub")
 			})
 
+			// 47950 Tests ocp upgrade with image precaching enabled
 			It("tests for ocp cache with version", reportxml.ID("47950"), func() {
 				By("creating and applying policy with clusterversion CR that defines the upgrade graph, channel, and version")
 				cguBuilder := getPrecacheCGU([]string{tsparams.PolicyName}, []string{RANConfig.Spoke1Name})
@@ -149,6 +151,7 @@ var _ = Describe("TALM precache", Label(tsparams.LabelPreCacheTestCases), func()
 				Expect(errList).To(BeEmpty(), "Failed to clean up test resources on hub")
 			})
 
+			// 48903 Upgrade image precaching - OCP image with explicit image url
 			It("tests for ocp cache with image", reportxml.ID("48903"), func() {
 				By("creating and applying policy with clusterversion that defines the upgrade graph, channel, and version")
 				cguBuilder := getPrecacheCGU([]string{tsparams.PolicyName}, []string{RANConfig.Spoke1Name})

--- a/tests/cnf/ran/talm/tests/talm-precache.go
+++ b/tests/cnf/ran/talm/tests/talm-precache.go
@@ -300,7 +300,8 @@ var _ = Describe("TALM precache", Label(tsparams.LabelPreCacheTestCases), func()
 				}
 			})
 
-			It("tests custom image precaching using an invalid image", func() {
+			// Precache Invalid User-Specified Image
+			It("tests custom image precaching using an invalid image", reportxml.ID("64747"), func() {
 				versionInRange, err := ranhelper.IsVersionStringInRange(RANConfig.HubOperatorVersions[ranparam.TALM], "4.14", "")
 				Expect(err).ToNot(HaveOccurred(), "Failed to compare TALM version string")
 

--- a/tests/cnf/ran/talm/tests/talm-precache.go
+++ b/tests/cnf/ran/talm/tests/talm-precache.go
@@ -303,7 +303,7 @@ var _ = Describe("TALM precache", Label(tsparams.LabelPreCacheTestCases), func()
 				}
 			})
 
-			// Precache Invalid User-Specified Image
+			// 64747 Precache Invalid User-Specified Image
 			It("tests custom image precaching using an invalid image", reportxml.ID("64747"), func() {
 				versionInRange, err := ranhelper.IsVersionStringInRange(RANConfig.HubOperatorVersions[ranparam.TALM], "4.14", "")
 				Expect(err).ToNot(HaveOccurred(), "Failed to compare TALM version string")


### PR DESCRIPTION
TALM test cases needed to be revised to remove duplicate test IDs. New polarion test cases were added where needed. Others were merged. Full details of Polarion changes are in each subtask of CNf-12600