### PR TITLE
global: Fail ExecCmdWithStdout if no nodes were found to execute command

### DIFF
--- a/tests/internal/cluster/cluster.go
+++ b/tests/internal/cluster/cluster.go
@@ -133,6 +133,10 @@ func ExecCmdWithStdout(
 		return nil, err
 	}
 
+	if len(nodeList) == 0 {
+		return nil, fmt.Errorf("could not find valid nodes to run command")
+	}
+
 	glog.V(90).Infof("Found %d nodes matching selector", len(nodeList))
 
 	outputMap := make(map[string]string)


### PR DESCRIPTION
Otherwise retry functions using this will not retry if no nodes are found(transient conditon after reboot). 