### PR TITLE
assisted ztp: increase timeouts for platform and trustbundle tests

### DIFF
--- a/tests/assisted/ztp/operator/tests/additional-trust-bundle.go
+++ b/tests/assisted/ztp/operator/tests/additional-trust-bundle.go
@@ -127,7 +127,7 @@ var _ = Describe(
 				infraenv.Definition.Spec.AdditionalTrustBundle = additionalTrustCertificate
 				_, err = infraenv.Create()
 				Expect(err).ToNot(HaveOccurred(), "error creating infraenv")
-				_, err := infraenv.WaitForDiscoveryISOCreation(time.Second * 20)
+				_, err := infraenv.WaitForDiscoveryISOCreation(time.Second * 40)
 				Expect(err).ToNot(HaveOccurred(), "error creating discovery iso")
 				By("Checking additionalTrustBundle equal to additionalTrustCertificate")
 				Expect(infraenv.Object.Spec.AdditionalTrustBundle).

--- a/tests/assisted/ztp/operator/tests/platform-selection-test.go
+++ b/tests/assisted/ztp/operator/tests/platform-selection-test.go
@@ -113,7 +113,7 @@ var _ = Describe(
 						Expect(err).ToNot(HaveOccurred(), "error creating agentclusterinstall")
 						By("Waiting for condition to report expected failure message")
 						err = testAgentClusterInstall.WaitForConditionMessage(v1beta1.ClusterSpecSyncedCondition,
-							"The Spec could not be synced due to an input error: "+message, time.Second*10)
+							"The Spec could not be synced due to an input error: "+message, time.Second*30)
 						Expect(err).NotTo(HaveOccurred(), "got unexpected message from SpecSynced condition")
 					}
 				},


### PR DESCRIPTION
These tests have been flaky recently but collected info always looks as expected. Increasing timeouts to hopefully remediate these failures.