### PR TITLE
system-test: use dedicated IPVLAN NADs per test

### DIFF
--- a/tests/system-tests/rdscore/internal/rdscorecommon/ipvlan-validation.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/ipvlan-validation.go
@@ -105,7 +105,7 @@ func VerifyIPVlanOnDifferentNodes() {
 	deployTwo := defineIPVlanDeployment(ipvlanDeploy11Name,
 		RDSCoreConfig.IPVlanNSOne,
 		ipvlanDeploy11Label,
-		RDSCoreConfig.IPVlanNADOneName,
+		RDSCoreConfig.IPVlanNADTwoName,
 		ipvlanDeploy2CMName,
 		deployContainerTwoCfg,
 		RDSCoreConfig.IPVlanDeployNodeSelectorTwo)
@@ -231,7 +231,7 @@ func VerifyIPVlanOnSameNode() {
 	deployOne := defineIPVlanDeployment(ipvlanDeploy20Name,
 		RDSCoreConfig.IPVlanNSOne,
 		ipvlanDeploy20Label,
-		RDSCoreConfig.IPVlanNADOneName,
+		RDSCoreConfig.IPVlanNADThreeName,
 		ipvlanDeploy3CMName,
 		deployContainerCfg,
 		RDSCoreConfig.IPVlanDeployNodeSelectorOne)
@@ -239,7 +239,7 @@ func VerifyIPVlanOnSameNode() {
 	deployTwo := defineIPVlanDeployment(ipvlanDeploy21Name,
 		RDSCoreConfig.IPVlanNSOne,
 		ipvlanDeploy21Label,
-		RDSCoreConfig.IPVlanNADOneName,
+		RDSCoreConfig.IPVlanNADFourName,
 		ipvlanDeploy4CMName,
 		deployContainerTwoCfg,
 		RDSCoreConfig.IPVlanDeployNodeSelectorOne)

--- a/tests/system-tests/rdscore/internal/rdscoreconfig/config.go
+++ b/tests/system-tests/rdscore/internal/rdscoreconfig/config.go
@@ -158,6 +158,9 @@ type CoreConfig struct {
 	IPVlanNSTwo          string `yaml:"rdscore_ipvlan_ns_two" envconfig:"ECO_RDSCORE_IPVLAN_NS_TWO"`
 	IPVlanDeployImageOne string `yaml:"rdscore_ipvlan_deploy_img_one" envconfig:"ECO_SYSTEM_RDSCORE_DEPLOY_IMG_ONE"`
 	IPVlanNADOneName     string `yaml:"rdscore_ipvlan_nad_one_name" envconfig:"ECO_SYSTEM_RDSCORE_IPVLAN_NAD_ONE_NAME"`
+	IPVlanNADTwoName     string `yaml:"rdscore_ipvlan_nad_two_name" envconfig:"ECO_SYSTEM_RDSCORE_IPVLAN_NAD_TWO_NAME"`
+	IPVlanNADThreeName   string `yaml:"rdscore_ipvlan_nad_three_name" envconfig:"ECO_SYSTEM_RDSCORE_IPVLAN_NAD_THREE_NAME"`
+	IPVlanNADFourName    string `yaml:"rdscore_ipvlan_nad_four_name" envconfig:"ECO_SYSTEM_RDSCORE_IPVLAN_NAD_FOUR_NAME"`
 	//nolint:lll
 	PerformanceProfileHTName string `yaml:"rdscore_performance_profile_ht_name" envconfig:"ECO_RDS_CORE_PERFORMANCE_PROFILE_HT_NAME"`
 	//nolint:lll

--- a/tests/system-tests/rdscore/internal/rdscoreconfig/default.yaml
+++ b/tests/system-tests/rdscore/internal/rdscoreconfig/default.yaml
@@ -85,7 +85,10 @@ rdscore_ipvlan_cm_data_one: {}
 rdscore_ipvlan_deploy_img_one: ""
 rdscore_ipvlan_deploy_1_cmd: []
 rdscore_ipvlan_deploy_2_cmd: []
-rdscore_ipvlan_nad_one_name: "ip-vlan"
+rdscore_ipvlan_nad_one_name: "ip-vlan-one"
+rdscore_ipvlan_nad_two_name: "ip-vlan-two"
+rdscore_ipvlan_nad_three_name: "ip-vlan-three"
+rdscore_ipvlan_nad_four_name: "ip-vlan-four"
 rdscore_ipvlan_1_node_selector: {}
 rdscore_ipvlan_2_node_selector: {}
 rdscore_ipcvlan_deploy_1_target: ""


### PR DESCRIPTION
With static address assignment it's required to have a dedicated _NAD_ per workload