### PR TITLE
cnf ran: update skipped talm test case

### DIFF
--- a/tests/cnf/ran/internal/ranconfig/default.yaml
+++ b/tests/cnf/ran/internal/ranconfig/default.yaml
@@ -13,7 +13,7 @@ bmcTimeout: "15s"
 ocpUpgradeUpstreamUrl: "https://api.openshift.com/api/upgrades_info/v1/graph"
 ptpOperatorNamespace: "openshift-ptp"
 talmPreCachePolicies:
-  - "common-config-policy"
-  - "common-subscriptions-policy"
+  - "^common(-v4\\.\\d\\d)?-config-policy"
+  - "^common(-v4\\.\\d\\d)?-subscriptions-policy"
 ztpSiteGenerateImage: "registry-proxy.engineering.redhat.com/rh-osbs/openshift4-ztp-site-generate"
 ...


### PR DESCRIPTION
There is currently a test case in the TALM suite that is always skipped due to the inputs being wrong. This PR switches it to use a regex that will work in newer versions.