### PR TITLE
cnf ran: Add siteconfig operator failover tests

### DIFF
--- a/tests/cnf/ran/gitopsztp/internal/tsparams/consts.go
+++ b/tests/cnf/ran/gitopsztp/internal/tsparams/consts.go
@@ -27,6 +27,8 @@ const (
 	LabelSpokeCheckerTests = "ztp-spoke-checker"
 	// LabelClusterInstanceDeleteTestCases is the label for the siteconfig operator's cluster instance delete test cases.
 	LabelClusterInstanceDeleteTestCases = "ztp-cluster-instance-delete"
+	// LabelSiteconfigFailoverTestCases is the label for the siteconfig operator's failover test cases.
+	LabelSiteconfigFailoverTestCases = "ztp-siteconfig-failover"
 
 	// LabelBiosDayZeroTests is the label for a particuarl set of test cases.
 	LabelBiosDayZeroTests = "ztp-bios-day-zero"
@@ -90,6 +92,10 @@ const (
 	ZtpTestPathDetachAIMNO = "ztp-test/siteconfig-operator/detach-ai-mno"
 	// ZtpTestPathDetachAISNO is the git path for the siteconfig operator detach AI SNO cluster instance test.
 	ZtpTestPathDetachAISNO = "ztp-test/siteconfig-operator/detach-ai-sno"
+	// ZtpTestPathNoClusterTemplateCm is the git path for the siteconfig operator non-existent cluster template cm test.
+	ZtpTestPathNoClusterTemplateCm = "ztp-test/siteconfig-operator/non-existent-cluster-template-cm"
+	// ZtpTestPathNoExtraManifestsCm is the git path for the siteconfig operator non-existent extra manifests cm test.
+	ZtpTestPathNoExtraManifestsCm = "ztp-test/siteconfig-operator/non-existent-extra-manifests-cm"
 	// ZtpKustomizationPath is the path to the kustomization file in the ztp test.
 	ZtpKustomizationPath = "/kustomization.yaml"
 
@@ -136,6 +142,17 @@ const (
 	DefaultAINodeTemplatesConfigMapName = "ai-node-templates-v1"
 	// SiteconfigOperatorPodLabel is the name of siteconfig operator pod label selector.
 	SiteconfigOperatorPodLabel = "app.kubernetes.io/name=siteconfig-controller"
+
+	// ClusterInstanceValidatedType is one of the type of ClusterInstance condition types.
+	ClusterInstanceValidatedType = "ClusterInstanceValidated"
+	// ClusterInstanceFailReason is the reason for a failure of all ClusterInstance condition types.
+	ClusterInstanceFailReason = "Failed"
+	// NonExistentExtraManifestConfigMapFailMessage is the message for ClusterInstanceValidated condition type.
+	NonExistentExtraManifestConfigMapFailMessage = "Validation failed: failed to retrieve ExtraManifest"
+	// NonExistentClusterTemplateConfigMapFailMessage is the message for ClusterInstanceValidated condition type.
+	NonExistentClusterTemplateConfigMapFailMessage = "Validation failed: failed to validate cluster-level TemplateRef"
+	// SiteconfigOperatorDefaultReconcileTime is the default time for siteconfig controller to reconcile.
+	SiteconfigOperatorDefaultReconcileTime = 5 * time.Minute
 
 	// LogLevel is the verbosity of glog statements in this test suite.
 	LogLevel glog.Level = 90

--- a/tests/cnf/ran/gitopsztp/internal/tsparams/ztpvars.go
+++ b/tests/cnf/ran/gitopsztp/internal/tsparams/ztpvars.go
@@ -11,6 +11,7 @@ import (
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 	placementrulev1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1"
@@ -79,5 +80,23 @@ var (
 		"image-registry-policy-pvc",
 		"image-registry-policy-pv",
 		"image-registry-policy-config",
+	}
+
+	// CINonExistentExtraManifestConfigMapCondition is the condition when referencing non-existent.
+	// extra-manifest config map in ClusterInstance CR.
+	CINonExistentExtraManifestConfigMapCondition = metav1.Condition{
+		Type:    ClusterInstanceValidatedType,
+		Status:  metav1.ConditionFalse,
+		Message: NonExistentExtraManifestConfigMapFailMessage,
+		Reason:  ClusterInstanceFailReason,
+	}
+
+	// CINonExistentClusterTemplateConfigMapCondition is the condition when referencing non-existent.
+	// cluster templates config map in ClusterInstance CR.
+	CINonExistentClusterTemplateConfigMapCondition = metav1.Condition{
+		Type:    ClusterInstanceValidatedType,
+		Status:  metav1.ConditionFalse,
+		Message: NonExistentClusterTemplateConfigMapFailMessage,
+		Reason:  ClusterInstanceFailReason,
 	}
 )

--- a/tests/cnf/ran/gitopsztp/tests/ztp-siteconfig-failover.go
+++ b/tests/cnf/ran/gitopsztp/tests/ztp-siteconfig-failover.go
@@ -1,0 +1,91 @@
+package tests
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
+	"github.com/openshift-kni/eco-goinfra/pkg/siteconfig"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/gitopsztp/internal/gitdetails"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/gitopsztp/internal/tsparams"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/version"
+
+	. "github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/raninittools"
+)
+
+var _ = Describe("ZTP Siteconfig Operator's Failover Tests",
+	Label(tsparams.LabelSiteconfigFailoverTestCases), func() {
+		// These tests use the hub and spoke architecture.
+		BeforeEach(func() {
+			By("verifying that ZTP meets the minimum version")
+			versionInRange, err := version.IsVersionStringInRange(RANConfig.ZTPVersion, "4.17", "")
+			Expect(err).ToNot(HaveOccurred(), "Failed to compare ZTP version string")
+
+			if !versionInRange {
+				Skip("ZTP Siteconfig operator tests require ZTP 4.17 or later")
+			}
+
+		})
+
+		AfterEach(func() {
+			By("resetting the clusters app back to the original settings")
+			err := gitdetails.SetGitDetailsInArgoCd(
+				tsparams.ArgoCdClustersAppName, tsparams.ArgoCdAppDetails[tsparams.ArgoCdClustersAppName],
+				true, false)
+			Expect(err).ToNot(HaveOccurred(), "Failed to reset clusters app git details")
+		})
+
+		// 75382 - Validate recovery mechanism by referencing non-existent cluster template configmap custom resource.
+		It("Verify siteconfig operator’s recovery mechanism by referencing non-existent cluster template configmap CR",
+			reportxml.ID("75382"), func() {
+
+				// Test step 1-Update the ztp-test git path to reference non-existent cluster template configmap.
+				// in clusterinstance.yaml.
+				By("updating the Argo CD clusters app with the non-existent cluster template configmap reference git path")
+				exists, err := gitdetails.UpdateArgoCdAppGitPath(tsparams.ArgoCdClustersAppName,
+					tsparams.ZtpTestPathNoClusterTemplateCm, true)
+				if !exists {
+					Skip(err.Error())
+				}
+
+				Expect(err).ToNot(HaveOccurred(), "Failed to update Argo CD clusters app with new git path")
+
+				// Test step 1 expected result validation.
+				By("checking cluster instance CR reporting validation failed with correct error message")
+				clusterInstance, err := siteconfig.PullClusterInstance(HubAPIClient, RANConfig.Spoke1Name, RANConfig.Spoke1Name)
+				Expect(err).ToNot(HaveOccurred(), "Failed to find cluster instance custom resource on hub")
+
+				// Test step 1.b expected result validation.
+				// i.e. to check the proper message: 'Validation failed: .
+				// failed to validate cluster-level TemplateRef'.
+				_, err = clusterInstance.WaitForCondition(tsparams.CINonExistentClusterTemplateConfigMapCondition,
+					tsparams.SiteconfigOperatorDefaultReconcileTime)
+				Expect(err).ToNot(HaveOccurred(), "Cluster instance failed to report an expected error message")
+			})
+
+		// 75383 - Validate recovery mechanism by referencing non-existent extra manifests configmap custom resource.
+		It("Verify siteconfig operator’s recovery mechanism by referencing non-existent extra manifests configmap CR",
+			reportxml.ID("75383"), func() {
+
+				// Test step 1-Update the ztp-test git path to reference non-existent extra manifests configmap.
+				// in clusterinstance.yaml.
+				By("updating the Argo CD clusters app with the non-existent extra manifests configmap reference git path")
+				exists, err := gitdetails.UpdateArgoCdAppGitPath(tsparams.ArgoCdClustersAppName,
+					tsparams.ZtpTestPathNoExtraManifestsCm, true)
+				if !exists {
+					Skip(err.Error())
+				}
+
+				Expect(err).ToNot(HaveOccurred(), "Failed to update Argo CD clusters app with new git path")
+
+				// Test step 1 expected result validation.
+				By("checking cluster instance CR reporting validation failed with correct error message")
+				clusterInstance, err := siteconfig.PullClusterInstance(HubAPIClient, RANConfig.Spoke1Name, RANConfig.Spoke1Name)
+				Expect(err).ToNot(HaveOccurred(), "Failed to find cluster instance custom resource on hub")
+
+				// Test step 1.b expected result validation.
+				// i.e. to check the proper message: 'Validation failed: failed to retrieve ExtraManifest'.
+				_, err = clusterInstance.WaitForCondition(tsparams.CINonExistentExtraManifestConfigMapCondition,
+					tsparams.SiteconfigOperatorDefaultReconcileTime)
+				Expect(err).ToNot(HaveOccurred(), "Cluster instance failed to report an expected error message")
+			})
+	})


### PR DESCRIPTION
Hello @klaskosk , @dgonyier , @josclark42.
Please help to review this PR when you have a time. Thanks!

Adding siteconfig operator failover test cases

[OCP-75382](https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-75382)

[OCP-75383](https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-75383)

Manual Test Logs:
https://docs.google.com/document/d/1mX-Pbs7affHaD3qGeuy4nHr5ppPoFH1F-laRAO9nchU/edit?usp=sharing