### PR TITLE
cnf network: fix-metallb-frrk8-test-label

### DIFF
--- a/tests/cnf/core/network/metallb/tests/frrk8-tests.go
+++ b/tests/cnf/core/network/metallb/tests/frrk8-tests.go
@@ -75,6 +75,13 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelFRRTestCases), ContinueOnFa
 			"Failed to detect master nodes")
 	})
 
+	AfterAll(func() {
+		if len(cnfWorkerNodeList) > 2 {
+			By("Remove custom metallb test label from nodes")
+			removeNodeLabel(workerNodeList, metalLbTestsLabel)
+		}
+	})
+
 	Context("IBGP Single hop", func() {
 
 		var (


### PR DESCRIPTION
Back port fix of metallb frrk8 test case label. Was not being deleted.