### PR TITLE
cnf ran: Add siteconfig operator negative tests

### DIFF
--- a/tests/cnf/ran/gitopsztp/internal/tsparams/consts.go
+++ b/tests/cnf/ran/gitopsztp/internal/tsparams/consts.go
@@ -29,6 +29,8 @@ const (
 	LabelClusterInstanceDeleteTestCases = "ztp-cluster-instance-delete"
 	// LabelSiteconfigFailoverTestCases is the label for the siteconfig operator's failover test cases.
 	LabelSiteconfigFailoverTestCases = "ztp-siteconfig-failover"
+	// LabelSiteconfigNegativeTestCases is the label for the siteconfig operator's negative test cases.
+	LabelSiteconfigNegativeTestCases = "ztp-siteconfig-negative"
 
 	// LabelBiosDayZeroTests is the label for a particuarl set of test cases.
 	LabelBiosDayZeroTests = "ztp-bios-day-zero"
@@ -96,6 +98,14 @@ const (
 	ZtpTestPathNoClusterTemplateCm = "ztp-test/siteconfig-operator/non-existent-cluster-template-cm"
 	// ZtpTestPathNoExtraManifestsCm is the git path for the siteconfig operator non-existent extra manifests cm test.
 	ZtpTestPathNoExtraManifestsCm = "ztp-test/siteconfig-operator/non-existent-extra-manifests-cm"
+	// ZtpTestPathInvalidTemplateRef is the git path for the siteconfig operator invalid template reference test.
+	ZtpTestPathInvalidTemplateRef = "ztp-test/siteconfig-operator/invalid-template-ref"
+	// ZtpTestPathValidTemplateRef is the git path for the siteconfig operator valid template reference test.
+	ZtpTestPathValidTemplateRef = "ztp-test/siteconfig-operator/valid-template-ref"
+	// ZtpTestPathUniqueClusterName is the git path for the siteconfig operator unique cluster name test.
+	ZtpTestPathUniqueClusterName = "ztp-test/siteconfig-operator/unique-cluster-name"
+	// ZtpTestPathDuplicateClusterName is the git path for the siteconfig operator duplicate cluster name test.
+	ZtpTestPathDuplicateClusterName = "ztp-test/siteconfig-operator/duplicate-cluster-name"
 	// ZtpKustomizationPath is the path to the kustomization file in the ztp test.
 	ZtpKustomizationPath = "/kustomization.yaml"
 
@@ -145,12 +155,24 @@ const (
 
 	// ClusterInstanceValidatedType is one of the type of ClusterInstance condition types.
 	ClusterInstanceValidatedType = "ClusterInstanceValidated"
+	// ProvisionedType is one of the type of ClusterInstance condition types.
+	ProvisionedType = "Provisioned"
+	// RenderedTemplatesValidatedType is one of the type of ClusterInstance condition types.
+	RenderedTemplatesValidatedType = "RenderedTemplatesValidated"
 	// ClusterInstanceFailReason is the reason for a failure of all ClusterInstance condition types.
 	ClusterInstanceFailReason = "Failed"
+	// ClusterInstanceInProgressReason is the reason for in-progress cluster provisioning.
+	ClusterInstanceInProgressReason = "InProgress"
 	// NonExistentExtraManifestConfigMapFailMessage is the message for ClusterInstanceValidated condition type.
 	NonExistentExtraManifestConfigMapFailMessage = "Validation failed: failed to retrieve ExtraManifest"
 	// NonExistentClusterTemplateConfigMapFailMessage is the message for ClusterInstanceValidated condition type.
 	NonExistentClusterTemplateConfigMapFailMessage = "Validation failed: failed to validate cluster-level TemplateRef"
+	// InvalidTemplateRefFailMessage is the message for invalid template reference condition.
+	InvalidTemplateRefFailMessage = "Validation failed: failed to validate node-level TemplateRef"
+	// ValidTemplateRefSuccessMessage is the message for valid template reference condition.
+	ValidTemplateRefSuccessMessage = "Provisioning cluster"
+	// RenderedManifestsFailMessage is the message for rendered manifests dry-run validation failure.
+	RenderedManifestsFailMessage = "Rendered manifests failed dry-run validation"
 	// SiteconfigOperatorDefaultReconcileTime is the default time for siteconfig controller to reconcile.
 	SiteconfigOperatorDefaultReconcileTime = 5 * time.Minute
 

--- a/tests/cnf/ran/gitopsztp/internal/tsparams/ztpvars.go
+++ b/tests/cnf/ran/gitopsztp/internal/tsparams/ztpvars.go
@@ -99,4 +99,31 @@ var (
 		Message: NonExistentClusterTemplateConfigMapFailMessage,
 		Reason:  ClusterInstanceFailReason,
 	}
+
+	// CIInvalidTemplateRefCondition is the condition when referencing invalid.
+	// node level template in ClusterInstance CR.
+	CIInvalidTemplateRefCondition = metav1.Condition{
+		Type:    ClusterInstanceValidatedType,
+		Status:  metav1.ConditionFalse,
+		Message: InvalidTemplateRefFailMessage,
+		Reason:  ClusterInstanceFailReason,
+	}
+
+	// CIValidTemplateRefCondition is the condition when referencing valid.
+	// cluster & node level template in ClusterInstance CR.
+	CIValidTemplateRefCondition = metav1.Condition{
+		Type:    ProvisionedType,
+		Status:  metav1.ConditionFalse,
+		Message: ValidTemplateRefSuccessMessage,
+		Reason:  ClusterInstanceInProgressReason,
+	}
+
+	// CIDuplicateClusterNameCondition is the condition when referencing duplicate.
+	// cluster name in ClusterInstance CR.
+	CIDuplicateClusterNameCondition = metav1.Condition{
+		Type:    RenderedTemplatesValidatedType,
+		Status:  metav1.ConditionFalse,
+		Message: RenderedManifestsFailMessage,
+		Reason:  ClusterInstanceFailReason,
+	}
 )

--- a/tests/cnf/ran/gitopsztp/tests/ztp-siteconfig-negative.go
+++ b/tests/cnf/ran/gitopsztp/tests/ztp-siteconfig-negative.go
@@ -1,0 +1,150 @@
+package tests
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/openshift-kni/eco-goinfra/pkg/siteconfig"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/gitopsztp/internal/gitdetails"
+
+	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/gitopsztp/internal/tsparams"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/version"
+
+	. "github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/raninittools"
+)
+
+var _ = Describe("ZTP Siteconfig Operator's Negative Tests",
+	Label(tsparams.LabelSiteconfigNegativeTestCases), func() {
+		// These tests use the hub and spoke architecture.
+		BeforeEach(func() {
+			By("verifying that ZTP meets the minimum version")
+			versionInRange, err := version.IsVersionStringInRange(RANConfig.ZTPVersion, "4.17", "")
+			Expect(err).ToNot(HaveOccurred(), "Failed to compare ZTP version string")
+
+			if !versionInRange {
+				Skip("ZTP Siteconfig operator tests require ZTP 4.17 or later")
+			}
+
+		})
+
+		AfterEach(func() {
+			By("resetting the clusters app back to the original settings")
+			err := gitdetails.SetGitDetailsInArgoCd(
+				tsparams.ArgoCdClustersAppName, tsparams.ArgoCdAppDetails[tsparams.ArgoCdClustersAppName],
+				true, false)
+			Expect(err).ToNot(HaveOccurred(), "Failed to reset clusters app git details")
+		})
+
+		// 75378 - Validate erroneous/invalid ClusterInstance CR does not block other ClusterInstance CR handling.
+		It("Verify erroneous/invalid ClusterInstance CR does not block other ClusterInstance CR handling",
+			reportxml.ID("75378"), func() {
+
+				// Deploy a first ClusterInstance CR with invalid template reference(i.e.invalid ClusterInstance CR).
+				// Test step-1: Update the ztp-test git path to reference invalid node template configmap.
+				// in kind:ClusterInstance to make ClusterInstance CR invalid.
+				By("updating the Argo CD clusters app with invalid template reference git path")
+				exists, err := gitdetails.UpdateArgoCdAppGitPath(tsparams.ArgoCdClustersAppName,
+					tsparams.ZtpTestPathInvalidTemplateRef, true)
+				if !exists {
+					Skip(err.Error())
+				}
+
+				Expect(err).ToNot(HaveOccurred(), "Failed to update Argo CD clusters app with new git path")
+
+				// Make sure that first ClusterInstance CR should show ClusterInstanceValidated false.
+				// Test step 1.a expected result validation.
+				By("checking cluster instance1 CR reporting validation failed with correct error message")
+				clusterInstance1, err := siteconfig.PullClusterInstance(HubAPIClient, RANConfig.Spoke1Name, RANConfig.Spoke1Name)
+				Expect(err).ToNot(HaveOccurred(), "Failed to find cluster instance1 custom resource on hub")
+
+				// Test step 1.b expected result validation.
+				// i.e. to check the proper message: 'Validation failed: .
+				// failed to validate node-level TemplateRef'.
+				_, err = clusterInstance1.WaitForCondition(tsparams.CIInvalidTemplateRefCondition,
+					tsparams.SiteconfigOperatorDefaultReconcileTime)
+				Expect(err).ToNot(HaveOccurred(), "cluster instance1 failed to report an expected error message")
+
+				// Deploy a second ClusterInstance CR with template reference which is valid.
+				// Test step-2: Update the ztp-test git path to reference valid cluster & node.
+				// template configmap in kind:ClusterInstance to make ClusterInstance CR valid.
+				By("updating the Argo CD clusters app with valid template reference git path")
+				exists, err = gitdetails.UpdateArgoCdAppGitPath(tsparams.ArgoCdClustersAppName,
+					tsparams.ZtpTestPathValidTemplateRef, true)
+				if !exists {
+					Skip(err.Error())
+				}
+
+				Expect(err).ToNot(HaveOccurred(), "Failed to update Argo CD clusters app with new git path")
+
+				// Make sure that second ClusterInstance CR should proceed to provisioning the spoke cluster.
+				// Test step 2.a expected result validation.
+				By("checking cluster instance2 CR reporting correct message and reason")
+				clusterInstance2, err := siteconfig.PullClusterInstance(HubAPIClient, RANConfig.Spoke2Name, RANConfig.Spoke2Name)
+				Expect(err).ToNot(HaveOccurred(), "Failed to find cluster instance2 custom resource on hub")
+
+				// Test step 2.b expected result validation.
+				// I.e. ClusterInstance2 reporting message: Provisioning cluster.
+				// with reason: InProgress.
+				_, err = clusterInstance2.WaitForCondition(tsparams.CIValidTemplateRefCondition,
+					tsparams.SiteconfigOperatorDefaultReconcileTime)
+				Expect(err).ToNot(HaveOccurred(), "cluster instance2 failed to report an expected message and reason")
+			})
+
+		// 75379 - Validate two ClusterInstance CR with duplicate cluster name.
+		It("Verify two ClusterInstance CR with duplicate cluster name",
+			reportxml.ID("75379"), func() {
+
+				// Deploy a first ClusterInstance CR named "site-plan-A" with valid template reference.
+				// and field clusterName: "clusterA".
+				// Test step-1: Update the ztp-test git path to reference valid template.
+				// in kind:ClusterInstance with field clusterName: "clusterA".
+				By("updating the Argo CD clusters app with unique cluster name git path")
+				exists, err := gitdetails.UpdateArgoCdAppGitPath(tsparams.ArgoCdClustersAppName,
+					tsparams.ZtpTestPathUniqueClusterName, true)
+				if !exists {
+					Skip(err.Error())
+				}
+
+				Expect(err).ToNot(HaveOccurred(), "Failed to update Argo CD clusters app with new git path")
+
+				// Make sure that first ClusterInstance CR should proceed to provisioning the spoke cluster.
+				// Test step 1.a expected result validation.
+				By("checking cluster instance1 CR reporting correct message and reason")
+				clusterInstance1, err := siteconfig.PullClusterInstance(HubAPIClient, RANConfig.Spoke1Name, RANConfig.Spoke1Name)
+				Expect(err).ToNot(HaveOccurred(), "Failed to find cluster instance1 custom resource on hub")
+
+				// Test step 1.b expected result validation.
+				// I.e. ClusterInstance1 should report a message: Provisioning cluster.
+				// with reason: InProgress.
+				_, err = clusterInstance1.WaitForCondition(tsparams.CIValidTemplateRefCondition,
+					tsparams.SiteconfigOperatorDefaultReconcileTime)
+				Expect(err).ToNot(HaveOccurred(), "cluster instance1 failed to report an expected message and reason")
+
+				// Deploy a second ClusterInstance CR named "site-plan-B" with valid template reference.
+				// and field clusterName: "value" (=>clusterA) should be same as first ClusterInstance CR.
+				// Test step-2: Update the ztp-test git path to reference valid template.
+				// in kind:ClusterInstance with field clusterName: "clusterA" (duplicate).
+				By("updating the Argo CD clusters app with duplicate cluster name git path")
+				exists, err = gitdetails.UpdateArgoCdAppGitPath(tsparams.ArgoCdClustersAppName,
+					tsparams.ZtpTestPathDuplicateClusterName, true)
+				if !exists {
+					Skip(err.Error())
+				}
+
+				Expect(err).ToNot(HaveOccurred(), "Failed to update Argo CD clusters app with new git path")
+
+				// Make sure that second ClusterInstance(with duplicated clusterName) would fail the dry-run validation.
+				// and reports a message: Rendered manifests failed dry-run validation.
+				// Test step 2.a expected result validation.
+				By("checking cluster instance2 CR reporting correct error message")
+				clusterInstance2, err := siteconfig.PullClusterInstance(HubAPIClient, RANConfig.Spoke2Name, RANConfig.Spoke2Name)
+				Expect(err).ToNot(HaveOccurred(), "Failed to find cluster instance2 custom resource on hub")
+
+				// Test step 2.b expected result validation.
+				// I.e. ClusterInstance2 reporting a message: Rendered manifests failed dry-run validation
+				// with reason: Failed.
+				_, err = clusterInstance2.WaitForCondition(tsparams.CIDuplicateClusterNameCondition,
+					tsparams.SiteconfigOperatorDefaultReconcileTime)
+				Expect(err).ToNot(HaveOccurred(), "cluster instance2 failed to report an expected error message")
+			})
+	})


### PR DESCRIPTION
Hello @klaskosk , @dgonyier , @josclark42.
Please help to review this PR when you have a time. Thanks!

Adding siteconfig operator negative test cases

[OCP-75378](https://polarion.engineering.redhat.com/polarion/redirect/project/OSE/workitem?id=OCP-75378)

[OCP-75379](https://polarion.engineering.redhat.com/polarion/redirect/project/OSE/workitem?id=OCP-75379)

Manual Test Logs:
[1]
https://docs.google.com/document/d/1goaT3l0-tPacJQN46xVyw68g2PtlkuTPVaEIoVHCVVA/edit?usp=sharing
[2]
https://docs.google.com/document/d/11-LXu9Krf-4UczKBmh_9vN1fKqNr74l8s4WFD3M7tCc/edit?usp=sharing
