### PR TITLE
cnf-network: adjusted metallb metric tests

### DIFF
--- a/tests/cnf/core/network/metallb/internal/prometheus/prometheus.go
+++ b/tests/cnf/core/network/metallb/internal/prometheus/prometheus.go
@@ -26,6 +26,7 @@ type metric struct {
 // PodMetricsPresentInDB returns true if the given metrics are present for the given pod in a prometheus database.
 func PodMetricsPresentInDB(prometheusPod *pod.Builder, podName string, uniqueMetricKeys []string) (bool, error) {
 	for _, metricsKey := range uniqueMetricKeys {
+		metricsKey = strings.Replace(metricsKey, "frrk8s", "metallb", 1)
 		metricFound := false
 		command := []string{
 			"curl",


### PR DESCRIPTION
The issue is that all MetalLB metrics in the frr-k8s pod now have a new prefix frrk8s_, whereas the old prefix was metallb_. When querying in Prometheus, it fails to find the new frrk8s_ prefix, while the old metallb_ prefix still works.

```
sh-5.1$ curl "http://localhost:9090/api/v1/query?query=frrk8s_bfd_control_packet_input"
{"status":"success","data":{"resultType":"vector","result":[]}}
```

```
sh-5.1$ curl "http://localhost:9090/api/v1/query?query=metallb_bfd_control_packet_input"
{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"metallb_bfd_control_packet_input","container":"kube-rbac-proxy-frr","endpoint":"frrmetricshttps","instance":"10.46.73.2:9141","job":"frr-k8s-monitor-service","namespace":"metallb-system","peer":"10.46.73.131","pod":"frr-k8s-pgxnw","service":"frr-k8s-monitor-service","vrf":"default"},"value":[1727664750.281,"484"]},{"metric":{"__name__":"metallb_bfd_control_packet_input","container":"kube-rbac-proxy-frr","endpoint":"frrmetricshttps","instance":"10.46.73.3:9141","job":"frr-k8s-monitor-service","namespace":"metallb-system","peer":"10.46.73.131","pod":"frr-k8s-f2hgt","service":"frr-k8s-monitor-service","vrf":"default"},"value":[1727664750.281,"509"]}]}}
```