### PR TITLE
cnf ran: reorganize talm helpers

### DIFF
--- a/tests/cnf/ran/talm/internal/helper/cgu.go
+++ b/tests/cnf/ran/talm/internal/helper/cgu.go
@@ -2,11 +2,8 @@ package helper
 
 import (
 	"context"
-	"errors"
-	"strings"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/openshift-kni/eco-goinfra/pkg/cgu"
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/namespace"
@@ -22,200 +19,17 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-// WaitForCguInCondition waits up to timeout until the provided cguBuilder matches the expected status. Only the Type,
-// Status, Reason, and Message fields of expected are checked.
-func WaitForCguInCondition(
-	cguBuilder *cgu.CguBuilder,
-	expected metav1.Condition,
-	timeout time.Duration) error {
-	return wait.PollUntilContextTimeout(
-		context.TODO(), 10*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
-			if !cguBuilder.Exists() {
-				glog.V(tsparams.LogLevel).Infof(
-					"cgu %s does not exist in namespace %s", cguBuilder.Definition.Name, cguBuilder.Definition.Namespace)
-
-				return false, nil
-			}
-
-			for _, condition := range cguBuilder.Object.Status.Conditions {
-				glog.V(tsparams.LogLevel).Infof("checking if condition %v matches the expected %v", condition, expected)
-
-				matches := true
-
-				if expected.Type != "" && condition.Type != expected.Type {
-					matches = false
-				}
-
-				if matches && expected.Status != "" && condition.Status != expected.Status {
-					matches = false
-				}
-
-				if matches && expected.Message != "" && !strings.Contains(condition.Message, expected.Message) {
-					matches = false
-				}
-
-				if matches && expected.Reason != "" && condition.Reason != expected.Reason {
-					matches = false
-				}
-
-				if matches {
-					return true, nil
-				}
-			}
-
-			return false, nil
-		},
-	)
-}
-
-// WaitForCguTimeout waits up to timeout until the provided cguBuilder matches the condition for a timeout.
-func WaitForCguTimeout(cguBuilder *cgu.CguBuilder, timeout time.Duration) error {
-	return WaitForCguInCondition(
-		cguBuilder,
-		metav1.Condition{
-			Type:   tsparams.SucceededType,
-			Reason: tsparams.TimedOutReason,
-		},
-		timeout)
-}
-
-// WaitForCguTimeoutMessage waits up to timeout until the provided cguBuilder matches the condition for a timeout.
-func WaitForCguTimeoutMessage(cguBuilder *cgu.CguBuilder, timeout time.Duration) error {
-	return WaitForCguInCondition(
-		cguBuilder,
-		metav1.Condition{
-			Type:    tsparams.SucceededType,
-			Message: tsparams.TalmTimeoutMessage,
-		},
-		timeout)
-}
-
-// WaitForCguTimeoutCanary waits up to timeout until the provided cguBuilder matches the condition for a timeout due to
-// canary clusters.
-func WaitForCguTimeoutCanary(cguBuilder *cgu.CguBuilder, timeout time.Duration) error {
-	return WaitForCguInCondition(
-		cguBuilder,
-		metav1.Condition{
-			Type:    tsparams.SucceededType,
-			Message: tsparams.TalmCanaryTimeoutMessage,
-		},
-		timeout)
-}
-
-// WaitForCguSuccessfulFinish waits up to the timeout until the provided cguBuilder matches the condition for a
-// successful finish.
-func WaitForCguSuccessfulFinish(cguBuilder *cgu.CguBuilder, timeout time.Duration) error {
-	return WaitForCguInCondition(
-		cguBuilder,
-		metav1.Condition{
-			Type:   tsparams.SucceededType,
-			Reason: tsparams.CompletedReason,
-		},
-		timeout)
-}
-
-// WaitForCguSucceeded waits for up to the timeout until the provided cguBuilder matches the condition for a success.
-func WaitForCguSucceeded(cguBuilder *cgu.CguBuilder, timeout time.Duration) error {
-	return WaitForCguInCondition(
-		cguBuilder,
-		metav1.Condition{
-			Type:   tsparams.SucceededType,
-			Status: metav1.ConditionTrue,
-		},
-		timeout)
-}
-
 // WaitForCguBlocked waits up to the timeout until the provided cguBuilder matches the condition for being blocked.
 func WaitForCguBlocked(cguBuilder *cgu.CguBuilder, message string) error {
-	return WaitForCguInCondition(
-		cguBuilder,
-		metav1.Condition{
-			Type:    tsparams.ProgressingType,
-			Status:  metav1.ConditionFalse,
-			Message: message,
-		},
-		6*time.Minute)
-}
-
-// WaitForCguPreCacheValid waits up to the timeout until the provided cguBuilder matches the condition for valid
-// precaching.
-func WaitForCguPreCacheValid(cguBuilder *cgu.CguBuilder, timeout time.Duration) error {
-	return WaitForCguInCondition(
-		cguBuilder,
-		metav1.Condition{
-			Type:    tsparams.PreCacheValidType,
-			Status:  metav1.ConditionTrue,
-			Message: tsparams.PreCacheValidMessage,
-		},
-		timeout)
-}
-
-// WaitForCguPreCachePartiallyDone waits up to the timeout until the provided cguBuilder matches the condition for
-// precaching being partially done.
-func WaitForCguPreCachePartiallyDone(cguBuilder *cgu.CguBuilder, timeout time.Duration) error {
-	return WaitForCguInCondition(
-		cguBuilder,
-		metav1.Condition{
-			Type:    tsparams.PreCacheSucceededType,
-			Status:  metav1.ConditionTrue,
-			Message: tsparams.PreCachePartialFailMessage,
-			Reason:  tsparams.PartiallyDoneReason,
-		},
-		timeout)
-}
-
-// IsClusterInCguInProgress checks if the current batch remediation progress for the provided cluster is InProgress.
-func IsClusterInCguInProgress(cguBuilder *cgu.CguBuilder, cluster string) (bool, error) {
-	if !cguBuilder.Exists() {
-		return false, errors.New("provided CGU does not exist on client")
+	blockedCondition := metav1.Condition{
+		Type:    tsparams.ProgressingType,
+		Status:  metav1.ConditionFalse,
+		Message: message,
 	}
 
-	status, ok := cguBuilder.Object.Status.Status.CurrentBatchRemediationProgress[cluster]
-	if !ok {
-		glog.V(tsparams.LogLevel).Infof(
-			"cluster %s not found in batch remediation progress for cgu %s in namespace %s",
-			cluster, cguBuilder.Definition.Name, cguBuilder.Definition.Namespace)
+	_, err := cguBuilder.WaitForCondition(blockedCondition, 6*time.Minute)
 
-		return false, nil
-	}
-
-	return status.State == "InProgress", nil
-}
-
-// isClusterInCguCompleted checks if the current batch remediation progress for the provided cluster is Completed.
-func isClusterInCguCompleted(cguBuilder *cgu.CguBuilder, cluster string) (bool, error) {
-	if !cguBuilder.Exists() {
-		return false, errors.New("provided CGU does not exist on client")
-	}
-
-	status, ok := cguBuilder.Object.Status.Status.CurrentBatchRemediationProgress[cluster]
-	if !ok {
-		glog.V(tsparams.LogLevel).Infof(
-			"cluster %s not found in batch remediation progress for cgu %s in namespace %s",
-			cluster, cguBuilder.Definition.Name, cguBuilder.Definition.Namespace)
-
-		return false, nil
-	}
-
-	return status.State == "Completed", nil
-}
-
-// WaitForClusterInCguInProgress waits up to timeout for the current batch remediation progress for the provided cluster
-// to show InProgress.
-func WaitForClusterInCguInProgress(cguBuilder *cgu.CguBuilder, cluster string, timeout time.Duration) error {
-	return wait.PollUntilContextTimeout(
-		context.TODO(), 15*time.Second, timeout, true, func(context.Context) (bool, error) {
-			return IsClusterInCguInProgress(cguBuilder, cluster)
-		})
-}
-
-// WaitForClusterInCguCompleted waits up to timeout for the current batch remediation progress for the provided cluster
-// to show Completed.
-func WaitForClusterInCguCompleted(cguBuilder *cgu.CguBuilder, cluster string, timeout time.Duration) error {
-	return wait.PollUntilContextTimeout(
-		context.TODO(), 15*time.Second, timeout, true, func(context.Context) (bool, error) {
-			return isClusterInCguCompleted(cguBuilder, cluster)
-		})
+	return err
 }
 
 // SetupCguWithNamespace creates the policy with a namespace and its components for a cguBuilder then creates the

--- a/tests/cnf/ran/talm/internal/mount/mount.go
+++ b/tests/cnf/ran/talm/internal/mount/mount.go
@@ -1,4 +1,4 @@
-package helper
+package mount
 
 import (
 	"fmt"

--- a/tests/cnf/ran/talm/internal/setup/cleanup.go
+++ b/tests/cnf/ran/talm/internal/setup/cleanup.go
@@ -1,4 +1,4 @@
-package helper
+package setup
 
 import (
 	"time"

--- a/tests/cnf/ran/talm/internal/setup/setup.go
+++ b/tests/cnf/ran/talm/internal/setup/setup.go
@@ -1,4 +1,4 @@
-package helper
+package setup
 
 import (
 	"fmt"

--- a/tests/cnf/ran/talm/internal/tsparams/talmvars.go
+++ b/tests/cnf/ran/talm/internal/tsparams/talmvars.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/ranparam"
 	"github.com/openshift-kni/k8sreporter"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 	policiesv1beta1 "open-cluster-management.io/governance-policy-propagator/api/v1beta1"
@@ -55,4 +56,32 @@ var (
 		"Unable to select clusters: cluster %s is not a ManagedCluster", NonExistentClusterName)
 	// TalmNonExistentPolicyMessage is the condition message for when a policy is non-existent.
 	TalmNonExistentPolicyMessage = fmt.Sprintf("Missing managed policies: [%s]", NonExistentPolicyName)
+
+	// CguTimeoutReasonCondition is the condition when the CGU has timed out.
+	CguTimeoutReasonCondition = metav1.Condition{Type: SucceededType, Reason: TimedOutReason}
+	// CguTimeoutMessageCondition is the condition when the CGU has timed out since policy remidation took too long.
+	CguTimeoutMessageCondition = metav1.Condition{Type: SucceededType, Message: TalmTimeoutMessage}
+	// CguTimeoutCanaryCondition is the condition when the CGU has timed out due to canary policy remediation.
+	CguTimeoutCanaryCondition = metav1.Condition{Type: SucceededType, Message: TalmCanaryTimeoutMessage}
+	// CguSuccessfulFinishCondition is the condition when the CGU has completed.
+	CguSuccessfulFinishCondition = metav1.Condition{Type: SucceededType, Reason: CompletedReason}
+	// CguSucceededCondition is the condition when the CGU has succeeded for any reason.
+	CguSucceededCondition = metav1.Condition{Type: SucceededType, Status: metav1.ConditionTrue}
+	// CguNonExistentClusterCondition is the condition when the CGU has a non-existent cluster.
+	CguNonExistentClusterCondition = metav1.Condition{Type: ClustersSelectedType, Message: TalmNonExistentClusterMessage}
+	// CguNonExistentPolicyCondition is the condition when the CGU has a non-existent policy.
+	CguNonExistentPolicyCondition = metav1.Condition{Type: ValidatedType, Message: TalmNonExistentPolicyMessage}
+	// CguPreCacheValidCondition is the condition when the CGU pre-caching is valid.
+	CguPreCacheValidCondition = metav1.Condition{
+		Type:    PreCacheValidType,
+		Status:  metav1.ConditionTrue,
+		Message: PreCacheValidMessage,
+	}
+	// CguPreCachePartialCondition is the condition when the CGU pre-caching could only partially complete.
+	CguPreCachePartialCondition = metav1.Condition{
+		Type:    PreCacheSucceededType,
+		Status:  metav1.ConditionTrue,
+		Message: PreCachePartialFailMessage,
+		Reason:  PartiallyDoneReason,
+	}
 )

--- a/tests/cnf/ran/talm/talm_suite_test.go
+++ b/tests/cnf/ran/talm/talm_suite_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
 	. "github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/raninittools"
-	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/talm/internal/helper"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/talm/internal/setup"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/talm/internal/tsparams"
 	_ "github.com/openshift-kni/eco-gotests/tests/cnf/ran/talm/tests"
 	"github.com/openshift-kni/eco-gotests/tests/internal/reporter"
@@ -28,19 +28,19 @@ func TestTalm(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	err := helper.VerifyTalmIsInstalled()
+	err := setup.VerifyTalmIsInstalled()
 	Expect(err).ToNot(HaveOccurred(), "Failed to verify that TALM is installed")
 
 	By("deleting and recreating TALM test namespace to ensure a blank slate")
-	err = helper.DeleteTalmTestNamespace()
+	err = setup.DeleteTalmTestNamespace()
 	Expect(err).ToNot(HaveOccurred(), "Failed to delete TALM test namespace")
-	err = helper.CreateTalmTestNamespace()
+	err = setup.CreateTalmTestNamespace()
 	Expect(err).ToNot(HaveOccurred(), "Failed to create TALM test namespace")
 })
 
 var _ = AfterSuite(func() {
 	// Deleting the namespace after the suite finishes ensures all the CGUs created are deleted
-	err := helper.DeleteTalmTestNamespace()
+	err := setup.DeleteTalmTestNamespace()
 	Expect(err).ToNot(HaveOccurred(), "Failed to delete TALM test namespace")
 })
 

--- a/tests/cnf/ran/talm/tests/talm-backup.go
+++ b/tests/cnf/ran/talm/tests/talm-backup.go
@@ -13,6 +13,8 @@ import (
 	. "github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/raninittools"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/ranparam"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/talm/internal/helper"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/talm/internal/mount"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/talm/internal/setup"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/talm/internal/tsparams"
 	"k8s.io/utils/ptr"
 )
@@ -50,24 +52,24 @@ var _ = Describe("TALM backup tests", Label(tsparams.LabelBackupTestCases), func
 
 		AfterEach(func() {
 			By("cleaning up resources on hub")
-			errorList := helper.CleanupTestResourcesOnHub(HubAPIClient, tsparams.TestNamespace, "")
+			errorList := setup.CleanupTestResourcesOnHub(HubAPIClient, tsparams.TestNamespace, "")
 			Expect(errorList).To(BeEmpty(), "Failed to clean up test resources on hub")
 
 			By("cleaning up resources on spoke 1")
-			errorList = helper.CleanupTestResourcesOnSpokes([]*clients.Settings{Spoke1APIClient}, "")
+			errorList = setup.CleanupTestResourcesOnSpokes([]*clients.Settings{Spoke1APIClient}, "")
 			Expect(errorList).To(BeEmpty(), "Failed to clean up test resources on spoke 1")
 		})
 
 		Context("with full disk for spoke1", func() {
 			BeforeEach(func() {
 				By("setting up filesystem to simulate low space")
-				loopbackDevicePath, err = helper.PrepareEnvWithSmallMountPoint(Spoke1APIClient)
+				loopbackDevicePath, err = mount.PrepareEnvWithSmallMountPoint(Spoke1APIClient)
 				Expect(err).ToNot(HaveOccurred(), "Failed to prepare mount point")
 			})
 
 			AfterEach(func() {
 				By("starting disk-full env clean up")
-				err = helper.DiskFullEnvCleanup(Spoke1APIClient, loopbackDevicePath)
+				err = mount.DiskFullEnvCleanup(Spoke1APIClient, loopbackDevicePath)
 				Expect(err).ToNot(HaveOccurred(), "Failed to clean up mount point")
 			})
 
@@ -139,21 +141,21 @@ var _ = Describe("TALM backup tests", Label(tsparams.LabelBackupTestCases), func
 				ToNot(ContainElement(BeNil()), "Failed due to missing API client")
 
 			By("setting up filesystem to simulate low space")
-			loopbackDevicePath, err = helper.PrepareEnvWithSmallMountPoint(Spoke1APIClient)
+			loopbackDevicePath, err = mount.PrepareEnvWithSmallMountPoint(Spoke1APIClient)
 			Expect(err).ToNot(HaveOccurred(), "Failed to prepare mount point")
 		})
 
 		AfterEach(func() {
 			By("cleaning up resources on hub")
-			errorList := helper.CleanupTestResourcesOnHub(HubAPIClient, tsparams.TestNamespace, "")
+			errorList := setup.CleanupTestResourcesOnHub(HubAPIClient, tsparams.TestNamespace, "")
 			Expect(errorList).To(BeEmpty(), "Failed to clean up test resources on hub")
 
 			By("starting disk-full env clean up")
-			err = helper.DiskFullEnvCleanup(Spoke1APIClient, loopbackDevicePath)
+			err = mount.DiskFullEnvCleanup(Spoke1APIClient, loopbackDevicePath)
 			Expect(err).ToNot(HaveOccurred(), "Failed to clean up mount point")
 
 			By("cleaning up resources on spokes")
-			errorList = helper.CleanupTestResourcesOnSpokes(
+			errorList = setup.CleanupTestResourcesOnSpokes(
 				[]*clients.Settings{Spoke1APIClient, Spoke2APIClient}, "")
 			Expect(errorList).To(BeEmpty(), "Failed to clean up test resources on spokes")
 		})

--- a/tests/cnf/ran/talm/tests/talm-blockingcr.go
+++ b/tests/cnf/ran/talm/tests/talm-blockingcr.go
@@ -14,6 +14,7 @@ import (
 	. "github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/raninittools"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/ranparam"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/talm/internal/helper"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/talm/internal/setup"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/talm/internal/tsparams"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -39,10 +40,10 @@ var _ = Describe("TALM Blocking CRs Tests", Label(tsparams.LabelBlockingCRTestCa
 
 	AfterEach(func() {
 		By("Cleaning up test resources on hub")
-		errList := helper.CleanupTestResourcesOnHub(HubAPIClient, tsparams.TestNamespace, blockingA)
+		errList := setup.CleanupTestResourcesOnHub(HubAPIClient, tsparams.TestNamespace, blockingA)
 		Expect(errList).To(BeEmpty(), "Failed to cleanup resources for blocking A on hub")
 
-		errList = helper.CleanupTestResourcesOnHub(HubAPIClient, tsparams.TestNamespace, blockingB)
+		errList = setup.CleanupTestResourcesOnHub(HubAPIClient, tsparams.TestNamespace, blockingB)
 		Expect(errList).To(BeEmpty(), "Failed to cleanup resources for blocking B on hub")
 
 		By("Deleting test namespaces on spoke 1")
@@ -80,11 +81,11 @@ var _ = Describe("TALM Blocking CRs Tests", Label(tsparams.LabelBlockingCRTestCa
 			Expect(err).ToNot(HaveOccurred(), "Failed to wait for CGU B to be blocked")
 
 			By("Waiting for CGU A to succeed")
-			err = helper.WaitForCguSuccessfulFinish(cguA, 12*time.Minute)
+			_, err = cguA.WaitForCondition(tsparams.CguSuccessfulFinishCondition, 12*time.Minute)
 			Expect(err).ToNot(HaveOccurred(), "Failed to wait for CGU A to succeed")
 
 			By("Waiting for CGU B to succeed")
-			err = helper.WaitForCguSuccessfulFinish(cguB, 17*time.Minute)
+			_, err = cguB.WaitForCondition(tsparams.CguSuccessfulFinishCondition, 17*time.Minute)
 			Expect(err).ToNot(HaveOccurred(), "Failed to wait for CGU B to succeed")
 		})
 	})
@@ -127,7 +128,7 @@ var _ = Describe("TALM Blocking CRs Tests", Label(tsparams.LabelBlockingCRTestCa
 			Expect(err).ToNot(HaveOccurred(), "Failed to wait for CGU B to be blocked")
 
 			By("Waiting for CGU A to fail because of timeout")
-			err = helper.WaitForCguTimeoutMessage(cguA, 7*time.Minute)
+			_, err = cguA.WaitForCondition(tsparams.CguTimeoutMessageCondition, 7*time.Minute)
 			Expect(err).ToNot(HaveOccurred(), "Failed to wait for CGU A to fail")
 
 			By("Verifiying that CGU B is still blocked")
@@ -174,11 +175,11 @@ var _ = Describe("TALM Blocking CRs Tests", Label(tsparams.LabelBlockingCRTestCa
 			Expect(err).ToNot(HaveOccurred(), "Failed to enable CGU A")
 
 			By("Waiting for CGU A to succeed")
-			err = helper.WaitForCguSucceeded(cguA, 12*time.Minute)
+			_, err = cguA.WaitForCondition(tsparams.CguSucceededCondition, 12*time.Minute)
 			Expect(err).ToNot(HaveOccurred(), "Failed to wait for CGU A to succeed")
 
 			By("Waiting for CGU B to succeed")
-			err = helper.WaitForCguSucceeded(cguB, 17*time.Minute)
+			_, err = cguB.WaitForCondition(tsparams.CguSucceededCondition, 17*time.Minute)
 			Expect(err).ToNot(HaveOccurred(), "Failed to wait for CGU B to succeed")
 		})
 	})


### PR DESCRIPTION
* Reorganize talm/internal/helper into three different, more-specific packages.
* Switch to eco-goinfra functions where available, such as waiting for CGU conditions.
* Some other minor refactorings, like removing the unnecessary loop in `helper.DoesClusterLabelExist`.