### PR TITLE
lca cnf: fix missing ibgu builder during e2e afterall

### DIFF
--- a/tests/lca/imagebasedupgrade/cnf/upgrade-talm/tests/e2e-upgrade-test.go
+++ b/tests/lca/imagebasedupgrade/cnf/upgrade-talm/tests/e2e-upgrade-test.go
@@ -25,8 +25,7 @@ var _ = Describe(
 	Label(tsparams.LabelEndToEndUpgrade), func() {
 
 		var (
-			newIbguBuilder *ibgu.IbguBuilder
-			clusterList    []*clients.Settings
+			clusterList []*clients.Settings
 		)
 
 		BeforeAll(func() {
@@ -52,6 +51,13 @@ var _ = Describe(
 
 		AfterAll(func() {
 			By("Deleting upgrade ibgu created on target hub cluster", func() {
+				newIbguBuilder := ibgu.NewIbguBuilder(cnfinittools.TargetHubAPIClient,
+					tsparams.IbguName, tsparams.IbguNamespace).
+					WithClusterLabelSelectors(tsparams.ClusterLabelSelector).
+					WithSeedImageRef(cnfinittools.CNFConfig.IbguSeedImage, cnfinittools.CNFConfig.IbguSeedImageVersion).
+					WithOadpContent(cnfinittools.CNFConfig.IbguOadpCmName, cnfinittools.CNFConfig.IbguOadpCmNamespace).
+					WithPlan([]string{"Prep", "Upgrade"}, 5, 30)
+
 				_, err := newIbguBuilder.DeleteAndWait(1 * time.Minute)
 				Expect(err).ToNot(HaveOccurred(), "Failed to delete prep-upgrade ibgu on target hub cluster")
 


### PR DESCRIPTION
Currently the step is failing with

```
16:17:02    END STEP: Deleting upgrade ibgu created on target hub cluster - /home/testuser/tests/lca/imagebasedupgrade/cnf/upgrade-talm/tests/e2e-upgrade-test.go:54 @ 10/15/24 13:16:55.544 (0s)
16:17:02    [FAILED] Failed to delete prep-upgrade ibgu on target hub cluster
16:17:02    Unexpected error:
16:17:02        <*errors.errorString | 0xc001013240>: 
16:17:02        error: received nil ibgu builder
16:17:02        {
16:17:02            s: "error: received nil ibgu builder",
16:17:02        }
16:17:02    occurred
16:17:02    In [AfterAll] at: /home/testuser/tests/lca/imagebasedupgrade/cnf/upgrade-talm/tests/e2e-upgrade-test.go:56 @ 10/15/24 13:16:55.544
16:17:02    < Exit [AfterAll] Performing happy path image based upgrade - /home/testuser/tests/lca/imagebasedupgrade/cnf/upgrade-talm/tests/e2e-upgrade-test.go:53 @ 10/15/24 13:16:55.544 (0s)
16:17:02  • [FAILED] [5.127 seconds]
```