### PR TITLE
assisted ztp: add operator suite test namespaces to reporter

### DIFF
--- a/tests/assisted/ztp/operator/tests/aci-dualstack-ipv4-first.go
+++ b/tests/assisted/ztp/operator/tests/aci-dualstack-ipv4-first.go
@@ -40,6 +40,8 @@ var _ = Describe(
 				}
 
 				nsBuilder = namespace.NewBuilder(HubAPIClient, dualstackTestSpoke)
+
+				tsparams.ReporterNamespacesToDump[dualstackTestSpoke] = "dualstacktest namespace"
 			})
 			AfterEach(func() {
 				By("Delete the temporary namespace after test")

--- a/tests/assisted/ztp/operator/tests/build-artifacts-rootfs.go
+++ b/tests/assisted/ztp/operator/tests/build-artifacts-rootfs.go
@@ -50,6 +50,8 @@ var _ = Describe(
 					}
 				}
 
+				tsparams.ReporterNamespacesToDump[rootfsSpokeName] = "rootfs-test namespace"
+
 				By("Creating " + rootfsSpokeName + " spoke cluster resources")
 				rootfsSpokeResources, err = setup.NewSpokeCluster(HubAPIClient).WithName(rootfsSpokeName).WithDefaultNamespace().
 					WithDefaultPullSecret().WithDefaultClusterDeployment().

--- a/tests/assisted/ztp/operator/tests/infraenv-multiarch-image.go
+++ b/tests/assisted/ztp/operator/tests/infraenv-multiarch-image.go
@@ -60,6 +60,8 @@ var _ = Describe(
 					Skip("The hub cluster must be connected")
 				}
 
+				tsparams.ReporterNamespacesToDump[infraenvTestSpoke] = "infraenv-spoke namespace"
+
 				nsBuilder = namespace.NewBuilder(HubAPIClient, infraenvTestSpoke)
 
 				By("Grab the MirrorRegistryRef value from the spec")

--- a/tests/assisted/ztp/operator/tests/osimage-clusterimageset-test.go
+++ b/tests/assisted/ztp/operator/tests/osimage-clusterimageset-test.go
@@ -54,6 +54,8 @@ var _ = Describe(
 				if !osImageFound {
 					Skip("Corresponding OS Image not found in AgentServiceConfig")
 				}
+
+				tsparams.ReporterNamespacesToDump[osImageClusterImageSetName] = "osimage-clusterimageset-test namespace"
 			})
 
 			It("result in successfully created infraenv", reportxml.ID("41937"), func() {


### PR DESCRIPTION
Adds test namespace created during operator test suite to reporter in order to dump CRs for failed tests 