### PR TITLE
ci: ensure id_rsa file exists

### DIFF
--- a/.github/workflows/eco-goinfra-bump.yml
+++ b/.github/workflows/eco-goinfra-bump.yml
@@ -12,6 +12,8 @@ jobs:
 
       - name: Setup agent and add repo ssh key
         run: |
+          mkdir -p ~/.ssh
+          touch ~/.ssh/eco-gotests.id_rsa
           echo "${{ secrets.REPO_ACCESS_KEY }}" > ~/.ssh/eco-gotests.id_rsa
           chmod 0600 ~/.ssh/eco-gotests.id_rsa
       


### PR DESCRIPTION
The error from the previous [run](https://github.com/openshift-kni/eco-gotests/actions/runs/11000202120/job/30542074725):

```
Run echo "" > ~/.ssh/eco-gotests.id_rsa
/home/runner/work/_temp/9ab6dc9e-92[7](https://github.com/openshift-kni/eco-gotests/actions/runs/11000202120/job/30542074725#step:3:8)5-4f77-8a12-e4f64975a9ee.sh: line 1: /home/runner/.ssh/eco-gotests.id_rsa: No such file or directory
```

Just making sure that the directory and file exist prior to sending the REPO_ACCESS_KEY contents to the file.