### PR TITLE
assisted ztp: use eventually in platform tests

### DIFF
--- a/tests/assisted/ztp/operator/tests/platform-selection-test.go
+++ b/tests/assisted/ztp/operator/tests/platform-selection-test.go
@@ -112,9 +112,21 @@ var _ = Describe(
 					} else {
 						Expect(err).ToNot(HaveOccurred(), "error creating agentclusterinstall")
 						By("Waiting for condition to report expected failure message")
-						err = testAgentClusterInstall.WaitForConditionMessage(v1beta1.ClusterSpecSyncedCondition,
-							"The Spec could not be synced due to an input error: "+message, time.Minute*2)
-						Expect(err).NotTo(HaveOccurred(), "got unexpected message from SpecSynced condition")
+						Eventually(func() (string, error) {
+							testAgentClusterInstall.Object, err = testAgentClusterInstall.Get()
+							if err != nil {
+								return "", err
+							}
+
+							for _, condition := range testAgentClusterInstall.Object.Status.Conditions {
+								if condition.Type == v1beta1.ClusterSpecSyncedCondition {
+									return condition.Message, nil
+								}
+							}
+
+							return "", nil
+						}).WithTimeout(time.Minute*2).Should(Equal("The Spec could not be synced due to an input error: "+message),
+							"got unexpected message from SpecSynced condition")
 					}
 				},
 				Entry("that is SNO with VSphere platform", v1beta1.VSpherePlatformType, true, 1, 0,


### PR DESCRIPTION
Currently our tests leverage Wait methods which prevent us from capturing actual vs expected behavior. This PR updates the platform-selection tests to use the Eventually container and compare condition message directly. 