### PR TITLE
global: added all schemes to reporter package

### DIFF
--- a/tests/accel/upgrade/upgrade_suite_test.go
+++ b/tests/accel/upgrade/upgrade_suite_test.go
@@ -7,7 +7,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/namespace"
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
 	. "github.com/openshift-kni/eco-gotests/tests/accel/internal/accelinittools"
@@ -37,8 +36,7 @@ var _ = AfterSuite(func() {
 
 var _ = JustAfterEach(func() {
 	reporter.ReportIfFailed(
-		CurrentSpecReport(), currentFile, upgradeparams.ReporterNamespacesToDump,
-		upgradeparams.ReporterCRDsToDump, clients.SetScheme)
+		CurrentSpecReport(), currentFile, upgradeparams.ReporterNamespacesToDump, upgradeparams.ReporterCRDsToDump)
 })
 
 var _ = ReportAfterSuite("", func(report Report) {

--- a/tests/assisted/ztp/operator/internal/tsparams/operatorvars.go
+++ b/tests/assisted/ztp/operator/internal/tsparams/operatorvars.go
@@ -2,14 +2,12 @@ package tsparams
 
 import (
 	bmhv1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
-	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	hiveextV1Beta1 "github.com/openshift-kni/eco-goinfra/pkg/schemes/assisted/api/hiveextension/v1beta1"
 	agentInstallV1Beta1 "github.com/openshift-kni/eco-goinfra/pkg/schemes/assisted/api/v1beta1"
 	hivev1 "github.com/openshift-kni/eco-goinfra/pkg/schemes/assisted/hive/api/v1"
 	"github.com/openshift-kni/eco-gotests/tests/assisted/ztp/internal/ztpparams"
 	"github.com/openshift-kni/k8sreporter"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 var (
@@ -34,21 +32,3 @@ var (
 	// MCENameSpace is the namespace used by the assisted service.
 	MCENameSpace = "multicluster-engine"
 )
-
-var schemesToAdd = []clients.SchemeAttacher{
-	hivev1.AddToScheme,
-	hiveextV1Beta1.AddToScheme,
-	agentInstallV1Beta1.AddToScheme,
-	bmhv1alpha1.AddToScheme,
-}
-
-// SetReporterSchemes add specified schemes to the reporter.
-func SetReporterSchemes(crScheme *runtime.Scheme) error {
-	for _, addScheme := range schemesToAdd {
-		if err := addScheme(crScheme); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}

--- a/tests/assisted/ztp/operator/operator_suite_test.go
+++ b/tests/assisted/ztp/operator/operator_suite_test.go
@@ -48,6 +48,5 @@ var _ = JustAfterEach(func() {
 		CurrentSpecReport(),
 		currentFile,
 		tsparams.ReporterNamespacesToDump,
-		tsparams.ReporterCRDsToDump,
-		tsparams.SetReporterSchemes)
+		tsparams.ReporterCRDsToDump)
 })

--- a/tests/assisted/ztp/spoke/internal/tsparams/spokevars.go
+++ b/tests/assisted/ztp/spoke/internal/tsparams/spokevars.go
@@ -2,14 +2,12 @@ package tsparams
 
 import (
 	bmhv1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
-	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	hiveextV1Beta1 "github.com/openshift-kni/eco-goinfra/pkg/schemes/assisted/api/hiveextension/v1beta1"
 	agentInstallV1Beta1 "github.com/openshift-kni/eco-goinfra/pkg/schemes/assisted/api/v1beta1"
 	hivev1 "github.com/openshift-kni/eco-goinfra/pkg/schemes/assisted/hive/api/v1"
 	"github.com/openshift-kni/eco-gotests/tests/assisted/ztp/internal/ztpparams"
 	"github.com/openshift-kni/k8sreporter"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 var (
@@ -31,21 +29,3 @@ var (
 		{Cr: &agentInstallV1Beta1.AgentList{}},
 	}
 )
-
-var schemesToAdd = []clients.SchemeAttacher{
-	hivev1.AddToScheme,
-	hiveextV1Beta1.AddToScheme,
-	agentInstallV1Beta1.AddToScheme,
-	bmhv1alpha1.AddToScheme,
-}
-
-// SetReporterSchemes add specified schemes to the reporter.
-func SetReporterSchemes(crScheme *runtime.Scheme) error {
-	for _, addScheme := range schemesToAdd {
-		if err := addScheme(crScheme); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}

--- a/tests/assisted/ztp/spoke/spoke_suite_test.go
+++ b/tests/assisted/ztp/spoke/spoke_suite_test.go
@@ -48,6 +48,5 @@ var _ = JustAfterEach(func() {
 		CurrentSpecReport(),
 		currentFile,
 		tsparams.ReporterNamespacesToDump,
-		tsparams.ReporterCRDsToDump,
-		tsparams.SetReporterSchemes)
+		tsparams.ReporterCRDsToDump)
 })

--- a/tests/cnf/core/network/bfd/bfd_suite_test.go
+++ b/tests/cnf/core/network/bfd/bfd_suite_test.go
@@ -5,7 +5,6 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/namespace"
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/core/network/bfd/internal/tsparams"
@@ -53,7 +52,7 @@ var _ = AfterSuite(func() {
 
 var _ = JustAfterEach(func() {
 	reporter.ReportIfFailed(
-		CurrentSpecReport(), currentFile, tsparams.ReporterNamespacesToDump, tsparams.ReporterCRDsToDump, clients.SetScheme)
+		CurrentSpecReport(), currentFile, tsparams.ReporterNamespacesToDump, tsparams.ReporterCRDsToDump)
 })
 
 var _ = ReportAfterSuite("", func(report Report) {

--- a/tests/cnf/core/network/cni/cni_suite_test.go
+++ b/tests/cnf/core/network/cni/cni_suite_test.go
@@ -6,7 +6,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/namespace"
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/core/network/cni/internal/tsparams"
@@ -50,7 +49,7 @@ var _ = AfterSuite(func() {
 
 var _ = JustAfterEach(func() {
 	reporter.ReportIfFailed(
-		CurrentSpecReport(), currentFile, tsparams.ReporterNamespacesToDump, tsparams.ReporterCRDsToDump, clients.SetScheme)
+		CurrentSpecReport(), currentFile, tsparams.ReporterNamespacesToDump, tsparams.ReporterCRDsToDump)
 })
 
 var _ = ReportAfterSuite("", func(report Report) {

--- a/tests/cnf/core/network/day1day2/day1day2_suite_test.go
+++ b/tests/cnf/core/network/day1day2/day1day2_suite_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/namespace"
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
 
@@ -69,7 +68,7 @@ var _ = AfterSuite(func() {
 
 var _ = JustAfterEach(func() {
 	reporter.ReportIfFailed(
-		CurrentSpecReport(), currentFile, tsparams.ReporterNamespacesToDump, tsparams.ReporterCRDsToDump, clients.SetScheme)
+		CurrentSpecReport(), currentFile, tsparams.ReporterNamespacesToDump, tsparams.ReporterCRDsToDump)
 })
 
 var _ = ReportAfterSuite("", func(report Report) {

--- a/tests/cnf/core/network/dpdk/dpdk_suite_test.go
+++ b/tests/cnf/core/network/dpdk/dpdk_suite_test.go
@@ -7,7 +7,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/mco"
 	"github.com/openshift-kni/eco-goinfra/pkg/namespace"
 	"github.com/openshift-kni/eco-goinfra/pkg/nto" //nolint:misspell
@@ -79,7 +78,7 @@ var _ = AfterSuite(func() {
 
 var _ = JustAfterEach(func() {
 	reporter.ReportIfFailed(
-		CurrentSpecReport(), currentFile, tsparams.ReporterNamespacesToDump, tsparams.ReporterCRDsToDump, clients.SetScheme)
+		CurrentSpecReport(), currentFile, tsparams.ReporterNamespacesToDump, tsparams.ReporterCRDsToDump)
 })
 
 var _ = ReportAfterSuite("", func(report Report) {

--- a/tests/cnf/core/network/metallb/metallb_suite_test.go
+++ b/tests/cnf/core/network/metallb/metallb_suite_test.go
@@ -7,7 +7,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/namespace"
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
 	. "github.com/openshift-kni/eco-gotests/tests/cnf/core/network/internal/netinittools"
@@ -67,7 +66,7 @@ var _ = AfterSuite(func() {
 
 var _ = JustAfterEach(func() {
 	reporter.ReportIfFailed(
-		CurrentSpecReport(), currentFile, tsparams.ReporterNamespacesToDump, tsparams.ReporterCRDsToDump, clients.SetScheme)
+		CurrentSpecReport(), currentFile, tsparams.ReporterNamespacesToDump, tsparams.ReporterCRDsToDump)
 })
 
 var _ = ReportAfterSuite("", func(report Report) {

--- a/tests/cnf/core/network/policy/policy_suite_test.go
+++ b/tests/cnf/core/network/policy/policy_suite_test.go
@@ -6,7 +6,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/namespace"
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
 	. "github.com/openshift-kni/eco-gotests/tests/cnf/core/network/internal/netinittools"
@@ -50,7 +49,7 @@ var _ = AfterSuite(func() {
 
 var _ = JustAfterEach(func() {
 	reporter.ReportIfFailed(
-		CurrentSpecReport(), currentFile, tsparams.ReporterNamespacesToDump, tsparams.ReporterCRDsToDump, clients.SetScheme)
+		CurrentSpecReport(), currentFile, tsparams.ReporterNamespacesToDump, tsparams.ReporterCRDsToDump)
 })
 
 var _ = ReportAfterSuite("", func(report Report) {

--- a/tests/cnf/core/network/sriov/sriov_suite_test.go
+++ b/tests/cnf/core/network/sriov/sriov_suite_test.go
@@ -6,7 +6,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/namespace"
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/core/network/internal/netenv"
@@ -55,7 +54,7 @@ var _ = AfterSuite(func() {
 
 var _ = JustAfterEach(func() {
 	reporter.ReportIfFailed(
-		CurrentSpecReport(), currentFile, tsparams.ReporterNamespacesToDump, tsparams.ReporterCRDsToDump, clients.SetScheme)
+		CurrentSpecReport(), currentFile, tsparams.ReporterNamespacesToDump, tsparams.ReporterCRDsToDump)
 })
 
 var _ = ReportAfterSuite("", func(report Report) {

--- a/tests/cnf/ran/gitopsztp/ztp_suite_test.go
+++ b/tests/cnf/ran/gitopsztp/ztp_suite_test.go
@@ -60,7 +60,7 @@ var _ = JustAfterEach(func() {
 	)
 
 	reporter.ReportIfFailed(
-		report, currentFile, tsparams.ReporterSpokeNamespacesToDump, tsparams.ReporterSpokeCRsToDump, clients.SetScheme)
+		report, currentFile, tsparams.ReporterSpokeNamespacesToDump, tsparams.ReporterSpokeCRsToDump)
 
 	if HubAPIClient != nil {
 		reporter.ReportIfFailedOnCluster(
@@ -68,8 +68,7 @@ var _ = JustAfterEach(func() {
 			report,
 			hubReportPath,
 			tsparams.ReporterHubNamespacesToDump,
-			tsparams.ReporterHubCRsToDump,
-			clients.SetScheme)
+			tsparams.ReporterHubCRsToDump)
 	}
 })
 

--- a/tests/cnf/ran/powermanagement/powermanagement_suite_test.go
+++ b/tests/cnf/ran/powermanagement/powermanagement_suite_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/golang/glog"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/namespace"
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
 	. "github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/raninittools"
@@ -52,7 +51,7 @@ var _ = AfterSuite(func() {
 
 var _ = JustAfterEach(func() {
 	reporter.ReportIfFailed(
-		CurrentSpecReport(), currentFile, tsparams.ReporterNamespacesToDump, tsparams.ReporterCRsToDump, clients.SetScheme)
+		CurrentSpecReport(), currentFile, tsparams.ReporterNamespacesToDump, tsparams.ReporterCRsToDump)
 })
 
 var _ = ReportAfterSuite("", func(report Report) {

--- a/tests/cnf/ran/talm/talm_suite_test.go
+++ b/tests/cnf/ran/talm/talm_suite_test.go
@@ -8,7 +8,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
 	. "github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/raninittools"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/talm/internal/setup"
@@ -53,7 +52,7 @@ var _ = JustAfterEach(func() {
 	)
 
 	reporter.ReportIfFailed(
-		report, currentFile, tsparams.ReporterSpokeNamespacesToDump, tsparams.ReporterSpokeCRsToDump, clients.SetScheme)
+		report, currentFile, tsparams.ReporterSpokeNamespacesToDump, tsparams.ReporterSpokeCRsToDump)
 
 	if HubAPIClient != nil {
 		reporter.ReportIfFailedOnCluster(
@@ -61,8 +60,7 @@ var _ = JustAfterEach(func() {
 			report,
 			hubReportPath,
 			tsparams.ReporterHubNamespacesToDump,
-			tsparams.ReporterHubCRsToDump,
-			clients.SetScheme)
+			tsparams.ReporterHubCRsToDump)
 	}
 
 	if Spoke2APIClient != nil {
@@ -71,8 +69,7 @@ var _ = JustAfterEach(func() {
 			report,
 			spoke2ReportPath,
 			tsparams.ReporterSpokeNamespacesToDump,
-			tsparams.ReporterSpokeCRsToDump,
-			clients.SetScheme)
+			tsparams.ReporterSpokeCRsToDump)
 	}
 })
 

--- a/tests/hw-accel/kmm/1upgrade/upgrade_suite_test.go
+++ b/tests/hw-accel/kmm/1upgrade/upgrade_suite_test.go
@@ -4,7 +4,6 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
 	"github.com/openshift-kni/eco-gotests/tests/hw-accel/kmm/1upgrade/internal/tsparams"
 	_ "github.com/openshift-kni/eco-gotests/tests/hw-accel/kmm/1upgrade/tests"
@@ -32,5 +31,5 @@ var _ = ReportAfterSuite("1upgrade", func(report Report) {
 
 var _ = JustAfterEach(func() {
 	reporter.ReportIfFailed(
-		CurrentSpecReport(), currentFile, map[string]string{kmmparams.KmmOperatorNamespace: "op"}, nil, clients.SetScheme)
+		CurrentSpecReport(), currentFile, map[string]string{kmmparams.KmmOperatorNamespace: "op"}, nil)
 })

--- a/tests/hw-accel/kmm/mcm/mcm_suite_test.go
+++ b/tests/hw-accel/kmm/mcm/mcm_suite_test.go
@@ -20,7 +20,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	. "github.com/openshift-kni/eco-gotests/tests/hw-accel/kmm/internal/kmminittools"
 	"github.com/openshift-kni/eco-gotests/tests/hw-accel/kmm/mcm/internal/tsparams"
 	. "github.com/openshift-kni/eco-gotests/tests/internal/inittools"
@@ -50,7 +49,7 @@ var _ = ReportAfterSuite("", func(report Report) {
 
 var _ = JustAfterEach(func() {
 	reporter.ReportIfFailed(
-		CurrentSpecReport(), currentFile, tsparams.ReporterNamespacesToDump, tsparams.ReporterCRDsToDump, clients.SetScheme)
+		CurrentSpecReport(), currentFile, tsparams.ReporterNamespacesToDump, tsparams.ReporterCRDsToDump)
 })
 
 var _ = BeforeSuite(func() {

--- a/tests/hw-accel/kmm/modules/modules_suite_test.go
+++ b/tests/hw-accel/kmm/modules/modules_suite_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/deployment"
 	"github.com/openshift-kni/eco-goinfra/pkg/nodes"
 	"github.com/openshift-kni/eco-goinfra/pkg/pod"
@@ -126,5 +125,5 @@ var _ = ReportAfterSuite("", func(report Report) {
 
 var _ = JustAfterEach(func() {
 	reporter.ReportIfFailed(
-		CurrentSpecReport(), currentFile, tsparams.ReporterNamespacesToDump, tsparams.ReporterCRDsToDump, clients.SetScheme)
+		CurrentSpecReport(), currentFile, tsparams.ReporterNamespacesToDump, tsparams.ReporterCRDsToDump)
 })

--- a/tests/hw-accel/nfd/2upgrade/upgrade_suite_test.go
+++ b/tests/hw-accel/nfd/2upgrade/upgrade_suite_test.go
@@ -6,7 +6,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
 	"github.com/openshift-kni/eco-gotests/tests/hw-accel/nfd/2upgrade/internal/tsparams"
 	_ "github.com/openshift-kni/eco-gotests/tests/hw-accel/nfd/2upgrade/tests"
@@ -32,5 +31,5 @@ var _ = ReportAfterSuite(tsparams.NfdUpgradeLabel, func(report Report) {
 
 var _ = JustAfterEach(func() {
 	reporter.ReportIfFailed(
-		CurrentSpecReport(), currentFile, map[string]string{nfdparams.NFDNamespace: "op"}, nil, clients.SetScheme)
+		CurrentSpecReport(), currentFile, map[string]string{nfdparams.NFDNamespace: "op"}, nil)
 })

--- a/tests/hw-accel/nfd/features/nfd_suite_test.go
+++ b/tests/hw-accel/nfd/features/nfd_suite_test.go
@@ -6,7 +6,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
 	"github.com/openshift-kni/eco-gotests/tests/hw-accel/nfd/features/internal/tsparams"
 	_ "github.com/openshift-kni/eco-gotests/tests/hw-accel/nfd/features/tests"
@@ -32,5 +31,5 @@ var _ = ReportAfterSuite("", func(report Report) {
 
 var _ = JustAfterEach(func() {
 	reporter.ReportIfFailed(
-		CurrentSpecReport(), currentFile, tsparams.ReporterNamespacesToDump, tsparams.ReporterCRDsToDump, clients.SetScheme)
+		CurrentSpecReport(), currentFile, tsparams.ReporterNamespacesToDump, tsparams.ReporterCRDsToDump)
 })

--- a/tests/hw-accel/nvidiagpu/gpudeploy/gpu_suite_test.go
+++ b/tests/hw-accel/nvidiagpu/gpudeploy/gpu_suite_test.go
@@ -4,7 +4,6 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-gotests/tests/internal/reporter"
 
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
@@ -33,5 +32,5 @@ var _ = ReportAfterSuite("", func(report Report) {
 
 var _ = JustAfterEach(func() {
 	reporter.ReportIfFailed(
-		CurrentSpecReport(), currentFile, tsparams.ReporterNamespacesToDump, tsparams.ReporterCRDsToDump, clients.SetScheme)
+		CurrentSpecReport(), currentFile, tsparams.ReporterNamespacesToDump, tsparams.ReporterCRDsToDump)
 })

--- a/tests/internal/reporter/reporter.go
+++ b/tests/internal/reporter/reporter.go
@@ -52,9 +52,8 @@ func ReportIfFailed(
 	report types.SpecReport,
 	testSuite string,
 	nSpaces map[string]string,
-	cRDs []k8sreporter.CRData,
-	apiScheme func(scheme *runtime.Scheme) error) {
-	ReportIfFailedOnCluster("", report, testSuite, nSpaces, cRDs, apiScheme)
+	cRDs []k8sreporter.CRData) {
+	ReportIfFailedOnCluster("", report, testSuite, nSpaces, cRDs)
 }
 
 // ReportIfFailedOnCluster dumps the requested cluster CRs on the cluster specified by kubeconfig if TC is failed to the
@@ -64,8 +63,7 @@ func ReportIfFailedOnCluster(
 	report types.SpecReport,
 	testSuite string,
 	nSpaces map[string]string,
-	cRDs []k8sreporter.CRData,
-	apiScheme func(scheme *runtime.Scheme) error) {
+	cRDs []k8sreporter.CRData) {
 	if !types.SpecStateFailureStates.Is(report.State) {
 		return
 	}
@@ -73,7 +71,7 @@ func ReportIfFailedOnCluster(
 	dumpDir := GeneralConfig.GetDumpFailedTestReportLocation(testSuite)
 
 	if dumpDir != "" {
-		reporter, err := newReporter(dumpDir, kubeconfig, nSpaces, apiScheme, cRDs)
+		reporter, err := newReporter(dumpDir, kubeconfig, nSpaces, setReporterSchemes, cRDs)
 
 		if err != nil {
 			glog.Fatalf("Failed to create log reporter due to %s", err)

--- a/tests/internal/reporter/schemes.go
+++ b/tests/internal/reporter/schemes.go
@@ -1,0 +1,70 @@
+package reporter
+
+import (
+	nvidiagpuv1 "github.com/NVIDIA/gpu-operator/api/v1"
+	multinetpolicyapiv1beta1 "github.com/k8snetworkplumbingwg/multi-networkpolicy/pkg/apis/k8s.cni.cncf.io/v1beta1"
+	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	sriovv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
+	bmhv1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	nmstatev1 "github.com/nmstate/kubernetes-nmstate/api/v1"
+	nmstatev1alpha1 "github.com/nmstate/kubernetes-nmstate/api/v1alpha1"
+	cguv1alpha1 "github.com/openshift-kni/cluster-group-upgrades-operator/pkg/api/clustergroupupgrades/v1alpha1"
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/openshift-kni/eco-goinfra/pkg/schemes/argocd/argocdoperator"
+	argocdv1alpha1 "github.com/openshift-kni/eco-goinfra/pkg/schemes/argocd/argocdtypes/v1alpha1"
+	hiveextv1beta1 "github.com/openshift-kni/eco-goinfra/pkg/schemes/assisted/api/hiveextension/v1beta1"
+	agentinstallv1beta1 "github.com/openshift-kni/eco-goinfra/pkg/schemes/assisted/api/v1beta1"
+	hivev1 "github.com/openshift-kni/eco-goinfra/pkg/schemes/assisted/hive/api/v1"
+	olmv1alpha1 "github.com/openshift-kni/eco-goinfra/pkg/schemes/olm/operators/v1alpha1"
+	lcav1 "github.com/openshift-kni/lifecycle-agent/api/imagebasedupgrade/v1"
+	configv1 "github.com/openshift/api/config/v1"
+	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
+	nfdv1 "github.com/openshift/cluster-nfd-operator/api/v1"
+	performanceprofilev2 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v2"
+	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	mcmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api-hub/v1beta1"
+	modulev1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	policiesv1beta1 "open-cluster-management.io/governance-policy-propagator/api/v1beta1"
+	placementrulev1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1"
+)
+
+var reporterSchemes = []clients.SchemeAttacher{
+	clients.SetScheme,
+	hivev1.AddToScheme,
+	hiveextv1beta1.AddToScheme,
+	agentinstallv1beta1.AddToScheme,
+	bmhv1alpha1.AddToScheme,
+	configv1.Install,
+	nadv1.AddToScheme,
+	nmstatev1.AddToScheme,
+	nmstatev1alpha1.AddToScheme,
+	sriovv1.AddToScheme,
+	machineconfigv1.Install,
+	performanceprofilev2.AddToScheme,
+	multinetpolicyapiv1beta1.AddToScheme,
+	policiesv1.AddToScheme,
+	placementrulev1.AddToScheme,
+	imageregistryv1.Install,
+	argocdoperator.AddToScheme,
+	argocdv1alpha1.AddToScheme,
+	cguv1alpha1.AddToScheme,
+	olmv1alpha1.AddToScheme,
+	policiesv1beta1.AddToScheme,
+	mcmv1beta1.AddToScheme,
+	modulev1beta1.AddToScheme,
+	nfdv1.AddToScheme,
+	nvidiagpuv1.AddToScheme,
+	lcav1.AddToScheme,
+}
+
+func setReporterSchemes(scheme *runtime.Scheme) error {
+	for _, schemeAttacher := range reporterSchemes {
+		if err := schemeAttacher(scheme); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/tests/lca/imagebasedupgrade/cnf/upgrade-talm/upgrade_suite_test.go
+++ b/tests/lca/imagebasedupgrade/cnf/upgrade-talm/upgrade_suite_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/openshift-kni/eco-gotests/tests/lca/imagebasedupgrade/cnf/internal/cnfinittools"
 
-	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
 	"github.com/openshift-kni/eco-gotests/tests/internal/reporter"
 	"github.com/openshift-kni/eco-gotests/tests/lca/imagebasedupgrade/cnf/upgrade-talm/internal/tsparams"
@@ -48,6 +47,5 @@ var _ = JustAfterEach(func() {
 		CurrentSpecReport(),
 		currentFile,
 		tsparams.ReporterNamespacesToDump,
-		tsparams.ReporterCRDsToDump,
-		clients.SetScheme)
+		tsparams.ReporterCRDsToDump)
 })

--- a/tests/lca/imagebasedupgrade/mgmt/negative/negative_suite_test.go
+++ b/tests/lca/imagebasedupgrade/mgmt/negative/negative_suite_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/lca"
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
 	"github.com/openshift-kni/eco-gotests/tests/internal/reporter"
@@ -90,6 +89,5 @@ var _ = JustAfterEach(func() {
 		CurrentSpecReport(),
 		currentFile,
 		tsparams.ReporterNamespacesToDump,
-		tsparams.ReporterCRDsToDump,
-		clients.SetScheme)
+		tsparams.ReporterCRDsToDump)
 })

--- a/tests/lca/imagebasedupgrade/mgmt/upgrade/upgrade_suite_test.go
+++ b/tests/lca/imagebasedupgrade/mgmt/upgrade/upgrade_suite_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
 	"github.com/openshift-kni/eco-gotests/tests/internal/reporter"
 	. "github.com/openshift-kni/eco-gotests/tests/lca/imagebasedupgrade/mgmt/internal/mgmtinittools"
@@ -45,6 +44,5 @@ var _ = JustAfterEach(func() {
 		CurrentSpecReport(),
 		currentFile,
 		tsparams.ReporterNamespacesToDump,
-		tsparams.ReporterCRDsToDump,
-		clients.SetScheme)
+		tsparams.ReporterCRDsToDump)
 })

--- a/tests/rhwa/far-operator/far_suite_test.go
+++ b/tests/rhwa/far-operator/far_suite_test.go
@@ -6,7 +6,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
 	"github.com/openshift-kni/eco-gotests/tests/internal/reporter"
 	"github.com/openshift-kni/eco-gotests/tests/rhwa/far-operator/internal/farparams"
@@ -26,8 +25,7 @@ func TestFAR(t *testing.T) {
 
 var _ = JustAfterEach(func() {
 	reporter.ReportIfFailed(
-		CurrentSpecReport(), currentFile, farparams.ReporterNamespacesToDump,
-		farparams.ReporterCRDsToDump, clients.SetScheme)
+		CurrentSpecReport(), currentFile, farparams.ReporterNamespacesToDump, farparams.ReporterCRDsToDump)
 })
 
 var _ = ReportAfterSuite("", func(report Report) {

--- a/tests/rhwa/mdr-operator/mdr_suite_test.go
+++ b/tests/rhwa/mdr-operator/mdr_suite_test.go
@@ -6,7 +6,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
 	"github.com/openshift-kni/eco-gotests/tests/internal/reporter"
 	. "github.com/openshift-kni/eco-gotests/tests/rhwa/internal/rhwainittools"
@@ -26,8 +25,7 @@ func TestMDR(t *testing.T) {
 
 var _ = JustAfterEach(func() {
 	reporter.ReportIfFailed(
-		CurrentSpecReport(), currentFile, mdrparams.ReporterNamespacesToDump,
-		mdrparams.ReporterCRDsToDump, clients.SetScheme)
+		CurrentSpecReport(), currentFile, mdrparams.ReporterNamespacesToDump, mdrparams.ReporterCRDsToDump)
 })
 
 var _ = ReportAfterSuite("", func(report Report) {

--- a/tests/rhwa/nmo-operator/nmo_suite_test.go
+++ b/tests/rhwa/nmo-operator/nmo_suite_test.go
@@ -6,7 +6,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
 	"github.com/openshift-kni/eco-gotests/tests/internal/reporter"
 	. "github.com/openshift-kni/eco-gotests/tests/rhwa/internal/rhwainittools"
@@ -26,8 +25,7 @@ func TestNMO(t *testing.T) {
 
 var _ = JustAfterEach(func() {
 	reporter.ReportIfFailed(
-		CurrentSpecReport(), currentFile, nmoparams.ReporterNamespacesToDump,
-		nmoparams.ReporterCRDsToDump, clients.SetScheme)
+		CurrentSpecReport(), currentFile, nmoparams.ReporterNamespacesToDump, nmoparams.ReporterCRDsToDump)
 })
 
 var _ = ReportAfterSuite("", func(report Report) {

--- a/tests/system-tests/ipsec/ipsec_suite_test.go
+++ b/tests/system-tests/ipsec/ipsec_suite_test.go
@@ -7,7 +7,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/namespace"
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
 	. "github.com/openshift-kni/eco-gotests/tests/internal/inittools"
@@ -51,8 +50,7 @@ var _ = AfterSuite(func() {
 
 var _ = JustAfterEach(func() {
 	reporter.ReportIfFailed(
-		CurrentSpecReport(), currentFile, ipsecparams.ReporterNamespacesToDump,
-		ipsecparams.ReporterCRDsToDump, clients.SetScheme)
+		CurrentSpecReport(), currentFile, ipsecparams.ReporterNamespacesToDump, ipsecparams.ReporterCRDsToDump)
 })
 
 var _ = ReportAfterSuite("", func(report Report) {

--- a/tests/system-tests/ran-du/ran_du_suite_test.go
+++ b/tests/system-tests/ran-du/ran_du_suite_test.go
@@ -7,7 +7,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/namespace"
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
 	. "github.com/openshift-kni/eco-gotests/tests/internal/inittools"
@@ -51,8 +50,7 @@ var _ = AfterSuite(func() {
 
 var _ = JustAfterEach(func() {
 	reporter.ReportIfFailed(
-		CurrentSpecReport(), currentFile, randuparams.ReporterNamespacesToDump,
-		randuparams.ReporterCRDsToDump, clients.SetScheme)
+		CurrentSpecReport(), currentFile, randuparams.ReporterNamespacesToDump, randuparams.ReporterCRDsToDump)
 })
 
 var _ = ReportAfterSuite("", func(report Report) {

--- a/tests/system-tests/rdscore/rds_suite_test.go
+++ b/tests/system-tests/rdscore/rds_suite_test.go
@@ -6,7 +6,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
 	. "github.com/openshift-kni/eco-gotests/tests/internal/inittools"
 	"github.com/openshift-kni/eco-gotests/tests/internal/reporter"
@@ -27,8 +26,7 @@ func TestRDSCore(t *testing.T) {
 
 var _ = JustAfterEach(func() {
 	reporter.ReportIfFailed(
-		CurrentSpecReport(), currentFile, rdscoreparams.ReporterNamespacesToDump,
-		rdscoreparams.ReporterCRDsToDump, clients.SetScheme)
+		CurrentSpecReport(), currentFile, rdscoreparams.ReporterNamespacesToDump, rdscoreparams.ReporterCRDsToDump)
 })
 
 var _ = ReportAfterSuite("", func(report Report) {

--- a/tests/system-tests/spk/spk_suite_test.go
+++ b/tests/system-tests/spk/spk_suite_test.go
@@ -6,7 +6,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
 	. "github.com/openshift-kni/eco-gotests/tests/internal/inittools"
 	"github.com/openshift-kni/eco-gotests/tests/internal/reporter"
@@ -26,8 +25,7 @@ func TestRanDu(t *testing.T) {
 
 var _ = JustAfterEach(func() {
 	reporter.ReportIfFailed(
-		CurrentSpecReport(), currentFile, spkparams.ReporterNamespacesToDump,
-		spkparams.ReporterCRDsToDump, clients.SetScheme)
+		CurrentSpecReport(), currentFile, spkparams.ReporterNamespacesToDump, spkparams.ReporterCRDsToDump)
 })
 
 var _ = ReportAfterSuite("", func(report Report) {

--- a/tests/system-tests/vcore/vcore_suite_test.go
+++ b/tests/system-tests/vcore/vcore_suite_test.go
@@ -11,7 +11,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
 	"github.com/openshift-kni/eco-gotests/tests/internal/reporter"
 	. "github.com/openshift-kni/eco-gotests/tests/system-tests/vcore/internal/vcoreinittools"
@@ -70,8 +69,7 @@ var _ = AfterSuite(func() {
 
 var _ = JustAfterEach(func() {
 	reporter.ReportIfFailed(
-		CurrentSpecReport(), currentFile, vcoreparams.ReporterNamespacesToDump,
-		vcoreparams.ReporterCRDsToDump, clients.SetScheme)
+		CurrentSpecReport(), currentFile, vcoreparams.ReporterNamespacesToDump, vcoreparams.ReporterCRDsToDump)
 })
 
 var _ = ReportAfterSuite("", func(report Report) {


### PR DESCRIPTION
Updated the reporter package to add all of the schemes currently used in reports for this repo. Also removed the option to provide a scheme attacher to the reporter functions since it is now done by default.