### PR TITLE
cnf ran: ztp generator tweaks based on testing

### DIFF
--- a/tests/cnf/ran/internal/ranparam/const.go
+++ b/tests/cnf/ran/internal/ranparam/const.go
@@ -5,6 +5,8 @@ import "github.com/golang/glog"
 const (
 	// Label represents the label for the ran test cases.
 	Label = "ran"
+	// LabelNoContainer is the label for RAN test cases that should not be executed in a container.
+	LabelNoContainer = "no-container"
 	// AcmOperatorNamespace ACM's namespace.
 	AcmOperatorNamespace = "rhacm"
 	// MceOperatorNamespace is the namespace for the MCE operator.

--- a/tests/cnf/ran/ztp/tests/ztp-generator.go
+++ b/tests/cnf/ran/ztp/tests/ztp-generator.go
@@ -12,11 +12,12 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/cluster"
 	. "github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/raninittools"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/ranparam"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/ztp/internal/tsparams"
 	"gopkg.in/yaml.v2"
 )
 
-var _ = Describe("ZTP Generator Tests", Label(tsparams.LabelGeneratorTestCases), func() {
+var _ = Describe("ZTP Generator Tests", Label(tsparams.LabelGeneratorTestCases, ranparam.LabelNoContainer), func() {
 	var siteConfigPath string
 
 	BeforeEach(func() {
@@ -64,7 +65,7 @@ var _ = Describe("ZTP Generator Tests", Label(tsparams.LabelGeneratorTestCases),
 				By("using brew to find the image tag")
 				cmd := "brew list-builds --package=ztp-site-generate-container --state=COMPLETE --quiet" +
 					fmt.Sprintf(" | grep %s", RANConfig.ZTPVersion) +
-					" | sort -V | tail -1 | awk '{ print $1 }'"
+					" | sort -V | tail -1 | awk '{ print $1 }' | sed -nr 's/.*-(v.*)$/\\1/p'"
 
 				output, err := cluster.ExecLocalCommand(time.Minute, "bash", "-c", cmd)
 				Expect(err).ToNot(HaveOccurred(), "Failed to get output from brew")


### PR DESCRIPTION
Testing the ZTP generator tests in the actual environment revealed that the output from brew was not handled properly. This PR adds a sed command to retrieve the version tag from the output.

Additionally, the no-container label is added for tests that should not be executed in a container, such as ztp-generator currently.