### PR TITLE
cnf ran: add secret creation to ztp hub templating

### DIFF
--- a/tests/cnf/ran/ztp/internal/helper/policiesapp.go
+++ b/tests/cnf/ran/ztp/internal/helper/policiesapp.go
@@ -98,7 +98,7 @@ func WaitForConditionInImageRegistry(
 	imageRegistryConfig *imageregistry.Builder, expected metav1.Condition, timeout time.Duration) error {
 	return wait.PollUntilContextTimeout(
 		context.TODO(), tsparams.ArgoCdChangeInterval, timeout, true, func(ctx context.Context) (bool, error) {
-			if !imageRegistryConfig.Exists() {
+			if !imageRegistryConfig.Exists() || imageRegistryConfig.Object == nil {
 				glog.V(tsparams.LogLevel).Infof("imageRegistry %s does not exist in namespace %s",
 					imageRegistryConfig.Definition.Name, imageRegistryConfig.Definition.Namespace)
 

--- a/tests/cnf/ran/ztp/internal/tsparams/consts.go
+++ b/tests/cnf/ran/ztp/internal/tsparams/consts.go
@@ -95,6 +95,8 @@ const (
 	// HubTemplatingCguNamespace is the namespace used by the hub templating CGU. It should be different than the
 	// policy namespace.
 	HubTemplatingCguNamespace = "default"
+	// HubTemplatingSecretName is the name of the secret used by the hub templating valid test.
+	HubTemplatingSecretName = "sriovsecret"
 	// NodeDeletionCrAnnotation is the annotation applied in the node deletion tests.
 	NodeDeletionCrAnnotation = "bmac.agent-install.openshift.io/remove-agent-and-node-on-delete"
 	// ZtpGeneratedAnnotation is the annotation applied to ztp generated resources.


### PR DESCRIPTION
This adds the secret creation to the code for the hub templating test rather than letting it be created by Argo CD since that is not permitted.

It additionally fixes an issue that has occured with the image registry object being nil.