### PR TITLE
cnf ran: image registry CR report and spoke checker fix

### DIFF
--- a/tests/cnf/ran/ztp/internal/tsparams/ztpvars.go
+++ b/tests/cnf/ran/ztp/internal/tsparams/ztpvars.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/raninittools"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/ranparam"
 	"github.com/openshift-kni/k8sreporter"
+	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/utils/ptr"
@@ -59,6 +60,7 @@ var (
 		{Cr: &corev1.ServiceAccountList{}, Namespace: ptr.To(CustomSourceTestNamespace)},
 		{Cr: &sriovv1.SriovNetworkList{}, Namespace: ptr.To(RANConfig.SriovOperatorNamespace)},
 		{Cr: &sriovv1.SriovNetworkList{}, Namespace: ptr.To(TestNamespace)},
+		{Cr: &imageregistryv1.ConfigList{}},
 	}
 
 	// ArgoCdApps is the slice of the Argo CD app names defined in this package.

--- a/tests/cnf/ran/ztp/tests/ztp-spoke-checker.go
+++ b/tests/cnf/ran/ztp/tests/ztp-spoke-checker.go
@@ -20,26 +20,31 @@ var _ = Describe("ZTP Spoke Checker Tests", Label(tsparams.LabelSpokeCheckerTest
 			By("verifying chronyd is inactive")
 			// Use `| cat -` to explicitly ignore the return code since it will be nonzero when the service
 			// is not active, which is expected here.
-			status, err := cluster.ExecCommandOnSNO(
-				Spoke1APIClient, 3, "systemctl is-active chronyd.service | cat -")
+			statuses, err := cluster.ExecCmdWithStdout(Spoke1APIClient, 3, "systemctl is-active chronyd.service | cat -")
 			Expect(err).ToNot(HaveOccurred(), "Failed to check if chronyd service is active")
+			Expect(statuses).ToNot(BeEmpty(), "Failed to find statuses for chronyd service")
 
-			glog.V(tsparams.LogLevel).Infof("active status: %s", status)
+			for nodeName, status := range statuses {
+				glog.V(tsparams.LogLevel).Infof("%s active status: %s", nodeName, status)
 
-			status = strings.TrimSpace(status)
-			Expect(status).To(Equal("inactive"), "chronyd service was not inactive")
+				status = strings.TrimSpace(status)
+				Expect(status).To(Equal("inactive"), "chronyd service was not inactive")
+			}
 
 			By("verifying chronyd is disabled")
 			// Use `| cat -` to explicitly ignore the return code since it will be nonzero when the service
 			// is disabled, which is expected here.
-			status, err = cluster.ExecCommandOnSNO(
-				Spoke1APIClient, 3, "systemctl is-enabled chronyd.service | cat -")
+			statuses, err = cluster.ExecCmdWithStdout(Spoke1APIClient, 3, "systemctl is-enabled chronyd.service | cat -")
 			Expect(err).ToNot(HaveOccurred(), "Failed to check if chronyd service is enabled")
+			Expect(statuses).ToNot(BeEmpty(), "Failed to find statuses for chronyd service")
 
-			glog.V(tsparams.LogLevel).Infof("enabled status: %s", status)
+			for nodeName, status := range statuses {
+				glog.V(tsparams.LogLevel).Infof("%s enabled status: %s", nodeName, status)
 
-			status = strings.TrimSpace(status)
-			Expect(status).To(Equal("disabled"), "chronyd service was not disabled")
+				status = strings.TrimSpace(status)
+				Expect(status).To(Equal("disabled"), "chronyd service was not disabled")
+			}
+
 		})
 
 		// 60904 - Verifies list of pods in openshift-network-diagnostics namespace on spoke


### PR DESCRIPTION
1. The list of spoke CRs to report for the ZTP suite test is currently missing the image registry config despite this CR being used in the policies app test.
2. The spoke checker test currently assumes that the cluster is SNO which causes it to fail for SNO+1. This PR updates it to perform the check on each node.