### PR TITLE
cnf-network:metallb: removed default route from the frr test container

### DIFF
--- a/tests/cnf/core/network/metallb/tests/common.go
+++ b/tests/cnf/core/network/metallb/tests/common.go
@@ -218,7 +218,9 @@ func createFrrPod(
 
 	if configmapName != "" {
 		frrContainer := pod.NewContainerBuilder(
-			tsparams.FRRSecondContainerName, NetConfig.CnfNetTestContainer, tsparams.SleepCMD).
+			tsparams.FRRSecondContainerName,
+			NetConfig.CnfNetTestContainer,
+			[]string{"/bin/bash", "-c", "ip route del default && sleep INF"}).
 			WithSecurityCapabilities([]string{"NET_ADMIN", "NET_RAW", "SYS_ADMIN"}, true)
 
 		frrCtr, err := frrContainer.GetContainerCfg()


### PR DESCRIPTION
This pull request addresses an issue with traffic validation during MetalLB testing. Currently, the client test pod is able to reach the server through the default route because it runs on a master node. This setup results in false positive validation results.