### PR TITLE
system-test: refactor KernelCrashKdump function

### DIFF
--- a/tests/system-tests/internal/reboot/reboot.go
+++ b/tests/system-tests/internal/reboot/reboot.go
@@ -100,16 +100,10 @@ func HardRebootNode(nodeName string, nsName string) error {
 
 // KernelCrashKdump triggers a kernel crash dump which generates a vmcore dump.
 func KernelCrashKdump(nodeName string) error {
-	// pull openshift apiserver deployment object to wait for after the node reboot.
-	openshiftAPIDeploy, err := deployment.Pull(APIClient, "apiserver", "openshift-apiserver")
-
-	if err != nil {
-		return err
-	}
-
 	cmdToExec := []string{"chroot", "/rootfs", "/bin/sh", "-c", "rm -rf /var/crash/*"}
+
 	glog.V(90).Infof("Remove any existing crash dumps. Exec cmd %v", cmdToExec)
-	_, err = remote.ExecuteOnNodeWithDebugPod(cmdToExec, nodeName)
+	_, err := remote.ExecuteOnNodeWithDebugPod(cmdToExec, nodeName)
 
 	if err != nil {
 		return err
@@ -119,13 +113,6 @@ func KernelCrashKdump(nodeName string) error {
 
 	glog.V(90).Infof("Trigerring kernel crash. Exec cmd %v", cmdToExec)
 	_, err = remote.ExecuteOnNodeWithDebugPod(cmdToExec, nodeName)
-
-	if err != nil {
-		return err
-	}
-
-	// wait for the openshift apiserver deployment to be available
-	err = openshiftAPIDeploy.WaitUntilCondition("Available", 5*time.Minute)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
evaluate _OpenShift API server_ availability outside of *KernelCrashKdump* function