### PR TITLE
lca cnf: fix ValidateNoImagesPulled post ibu validation

### DIFF
--- a/tests/lca/imagebasedupgrade/cnf/internal/validations/post_ibu_validations.go
+++ b/tests/lca/imagebasedupgrade/cnf/internal/validations/post_ibu_validations.go
@@ -345,7 +345,7 @@ func ValidateNoImagesPulled() {
 			}
 
 			logCmd := "journalctl -l --system | grep Pulling | grep image:"
-			logRes, err := cluster.ExecCmdWithStdout(TargetSNOAPIClient, logCmd+excludeImages)
+			logRes, err := cluster.ExecCmdWithStdout(TargetSNOAPIClient, logCmd+excludeImages+" || true")
 			Expect(err).ToNot(HaveOccurred(), "could not execute command: %s", err)
 
 			for _, stdout := range logRes {


### PR DESCRIPTION
when there are no images returned grep command exits with rc 1 and the ExecCmdWithStdout is failing before evaluating the output