### PR TITLE
cnf ran: cnf/ran/internal reorganization

### DIFF
--- a/tests/cnf/ran/gitopsztp/internal/nodedelete/nodedelete.go
+++ b/tests/cnf/ran/gitopsztp/internal/nodedelete/nodedelete.go
@@ -9,63 +9,9 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/assisted"
 	"github.com/openshift-kni/eco-goinfra/pkg/bmh"
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
-	"github.com/openshift-kni/eco-goinfra/pkg/nodes"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/gitopsztp/internal/tsparams"
-	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/ranhelper"
-	. "github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/raninittools"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
-
-// IsSnoPlusOne checks if the specified cluster has one control plane and one worker node.
-func IsSnoPlusOne(client *clients.Settings) (bool, error) {
-	controlPlanes, err := ranhelper.ListNodesByLabel(client, RANConfig.ControlPlaneLabelMap)
-	if err != nil {
-		return false, err
-	}
-
-	if len(controlPlanes) != 1 {
-		return false, nil
-	}
-
-	glog.V(tsparams.LogLevel).Info("Exactly one control plane node found")
-
-	workers, err := ranhelper.ListNodesByLabel(client, RANConfig.WorkerLabelMap)
-	if err != nil {
-		return false, err
-	}
-
-	trueWorkers := 0
-
-	for _, worker := range workers {
-		if !isNodeControlPlane(worker) {
-			trueWorkers++
-		}
-	}
-
-	if trueWorkers != 1 {
-		return false, nil
-	}
-
-	glog.V(tsparams.LogLevel).Info("Exactly one worker node found")
-
-	return true, nil
-}
-
-// GetPlusOneWorkerName gets the name of the one worker in a SNO+1 cluster.
-func GetPlusOneWorkerName(client *clients.Settings) (string, error) {
-	workers, err := ranhelper.ListNodesByLabel(client, RANConfig.WorkerLabelMap)
-	if err != nil {
-		return "", err
-	}
-
-	for _, worker := range workers {
-		if !isNodeControlPlane(worker) {
-			return worker.Definition.Name, nil
-		}
-	}
-
-	return "", fmt.Errorf("could not find a worker node for cluster")
-}
 
 // GetBmhNamespace returns the namespace for the specified BareMetalHost, if it exists.
 func GetBmhNamespace(client *clients.Settings, bmhName string) (string, error) {
@@ -102,11 +48,4 @@ func WaitForBMHDeprovisioning(client *clients.Settings, name, namespace string, 
 
 			return true, nil
 		})
-}
-
-// isNodeControlPlane checks whether the provided node is a control plane node.
-func isNodeControlPlane(node *nodes.Builder) bool {
-	_, exists := node.Definition.Labels[RANConfig.ControlPlaneLabel]
-
-	return exists
 }

--- a/tests/cnf/ran/gitopsztp/tests/ztp-argocd-acm-crs.go
+++ b/tests/cnf/ran/gitopsztp/tests/ztp-argocd-acm-crs.go
@@ -11,9 +11,9 @@ import (
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/gitopsztp/internal/gitdetails"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/gitopsztp/internal/helper"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/gitopsztp/internal/tsparams"
-	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/ranhelper"
 	. "github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/raninittools"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/ranparam"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/version"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 )
 
