### PR TITLE
cnf core: use GetGVR() instead of GetServiceGVR()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -247,7 +247,7 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-require gopkg.in/yaml.v3 v3.0.1 // indirect
+require gopkg.in/yaml.v3 v3.0.1
 
 replace (
 	github.com/imdario/mergo => github.com/imdario/mergo v0.3.16

--- a/tests/cnf/core/network/metallb/tests/bfd-test.go
+++ b/tests/cnf/core/network/metallb/tests/bfd-test.go
@@ -208,7 +208,7 @@ var _ = Describe("BFD", Ordered, Label(tsparams.LabelBFDTestCases), ContinueOnFa
 			err = namespace.NewBuilder(APIClient, tsparams.TestNamespaceName).CleanObjects(
 				tsparams.DefaultTimeout,
 				pod.GetGVR(),
-				service.GetServiceGVR(),
+				service.GetGVR(),
 				configmap.GetGVR(),
 				nad.GetGVR())
 			Expect(err).ToNot(HaveOccurred(), "Failed to clean test namespace")

--- a/tests/cnf/core/network/metallb/tests/bgp-tests.go
+++ b/tests/cnf/core/network/metallb/tests/bgp-tests.go
@@ -93,7 +93,7 @@ var _ = Describe("BGP", Ordered, Label(tsparams.LabelBGPTestCases), ContinueOnFa
 		err = namespace.NewBuilder(APIClient, tsparams.TestNamespaceName).CleanObjects(
 			tsparams.DefaultTimeout,
 			pod.GetGVR(),
-			service.GetServiceGVR(),
+			service.GetGVR(),
 			configmap.GetGVR(),
 			nad.GetGVR())
 		Expect(err).ToNot(HaveOccurred(), "Failed to clean test namespace")
@@ -216,7 +216,7 @@ var _ = Describe("BGP", Ordered, Label(tsparams.LabelBGPTestCases), ContinueOnFa
 			err = namespace.NewBuilder(APIClient, tsparams.TestNamespaceName).CleanObjects(
 				tsparams.DefaultTimeout,
 				pod.GetGVR(),
-				service.GetServiceGVR(),
+				service.GetGVR(),
 				configmap.GetGVR(),
 				nad.GetGVR())
 			Expect(err).ToNot(HaveOccurred(), "Failed to clean test namespace")

--- a/tests/cnf/core/network/metallb/tests/layer2-test.go
+++ b/tests/cnf/core/network/metallb/tests/layer2-test.go
@@ -114,7 +114,7 @@ var _ = Describe("Layer2", Ordered, Label(tsparams.LabelLayer2TestCases), Contin
 		err = namespace.NewBuilder(APIClient, tsparams.TestNamespaceName).CleanObjects(
 			tsparams.DefaultTimeout,
 			pod.GetGVR(),
-			service.GetServiceGVR(),
+			service.GetGVR(),
 			nad.GetGVR())
 		Expect(err).ToNot(HaveOccurred(), "Failed to clean test namespace")
 	})


### PR DESCRIPTION
Builds on: https://github.com/openshift-kni/eco-goinfra/pull/667

Bumps the version of eco-goinfra.  `GetServiceGVR()` has been deprecated in favor of a more generic `GetGVR()` to match other functions in eco-goinfra.