### PR TITLE
assisted ztp: update default registries in unauthenticated registries…

### DIFF
--- a/tests/assisted/ztp/operator/tests/unauthenticated-registries.go
+++ b/tests/assisted/ztp/operator/tests/unauthenticated-registries.go
@@ -237,7 +237,7 @@ var _ = Describe(
 // unAuthenticatedDefaultRegistriesList return the list of default registries.
 func unAuthenticatedDefaultRegistriesList() []string {
 	return []string{
-		"registry.svc.ci.openshift.org",
+		"registry.ci.openshift.org",
 		"quay.io",
 	}
 }
@@ -246,7 +246,7 @@ func unAuthenticatedDefaultRegistriesList() []string {
 func unAuthenticatedNonDefaultRegistriesList() []string {
 	return []string{
 		"registry.redhat.io",
-		"registry.ci.openshift.org",
+		"registry.svc.ci.openshift.org",
 		"docker.io",
 	}
 }


### PR DESCRIPTION
… test

Updates default registries used in unauthenticated registries test. Needed due to this change -  https://github.com/openshift/assisted-service/pull/6553