@@ -25,7 +25,7 @@ var _ = Describe("ZTP Argo CD ACM CR Tests", Label(tsparams.LabelArgoCdAcmCrsTes
 
 	BeforeEach(func() {
 		By("verifying that ZTP meets the minimum version")
-		versionInRange, err := ranhelper.IsVersionStringInRange(RANConfig.ZTPVersion, "4.12", "")
+		versionInRange, err := version.IsVersionStringInRange(RANConfig.ZTPVersion, "4.12", "")
 		Expect(err).ToNot(HaveOccurred(), "Failed to compare ZTP version string")
 
 		if !versionInRange {

--- a/tests/cnf/ran/gitopsztp/tests/ztp-argocd-clusters-app.go
+++ b/tests/cnf/ran/gitopsztp/tests/ztp-argocd-clusters-app.go
@@ -10,14 +10,14 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/gitopsztp/internal/gitdetails"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/gitopsztp/internal/tsparams"
-	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/ranhelper"
 	. "github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/raninittools"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/version"
 )
 
 var _ = Describe("ZTP Argo CD Clusters Tests", Label(tsparams.LabelArgoCdClustersAppTestCases), func() {
 	BeforeEach(func() {
 		By("verifying that ZTP meets the minimum version")
-		versionInRange, err := ranhelper.IsVersionStringInRange(RANConfig.ZTPVersion, "4.11", "")
+		versionInRange, err := version.IsVersionStringInRange(RANConfig.ZTPVersion, "4.11", "")
 		Expect(err).ToNot(HaveOccurred(), "Failed to compare ZTP version string")
 
 		if !versionInRange {

--- a/tests/cnf/ran/gitopsztp/tests/ztp-argocd-hub-templating.go
+++ b/tests/cnf/ran/gitopsztp/tests/ztp-argocd-hub-templating.go
@@ -18,9 +18,9 @@ import (
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/gitopsztp/internal/gitdetails"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/gitopsztp/internal/helper"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/gitopsztp/internal/tsparams"
-	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/ranhelper"
 	. "github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/raninittools"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/ranparam"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/version"
 	corev1 "k8s.io/api/core/v1"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 )
@@ -28,7 +28,7 @@ import (
 var _ = Describe("ZTP Argo CD Hub Templating Tests", Label(tsparams.LabelArgoCdHubTemplatingTestCases), func() {
 	BeforeEach(func() {
 		By("checking the ZTP version")
-		versionInRange, err := ranhelper.IsVersionStringInRange(RANConfig.ZTPVersion, "4.12", "")
+		versionInRange, err := version.IsVersionStringInRange(RANConfig.ZTPVersion, "4.12", "")
 		Expect(err).ToNot(HaveOccurred(), "Failed to check if ZTP version is in range")
 
 		if !versionInRange {
@@ -83,7 +83,7 @@ var _ = Describe("ZTP Argo CD Hub Templating Tests", Label(tsparams.LabelArgoCdH
 		// 54240 - Hub-side ACM templating with TALM
 		It("should create the policy successfully with a valid template", reportxml.ID("54240"), func() {
 			By("checking the ZTP version")
-			versionInRange, err := ranhelper.IsVersionStringInRange(RANConfig.ZTPVersion, "4.16", "")
+			versionInRange, err := version.IsVersionStringInRange(RANConfig.ZTPVersion, "4.16", "")
 			Expect(err).ToNot(HaveOccurred(), "Failed to check if ZTP version is in range")
 
 			validTestPath := tsparams.ZtpTestPathTemplatingValid

--- a/tests/cnf/ran/gitopsztp/tests/ztp-argocd-node-delete.go
+++ b/tests/cnf/ran/gitopsztp/tests/ztp-argocd-node-delete.go
@@ -11,8 +11,9 @@ import (
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/gitopsztp/internal/gitdetails"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/gitopsztp/internal/nodedelete"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/gitopsztp/internal/tsparams"
-	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/ranhelper"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/rancluster"
 	. "github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/raninittools"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/version"
 )
 
 var _ = Describe("ZTP Argo CD Node Deletion Tests", Label(tsparams.LabelArgoCdNodeDeletionTestCases), func() {
@@ -24,7 +25,7 @@ var _ = Describe("ZTP Argo CD Node Deletion Tests", Label(tsparams.LabelArgoCdNo
 
 	BeforeEach(func() {
 		By("checking the ZTP version")
-		versionInRange, err := ranhelper.IsVersionStringInRange(RANConfig.ZTPVersion, "4.14", "")
+		versionInRange, err := version.IsVersionStringInRange(RANConfig.ZTPVersion, "4.14", "")
 		Expect(err).ToNot(HaveOccurred(), "Failed to check if ZTP version is in range")
 
 		if !versionInRange {
@@ -32,7 +33,7 @@ var _ = Describe("ZTP Argo CD Node Deletion Tests", Label(tsparams.LabelArgoCdNo
 		}
 
 		By("checking that the cluster contains a control-plane and worker node")
-		snoPlusOne, err := nodedelete.IsSnoPlusOne(Spoke1APIClient)
+		snoPlusOne, err := rancluster.IsSnoPlusOne(Spoke1APIClient)
 		Expect(err).ToNot(HaveOccurred(), "Failed to check if cluster is SNO+1")
 
 		if !snoPlusOne {
@@ -46,7 +47,7 @@ var _ = Describe("ZTP Argo CD Node Deletion Tests", Label(tsparams.LabelArgoCdNo
 		Expect(err).ToNot(HaveOccurred(), "Failed to pull 'worker' MCP")
 		Expect(mcp.Definition.Status.ReadyMachineCount).To(BeNumerically(">", 0), "Node deletion requires ready 'worker' MCP")
 
-		plusOneNodeName, err = nodedelete.GetPlusOneWorkerName(Spoke1APIClient)
+		plusOneNodeName, err = rancluster.GetPlusOneWorkerName(Spoke1APIClient)
 		Expect(err).ToNot(HaveOccurred(), "Failed to get SNO+1 worker name")
 
 		bmhNamespace, err = nodedelete.GetBmhNamespace(HubAPIClient, plusOneNodeName)
@@ -65,10 +66,10 @@ var _ = Describe("ZTP Argo CD Node Deletion Tests", Label(tsparams.LabelArgoCdNo
 		Expect(err).ToNot(HaveOccurred(), "Failed to reset clusters app git details")
 
 		By("checking that the cluster is back to SNO+1")
-		err = ranhelper.WaitForNumberOfNodes(Spoke1APIClient, 2, 45*time.Minute)
+		err = rancluster.WaitForNumberOfNodes(Spoke1APIClient, 2, 45*time.Minute)
 		Expect(err).ToNot(HaveOccurred(), "Failed to wait for cluster to return to 2 nodes")
 
-		snoPlusOne, err := nodedelete.IsSnoPlusOne(Spoke1APIClient)
+		snoPlusOne, err := rancluster.IsSnoPlusOne(Spoke1APIClient)
 		Expect(err).ToNot(HaveOccurred(), "Failed to check if cluster is SNO+1")
 		Expect(snoPlusOne).To(BeTrue(), "Cluster is no longer SNO+1")
 	})
@@ -105,7 +106,7 @@ var _ = Describe("ZTP Argo CD Node Deletion Tests", Label(tsparams.LabelArgoCdNo
 		Expect(err).ToNot(HaveOccurred(), "Failed to wait for worker BMH to be deprovisioned")
 
 		By("checking that the cluster is healthy")
-		healthy, err := ranhelper.IsClusterStable(Spoke1APIClient)
+		healthy, err := rancluster.IsClusterStable(Spoke1APIClient)
 		Expect(err).ToNot(HaveOccurred(), "Failed to check if spoke cluster is healthy")
 		Expect(healthy).To(BeTrue(), "Spoke cluster was not healthy")
 	})

--- a/tests/cnf/ran/gitopsztp/tests/ztp-argocd-policies-app.go
+++ b/tests/cnf/ran/gitopsztp/tests/ztp-argocd-policies-app.go
@@ -17,9 +17,9 @@ import (
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/gitopsztp/internal/gitdetails"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/gitopsztp/internal/helper"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/gitopsztp/internal/tsparams"
-	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/ranhelper"
 	. "github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/raninittools"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/ranparam"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/version"
 	"github.com/openshift-kni/eco-gotests/tests/internal/cluster"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
@@ -28,7 +28,7 @@ import (
 var _ = Describe("ZTP Argo CD Policies Tests", Label(tsparams.LabelArgoCdPoliciesAppTestCases), func() {
 	BeforeEach(func() {
 		By("checking the ZTP version")
-		versionInRange, err := ranhelper.IsVersionStringInRange(RANConfig.ZTPVersion, "4.10", "")
+		versionInRange, err := version.IsVersionStringInRange(RANConfig.ZTPVersion, "4.10", "")
 		Expect(err).ToNot(HaveOccurred(), "Failed to check if ZTP version is in range")
 
 		if !versionInRange {
@@ -247,7 +247,7 @@ var _ = Describe("ZTP Argo CD Policies Tests", Label(tsparams.LabelArgoCdPolicie
 		It("verifies the custom source CR takes precedence over the default source CR with "+
 			"the same file name", reportxml.ID("62260"), func() {
 			By("checking the ZTP version")
-			versionInRange, err := ranhelper.IsVersionStringInRange(RANConfig.ZTPVersion, "4.14", "")
+			versionInRange, err := version.IsVersionStringInRange(RANConfig.ZTPVersion, "4.14", "")
 			Expect(err).ToNot(HaveOccurred(), "Failed to check if ZTP version is in range")
 
 			if !versionInRange {
@@ -281,7 +281,7 @@ var _ = Describe("ZTP Argo CD Policies Tests", Label(tsparams.LabelArgoCdPolicie
 		It("verifies a proper error is returned in ArgoCD app when a non-existent "+
 			"source-cr is used in PGT", reportxml.ID("63516"), func() {
 			By("checking the ZTP version")
-			versionInRange, err := ranhelper.IsVersionStringInRange(RANConfig.ZTPVersion, "4.14", "")
+			versionInRange, err := version.IsVersionStringInRange(RANConfig.ZTPVersion, "4.14", "")
 			Expect(err).ToNot(HaveOccurred(), "Failed to check if ZTP version is in range")
 
 			if !versionInRange {
@@ -310,7 +310,7 @@ var _ = Describe("ZTP Argo CD Policies Tests", Label(tsparams.LabelArgoCdPolicie
 		// 64407 - Verify source CR search path implementation
 		It("verifies custom and default source CRs can be included in the same policy", reportxml.ID("64407"), func() {
 			By("checking the ZTP version")
-			versionInRange, err := ranhelper.IsVersionStringInRange(RANConfig.ZTPVersion, "4.14", "")
+			versionInRange, err := version.IsVersionStringInRange(RANConfig.ZTPVersion, "4.14", "")
 			Expect(err).ToNot(HaveOccurred(), "Failed to check if ZTP version is in range")
 
 			if !versionInRange {

--- a/tests/cnf/ran/gitopsztp/ztp_suite_test.go
+++ b/tests/cnf/ran/gitopsztp/ztp_suite_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/gitopsztp/internal/gitdetails"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/gitopsztp/internal/tsparams"
 	_ "github.com/openshift-kni/eco-gotests/tests/cnf/ran/gitopsztp/tests"
-	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/ranhelper"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/rancluster"
 	. "github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/raninittools"
 	"github.com/openshift-kni/eco-gotests/tests/internal/reporter"
 )
@@ -32,7 +32,7 @@ func TestZtp(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	By("checking that the required clusters are present")
-	if !ranhelper.AreClustersPresent([]*clients.Settings{HubAPIClient, Spoke1APIClient}) {
+	if !rancluster.AreClustersPresent([]*clients.Settings{HubAPIClient, Spoke1APIClient}) {
 		Skip("not all of the required clusters are present")
 	}
 

--- a/tests/cnf/ran/internal/rancluster/rancluster.go
+++ b/tests/cnf/ran/internal/rancluster/rancluster.go
@@ -1,0 +1,127 @@
+package rancluster
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/openshift-kni/eco-goinfra/pkg/nodes"
+	. "github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/raninittools"
+	"github.com/openshift-kni/eco-gotests/tests/system-tests/diskencryption/tsparams"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// AreClustersPresent checks all of the provided clusters and returns false if any are nil.
+func AreClustersPresent(clusters []*clients.Settings) bool {
+	for _, cluster := range clusters {
+		if cluster == nil {
+			return false
+		}
+	}
+
+	return true
+}
+
+// GetPlusOneWorkerName gets the name of the one worker in a SNO+1 cluster.
+func GetPlusOneWorkerName(client *clients.Settings) (string, error) {
+	workers, err := ListNodesByLabel(client, RANConfig.WorkerLabelMap)
+	if err != nil {
+		return "", err
+	}
+
+	for _, worker := range workers {
+		if !IsNodeControlPlane(worker) {
+			return worker.Definition.Name, nil
+		}
+	}
+
+	return "", fmt.Errorf("could not find a worker node for cluster")
+}
+
+// IsClusterStable checks if the provided cluster does not have any unschedulable nodes.
+func IsClusterStable(client *clients.Settings) (bool, error) {
+	nodeList, err := nodes.List(client)
+	if err != nil {
+		return false, err
+	}
+
+	for _, node := range nodeList {
+		if node.Definition.Spec.Unschedulable {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// IsNodeControlPlane checks whether the provided node is a control plane node.
+func IsNodeControlPlane(node *nodes.Builder) bool {
+	_, exists := node.Definition.Labels[RANConfig.ControlPlaneLabel]
+
+	return exists
+}
+
+// IsSnoPlusOne checks if the specified cluster has one control plane and one worker node.
+func IsSnoPlusOne(client *clients.Settings) (bool, error) {
+	controlPlanes, err := ListNodesByLabel(client, RANConfig.ControlPlaneLabelMap)
+	if err != nil {
+		return false, err
+	}
+
+	if len(controlPlanes) != 1 {
+		return false, nil
+	}
+
+	glog.V(tsparams.LogLevel).Info("Exactly one control plane node found")
+
+	workers, err := ListNodesByLabel(client, RANConfig.WorkerLabelMap)
+	if err != nil {
+		return false, err
+	}
+
+	trueWorkers := 0
+
+	for _, worker := range workers {
+		if !IsNodeControlPlane(worker) {
+			trueWorkers++
+		}
+	}
+
+	if trueWorkers != 1 {
+		return false, nil
+	}
+
+	glog.V(tsparams.LogLevel).Info("Exactly one worker node found")
+
+	return true, nil
+}
+
+// ListNodesByLabel returns a list of nodes that have the specified label.
+func ListNodesByLabel(client *clients.Settings, labelMap map[string]string) ([]*nodes.Builder, error) {
+	return nodes.List(client, metav1.ListOptions{
+		LabelSelector: labels.Set(labelMap).String(),
+	})
+}
+
+// WaitForNumberOfNodes waits up to timeout until the number of nodes on the cluster matches the expected.
+func WaitForNumberOfNodes(client *clients.Settings, expected int, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(
+		context.TODO(), 5*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+			nodeList, err := nodes.List(client)
+			if err != nil {
+				return false, err
+			}
+
+			if len(nodeList) == expected {
+				return true, nil
+			}
+
+			glog.V(tsparams.LogLevel).Infof("Expected %d nodes but found %d nodes", expected, len(nodeList))
+
+			return false, nil
+		})
+}

--- a/tests/cnf/ran/internal/ranconfig/config.go
+++ b/tests/cnf/ran/internal/ranconfig/config.go
@@ -11,8 +11,8 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/bmc"
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/internal/cnfconfig"
-	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/ranhelper"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/ranparam"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/version"
 	"github.com/openshift-kni/eco-gotests/tests/internal/inittools"
 	"gopkg.in/yaml.v2"
 )
@@ -112,7 +112,7 @@ func (ranconfig *RANConfig) newHubConfig(configFile string) {
 
 	ranconfig.HubConfig.HubAPIClient = clients.New(ranconfig.HubConfig.HubKubeconfig)
 
-	ranconfig.HubConfig.HubOCPVersion, err = ranhelper.GetOCPVersion(ranconfig.HubConfig.HubAPIClient)
+	ranconfig.HubConfig.HubOCPVersion, err = version.GetOCPVersion(ranconfig.HubConfig.HubAPIClient)
 	if err != nil {
 		glog.V(ranparam.LogLevel).Infof("Failed to get OCP version from hub: %v", err)
 	}
@@ -121,25 +121,25 @@ func (ranconfig *RANConfig) newHubConfig(configFile string) {
 
 	ranconfig.HubConfig.HubOperatorVersions = make(map[ranparam.HubOperatorName]string)
 
-	ranconfig.HubConfig.HubOperatorVersions[ranparam.ACM], err = ranhelper.GetOperatorVersionFromCsv(
+	ranconfig.HubConfig.HubOperatorVersions[ranparam.ACM], err = version.GetOperatorVersionFromCsv(
 		ranconfig.HubConfig.HubAPIClient, string(ranparam.ACM), ranparam.AcmOperatorNamespace)
 	if err != nil {
 		glog.V(ranparam.LogLevel).Infof("Failed to get ACM version from hub: %v", err)
 	}
 
-	ranconfig.HubConfig.HubOperatorVersions[ranparam.GitOps], err = ranhelper.GetOperatorVersionFromCsv(
+	ranconfig.HubConfig.HubOperatorVersions[ranparam.GitOps], err = version.GetOperatorVersionFromCsv(
 		ranconfig.HubConfig.HubAPIClient, string(ranparam.GitOps), ranparam.OpenshiftGitOpsNamespace)
 	if err != nil {
 		glog.V(ranparam.LogLevel).Infof("Failed to get GitOps version from hub: %v", err)
 	}
 
-	ranconfig.HubConfig.HubOperatorVersions[ranparam.MCE], err = ranhelper.GetOperatorVersionFromCsv(
+	ranconfig.HubConfig.HubOperatorVersions[ranparam.MCE], err = version.GetOperatorVersionFromCsv(
 		ranconfig.HubConfig.HubAPIClient, string(ranparam.MCE), ranparam.MceOperatorNamespace)
 	if err != nil {
 		glog.V(ranparam.LogLevel).Infof("Failed to get MCE version from hub: %v", err)
 	}
 
-	ranconfig.HubConfig.HubOperatorVersions[ranparam.TALM], err = ranhelper.GetOperatorVersionFromCsv(
+	ranconfig.HubConfig.HubOperatorVersions[ranparam.TALM], err = version.GetOperatorVersionFromCsv(
 		ranconfig.HubConfig.HubAPIClient, string(ranparam.TALM), ranparam.OpenshiftOperatorNamespace)
 	if err != nil {
 		glog.V(ranparam.LogLevel).Infof("Failed to get TALM version from hub: %v", err)
@@ -147,7 +147,7 @@ func (ranconfig *RANConfig) newHubConfig(configFile string) {
 
 	glog.V(ranparam.LogLevel).Infof("Found operator versions on hub: %v", ranconfig.HubConfig.HubOperatorVersions)
 
-	ranconfig.HubConfig.ZTPVersion, err = ranhelper.GetZTPVersionFromArgoCd(
+	ranconfig.HubConfig.ZTPVersion, err = version.GetZTPVersionFromArgoCd(
 		ranconfig.HubConfig.HubAPIClient, ranparam.OpenshiftGitopsRepoServer, ranparam.OpenshiftGitOpsNamespace)
 	if err != nil {
 		glog.V(ranparam.LogLevel).Infof("Failed to get ZTP version from hub: %v", err)
@@ -170,7 +170,7 @@ func (ranconfig *RANConfig) newSpoke1Config(configFile string) {
 
 	spoke1Kubeconfig := os.Getenv("KUBECONFIG")
 	if spoke1Kubeconfig != "" {
-		ranconfig.Spoke1Config.Spoke1Name, err = ranhelper.GetClusterName(spoke1Kubeconfig)
+		ranconfig.Spoke1Config.Spoke1Name, err = version.GetClusterName(spoke1Kubeconfig)
 
 		if err != nil {
 			glog.V(ranparam.LogLevel).Infof("Failed to get spoke 1 name from kubeconfig at %s: %v", spoke1Kubeconfig, err)
@@ -179,7 +179,7 @@ func (ranconfig *RANConfig) newSpoke1Config(configFile string) {
 		glog.V(ranparam.LogLevel).Infof("No spoke 1 kubeconfig specified in KUBECONFIG environment variable")
 	}
 
-	ranconfig.Spoke1Config.Spoke1OCPVersion, err = ranhelper.GetOCPVersion(ranconfig.Spoke1Config.Spoke1APIClient)
+	ranconfig.Spoke1Config.Spoke1OCPVersion, err = version.GetOCPVersion(ranconfig.Spoke1Config.Spoke1APIClient)
 	if err != nil {
 		glog.V(ranparam.LogLevel).Infof("Failed to get OCP version from spoke 1: %v", err)
 	}
@@ -218,13 +218,13 @@ func (ranconfig *RANConfig) newSpoke2Config(configFile string) {
 
 	ranconfig.Spoke2Config.Spoke2APIClient = clients.New(ranconfig.Spoke2Config.Spoke2Kubeconfig)
 
-	ranconfig.Spoke2Config.Spoke2Name, err = ranhelper.GetClusterName(ranconfig.Spoke2Config.Spoke2Kubeconfig)
+	ranconfig.Spoke2Config.Spoke2Name, err = version.GetClusterName(ranconfig.Spoke2Config.Spoke2Kubeconfig)
 	if err != nil {
 		glog.V(ranparam.LogLevel).Infof(
 			"Failed to get spoke 2 name from kubeconfig at %s: %v", ranconfig.Spoke2Config.Spoke2Kubeconfig, err)
 	}
 
-	ranconfig.Spoke2Config.Spoke2OCPVersion, err = ranhelper.GetOCPVersion(ranconfig.Spoke2Config.Spoke2APIClient)
+	ranconfig.Spoke2Config.Spoke2OCPVersion, err = version.GetOCPVersion(ranconfig.Spoke2Config.Spoke2APIClient)
 	if err != nil {
 		glog.V(ranparam.LogLevel).Infof("Failed to get OCP version from spoke 2: %v", err)
 	}

--- a/tests/cnf/ran/internal/ranhelper/ranhelper.go
+++ b/tests/cnf/ran/internal/ranhelper/ranhelper.go
@@ -6,16 +6,10 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/openshift-kni/eco-goinfra/pkg/clients"
-	"github.com/openshift-kni/eco-goinfra/pkg/nodes"
 	"github.com/openshift-kni/eco-goinfra/pkg/pod"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/ranparam"
-	"github.com/openshift-kni/eco-gotests/tests/system-tests/diskencryption/tsparams"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 // DoesContainerExistInPod checks if a given container exists in a given pod.
@@ -31,59 +25,6 @@ func DoesContainerExistInPod(pod *pod.Builder, containerName string) bool {
 	}
 
 	return false
-}
-
-// AreClustersPresent checks all of the provided clusters and returns false if any are nil.
-func AreClustersPresent(clusters []*clients.Settings) bool {
-	for _, cluster := range clusters {
-		if cluster == nil {
-			return false
-		}
-	}
-
-	return true
-}
-
-// ListNodesByLabel returns a list of nodes that have the specified label.
-func ListNodesByLabel(client *clients.Settings, labelMap map[string]string) ([]*nodes.Builder, error) {
-	return nodes.List(client, metav1.ListOptions{
-		LabelSelector: labels.Set(labelMap).String(),
-	})
-}
-
-// IsClusterStable checks if the provided cluster does not have any unschedulable nodes.
-func IsClusterStable(client *clients.Settings) (bool, error) {
-	nodeList, err := nodes.List(client)
-	if err != nil {
-		return false, err
-	}
-
-	for _, node := range nodeList {
-		if node.Definition.Spec.Unschedulable {
-			return false, nil
-		}
-	}
-
-	return true, nil
-}
-
-// WaitForNumberOfNodes waits up to timeout until the number of nodes on the cluster matches the expected.
-func WaitForNumberOfNodes(client *clients.Settings, expected int, timeout time.Duration) error {
-	return wait.PollUntilContextTimeout(
-		context.TODO(), 5*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
-			nodeList, err := nodes.List(client)
-			if err != nil {
-				return false, err
-			}
-
-			if len(nodeList) == expected {
-				return true, nil
-			}
-
-			glog.V(tsparams.LogLevel).Infof("Expected %d nodes but found %d nodes", expected, len(nodeList))
-
-			return false, nil
-		})
 }
 
 // UnmarshalRaw converts raw bytes for a K8s CR into the actual type.

--- a/tests/cnf/ran/internal/version/version.go
+++ b/tests/cnf/ran/internal/version/version.go
@@ -1,4 +1,4 @@
-package ranhelper
+package version
 
 import (
 	"errors"

--- a/tests/cnf/ran/internal/version/version_test.go
+++ b/tests/cnf/ran/internal/version/version_test.go
@@ -1,4 +1,4 @@
-package ranhelper
+package version
 
 import (
 	"fmt"

--- a/tests/cnf/ran/powermanagement/tests/cpufreq.go
+++ b/tests/cnf/ran/powermanagement/tests/cpufreq.go
@@ -10,9 +10,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/openshift-kni/eco-goinfra/pkg/nto" //nolint:misspell
-	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/ranhelper"
 	. "github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/raninittools"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/ranparam"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/version"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/powermanagement/internal/helper"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/powermanagement/internal/tsparams"
 	"github.com/openshift-kni/eco-gotests/tests/internal/cluster"
@@ -64,7 +64,7 @@ var _ = Describe("CPU frequency tuning tests change the core frequencies of isol
 		When("reserved and isolated core frequency is configured via PerformanceProfile", func() {
 			It("sets the reserved and isolated core frequency correctly on the DUT", func() {
 
-				versionInRange, err := ranhelper.IsVersionStringInRange(RANConfig.Spoke1OCPVersion, "4.16", "")
+				versionInRange, err := version.IsVersionStringInRange(RANConfig.Spoke1OCPVersion, "4.16", "")
 				Expect(err).ToNot(HaveOccurred(), "Failed to compare OCP version string")
 
 				if !versionInRange {

--- a/tests/cnf/ran/talm/internal/helper/cluster.go
+++ b/tests/cnf/ran/talm/internal/helper/cluster.go
@@ -4,8 +4,8 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/clusterversion"
 	"github.com/openshift-kni/eco-goinfra/pkg/ocm"
-	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/ranhelper"
 	. "github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/raninittools"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/version"
 	configv1 "github.com/openshift/api/config/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -35,7 +35,7 @@ func GetClusterVersionDefinition(client *clients.Settings, config string) (*conf
 
 	// channel and upstream specs are required when desiredUpdate.version is used
 	if config != "Image" {
-		version, err := ranhelper.GetOCPVersion(client)
+		version, err := version.GetOCPVersion(client)
 		if err != nil {
 			return nil, err
 		}

--- a/tests/cnf/ran/talm/tests/talm-backup.go
+++ b/tests/cnf/ran/talm/tests/talm-backup.go
@@ -9,9 +9,10 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/cgu"
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
-	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/ranhelper"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/rancluster"
 	. "github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/raninittools"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/ranparam"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/version"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/talm/internal/helper"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/talm/internal/mount"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/talm/internal/setup"
@@ -27,7 +28,7 @@ var _ = Describe("TALM backup tests", Label(tsparams.LabelBackupTestCases), func
 
 	BeforeEach(func() {
 		By("checking that the talm version is at least 4.11")
-		versionInRange, err := ranhelper.IsVersionStringInRange(RANConfig.HubOperatorVersions[ranparam.TALM], "4.11", "")
+		versionInRange, err := version.IsVersionStringInRange(RANConfig.HubOperatorVersions[ranparam.TALM], "4.11", "")
 		Expect(err).ToNot(HaveOccurred(), "Failed to compared talm version string")
 
 		if !versionInRange {
@@ -35,7 +36,7 @@ var _ = Describe("TALM backup tests", Label(tsparams.LabelBackupTestCases), func
 		}
 
 		By("checking that the talm version is at most 4.15")
-		versionInRange, err = ranhelper.IsVersionStringInRange(RANConfig.HubOperatorVersions[ranparam.TALM], "", "4.15")
+		versionInRange, err = version.IsVersionStringInRange(RANConfig.HubOperatorVersions[ranparam.TALM], "", "4.15")
 		Expect(err).ToNot(HaveOccurred(), "Failed to compare talm version string")
 
 		if !versionInRange {
@@ -46,8 +47,8 @@ var _ = Describe("TALM backup tests", Label(tsparams.LabelBackupTestCases), func
 	When("there is a single spoke", func() {
 		BeforeEach(func() {
 			By("checking that the hub and spoke 1 are present")
-			Expect([]*clients.Settings{HubAPIClient, Spoke1APIClient}).
-				ToNot(ContainElement(BeNil()), "Failed due to missing API client")
+			Expect(rancluster.AreClustersPresent([]*clients.Settings{HubAPIClient, Spoke1APIClient})).
+				To(BeTrue(), "Failed due to missing API client")
 		})
 
 		AfterEach(func() {
@@ -92,7 +93,7 @@ var _ = Describe("TALM backup tests", Label(tsparams.LabelBackupTestCases), func
 		Context("with CGU disabled", func() {
 			BeforeEach(func() {
 				By("checking that the talm version is at least 4.12")
-				versionInRange, err := ranhelper.IsVersionStringInRange(RANConfig.HubOperatorVersions[ranparam.TALM], "4.12", "")
+				versionInRange, err := version.IsVersionStringInRange(RANConfig.HubOperatorVersions[ranparam.TALM], "4.12", "")
 				Expect(err).ToNot(HaveOccurred(), "Failed to compare talm version string")
 
 				if !versionInRange {
@@ -137,8 +138,8 @@ var _ = Describe("TALM backup tests", Label(tsparams.LabelBackupTestCases), func
 	When("there are two spokes", func() {
 		BeforeEach(func() {
 			By("checking that hub and two spokes are present")
-			Expect([]*clients.Settings{HubAPIClient, Spoke1APIClient, Spoke2APIClient}).
-				ToNot(ContainElement(BeNil()), "Failed due to missing API client")
+			Expect(rancluster.AreClustersPresent([]*clients.Settings{HubAPIClient, Spoke1APIClient, Spoke2APIClient})).
+				To(BeTrue(), "Failed due to missing API client")
 
 			By("setting up filesystem to simulate low space")
 			loopbackDevicePath, err = mount.PrepareEnvWithSmallMountPoint(Spoke1APIClient)

--- a/tests/cnf/ran/talm/tests/talm-batching.go
+++ b/tests/cnf/ran/talm/tests/talm-batching.go
@@ -13,9 +13,9 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/ocm"
 	"github.com/openshift-kni/eco-goinfra/pkg/olm"
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
-	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/ranhelper"
 	. "github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/raninittools"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/ranparam"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/version"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/talm/internal/helper"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/talm/internal/setup"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/talm/internal/tsparams"
@@ -33,7 +33,7 @@ var _ = Describe("TALM Batching Tests", Label(tsparams.LabelBatchingTestCases), 
 			ToNot(ContainElement(BeNil()), "Failed due to missing API client")
 
 		By("ensuring TALM is at least version 4.12")
-		versionInRange, err := ranhelper.IsVersionStringInRange(RANConfig.HubOperatorVersions[ranparam.TALM], "4.11", "")
+		versionInRange, err := version.IsVersionStringInRange(RANConfig.HubOperatorVersions[ranparam.TALM], "4.11", "")
 		Expect(err).ToNot(HaveOccurred(), "Failed to compare TALM version string")
 
 		if !versionInRange {

--- a/tests/cnf/ran/talm/tests/talm-blockingcr.go
+++ b/tests/cnf/ran/talm/tests/talm-blockingcr.go
@@ -10,9 +10,9 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/cgu"
 	"github.com/openshift-kni/eco-goinfra/pkg/namespace"
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
-	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/ranhelper"
 	. "github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/raninittools"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/ranparam"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/version"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/talm/internal/helper"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/talm/internal/setup"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/talm/internal/tsparams"
@@ -30,7 +30,7 @@ var _ = Describe("TALM Blocking CRs Tests", Label(tsparams.LabelBlockingCRTestCa
 
 	BeforeEach(func() {
 		By("ensuring TALM is at least version 4.12")
-		versionInRange, err := ranhelper.IsVersionStringInRange(RANConfig.HubOperatorVersions[ranparam.TALM], "4.11", "")
+		versionInRange, err := version.IsVersionStringInRange(RANConfig.HubOperatorVersions[ranparam.TALM], "4.11", "")
 		Expect(err).ToNot(HaveOccurred(), "Failed to compare TALM version string")
 
 		if !versionInRange {

--- a/tests/cnf/ran/talm/tests/talm-canary.go
+++ b/tests/cnf/ran/talm/tests/talm-canary.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/namespace"
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/rancluster"
 	. "github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/raninittools"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/talm/internal/helper"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/talm/internal/setup"
@@ -21,8 +22,8 @@ var _ = Describe("TALM Canary Tests", Label(tsparams.LabelCanaryTestCases), func
 
 	BeforeEach(func() {
 		By("checking that hub and two spokes are present")
-		Expect([]*clients.Settings{HubAPIClient, Spoke1APIClient, Spoke2APIClient}).
-			ToNot(ContainElement(BeNil()), "Failed due to missing API client")
+		Expect(rancluster.AreClustersPresent([]*clients.Settings{HubAPIClient, Spoke1APIClient, Spoke2APIClient})).
+			To(BeTrue(), "Failed due to missing API client")
 	})
 
 	AfterEach(func() {

--- a/tests/cnf/ran/talm/tests/talm-precache.go
+++ b/tests/cnf/ran/talm/tests/talm-precache.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/ranhelper"
 	. "github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/raninittools"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/ranparam"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/version"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/talm/internal/helper"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/talm/internal/setup"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/talm/internal/tsparams"
@@ -189,7 +190,7 @@ var _ = Describe("TALM precache", Label(tsparams.LabelPreCacheTestCases), func()
 
 			// 59948 - Configurable filters for precache images.
 			It("tests precache image filtering", reportxml.ID("59948"), func() {
-				versionInRange, err := ranhelper.IsVersionStringInRange(RANConfig.HubOperatorVersions[ranparam.TALM], "4.13", "")
+				versionInRange, err := version.IsVersionStringInRange(RANConfig.HubOperatorVersions[ranparam.TALM], "4.13", "")
 				Expect(err).ToNot(HaveOccurred(), "Failed to compare TALM version string")
 
 				if !versionInRange {
@@ -233,7 +234,7 @@ var _ = Describe("TALM precache", Label(tsparams.LabelPreCacheTestCases), func()
 
 			// 64746 - Precache User-Specified Image
 			It("tests custom image precaching using a PreCachingConfig CR", reportxml.ID("64746"), func() {
-				versionInRange, err := ranhelper.IsVersionStringInRange(RANConfig.HubOperatorVersions[ranparam.TALM], "4.14", "")
+				versionInRange, err := version.IsVersionStringInRange(RANConfig.HubOperatorVersions[ranparam.TALM], "4.14", "")
 				Expect(err).ToNot(HaveOccurred(), "Failed to compare TALM version string")
 
 				if !versionInRange {
@@ -308,7 +309,7 @@ var _ = Describe("TALM precache", Label(tsparams.LabelPreCacheTestCases), func()
 
 			// 64747 Precache Invalid User-Specified Image
 			It("tests custom image precaching using an invalid image", reportxml.ID("64747"), func() {
-				versionInRange, err := ranhelper.IsVersionStringInRange(RANConfig.HubOperatorVersions[ranparam.TALM], "4.14", "")
+				versionInRange, err := version.IsVersionStringInRange(RANConfig.HubOperatorVersions[ranparam.TALM], "4.14", "")
 				Expect(err).ToNot(HaveOccurred(), "Failed to compare TALM version string")
 
 				if !versionInRange {
@@ -345,7 +346,7 @@ var _ = Describe("TALM precache", Label(tsparams.LabelPreCacheTestCases), func()
 
 			// 64751 - Precache with Large Disk
 			It("tests precaching disk space checks using preCachingConfig", reportxml.ID("64751"), func() {
-				versionInRange, err := ranhelper.IsVersionStringInRange(RANConfig.HubOperatorVersions[ranparam.TALM], "4.14", "")
+				versionInRange, err := version.IsVersionStringInRange(RANConfig.HubOperatorVersions[ranparam.TALM], "4.14", "")
 				Expect(err).ToNot(HaveOccurred(), "Failed to compare TALM version string")
 
 				if !versionInRange {


### PR DESCRIPTION
* Moves version testing into its own package.
* Creates a new rancluster package for cluster-level utilities, such as checking if it is SNO+1.
* Updates the test suites to use these new packages.