### PR TITLE
rhwa: DAST test on FAR operator

### DIFF
--- a/tests/rhwa/far-operator/tests/far.go
+++ b/tests/rhwa/far-operator/tests/far.go
@@ -2,10 +2,8 @@ package tests
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -20,7 +18,6 @@ import (
 	"github.com/openshift-kni/eco-gotests/tests/rhwa/internal/rhwaparams"
 
 	"github.com/golang/glog"
-	"gopkg.in/yaml.v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -102,44 +99,3 @@ var _ = Describe(
 				"Trivy scan report contains High severity vulnerabilities")
 		})
 	})
-
-func prepareRapidastConfig(destinationPath string) error {
-
-	workingDir, err := os.Getwd()
-	Expect(err).ToNot(HaveOccurred(), err)
-
-	templateDir := filepath.Join(workingDir, rhwaparams.RapidastTemplateFolder)
-	rapidastConfigFile := filepath.Join(templateDir, rhwaparams.RapidastTemplateFile)
-
-	f, err := os.Open(rapidastConfigFile)
-	Expect(err).NotTo((HaveOccurred()))
-	defer f.Close()
-
-	content, err := io.ReadAll(f)
-	Expect(err).NotTo((HaveOccurred()))
-
-	yamlData := make(map[string]interface{})
-	err = yaml.Unmarshal(content, &yamlData)
-	Expect(err).NotTo((HaveOccurred()))
-
-	sc := yamlData["scanners"].(map[string]interface{})
-	genericTrivy := sc["generic_trivy"].(map[string]interface{})
-	genericTrivy["inline"] = fmt.Sprintf("trivy k8s --kubeconfig=/home/rapidast/.kube/config -n %s pod --severity=HIGH,CRITICAL --scanners=misconfig --report all --format json",
-		rhwaparams.RhwaOperatorNs)
-
-	modifiedYaml, err := yaml.Marshal(yamlData)
-	Expect(err).NotTo((HaveOccurred()))
-
-	filePath := filepath.Join(destinationPath, rhwaparams.RapidastTemplateFile)
-	rapidastConfig, err := os.Create(filePath)
-	Expect(err).NotTo((HaveOccurred()))
-	defer rapidastConfig.Close()
-
-	_, err = rapidastConfig.Write(modifiedYaml)
-	Expect(err).NotTo((HaveOccurred()))
-
-	err = rapidastConfig.Close()
-	Expect(err).NotTo((HaveOccurred()))
-
-	return nil
-}

--- a/tests/rhwa/far-operator/tests/far.go
+++ b/tests/rhwa/far-operator/tests/far.go
@@ -51,11 +51,12 @@ var _ = Describe(
 			Expect(err).ToNot(HaveOccurred(), "Pod is not ready")
 		})
 
-		It("Verify Fence Agents Remediation Operator passes trivy scan without vulnerabilities", reportxml.ID("76877"), func() {
+		It("Verify FAR Operator passes trivy scan without vulnerabilities", reportxml.ID("76877"), func() {
 
 			By("Creating temp directory")
 			dirname, err := os.MkdirTemp("", "case76877_*")
-			os.Chmod(dirname, 0755)
+			Expect(err).NotTo(HaveOccurred())
+			err = os.Chmod(dirname, 0755)
 			Expect(err).NotTo(HaveOccurred())
 			defer os.RemoveAll(dirname)
 
@@ -83,7 +84,11 @@ var _ = Describe(
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Creating podman command")
-			rapiDastCmd := fmt.Sprintf("podman run -it --rm -v %s:/home/rapidast/.kube/config:Z -v %s:/test:Z -v %s:/opt/rapidast/results:Z %s rapidast.py --config /test/%s",
+			rapiDastCmd := fmt.Sprintf("podman run -it --rm "+
+				"-v %s:/home/rapidast/.kube/config:Z "+
+				"-v %s:/test:Z "+
+				"-v %s:/opt/rapidast/results:Z "+
+				"%s rapidast.py --config /test/%s",
 				kubeconfigPath,
 				dirname,
 				resultsDirname,
@@ -92,7 +97,7 @@ var _ = Describe(
 			)
 			By("Running podman command")
 			rapiDastOutput, err := exec.Command("bash", "-c", rapiDastCmd).Output()
-			Expect(err).NotTo(HaveOccurred(), "Error occured during execution of RapiDast test")
+			Expect(err).NotTo(HaveOccurred(), "Error occurred during execution of RapiDast test")
 			glog.V(rhwaparams.RhwaLogLevel).Infof("RapiDast test execution output is %s\n", rapiDastOutput)
 
 			By("Checking output of trivy scan")

--- a/tests/rhwa/far-operator/tests/far.go
+++ b/tests/rhwa/far-operator/tests/far.go
@@ -2,6 +2,11 @@ package tests
 
 import (
 	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -14,6 +19,8 @@ import (
 	. "github.com/openshift-kni/eco-gotests/tests/rhwa/internal/rhwainittools"
 	"github.com/openshift-kni/eco-gotests/tests/rhwa/internal/rhwaparams"
 
+	"github.com/golang/glog"
+	"gopkg.in/yaml.v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -44,4 +51,97 @@ var _ = Describe(
 			)
 			Expect(err).ToNot(HaveOccurred(), "Pod is not ready")
 		})
+
+		It("Verify Fence Agents Remediation Operator passes trivy scan without vulnerabilities found", reportxml.ID("76877"), func() {
+
+			By("Creating temp directory")
+			dirname, err := os.MkdirTemp("", "case76877_*")
+			os.Chmod(dirname, 0755)
+			Expect(err).NotTo(HaveOccurred())
+			defer os.RemoveAll(dirname)
+
+			By("Creating rapidast configuration")
+			err = prepareRapidastConfig(dirname)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating rapidast output folder")
+			resultsDirname := fmt.Sprintf("%s/results", dirname)
+			err = os.MkdirAll(resultsDirname, 0755)
+			Expect(err).NotTo(HaveOccurred())
+			defer os.RemoveAll(resultsDirname)
+
+			defer func() {
+				command := fmt.Sprintf("sudo chown $USER -R %s", resultsDirname)
+				_, permErrResultsDir := exec.Command("bash", "-c", command).Output()
+				if permErrResultsDir != nil {
+					glog.V(rhwaparams.RhwaLogLevel).Infof("Error %s occurred restoring of permission for results directory", resultsDirname)
+				}
+			}()
+			command := fmt.Sprintf("podman unshare chown 1000 %s", resultsDirname)
+			_, permErrResultsDir := exec.Command("bash", "-c", command).Output()
+			Expect(permErrResultsDir).To(BeNil(), "Error occurred updating permission for results directory")
+
+			By("Getting KUBECONFIG env variable for trivy")
+			kubeconfigPath := os.Getenv("KUBECONFIG")
+			Expect(kubeconfigPath).NotTo(BeNil())
+
+			By("Creating podman command")
+			rapiDastCmd := fmt.Sprintf("podman run -it --rm -v %s:/home/rapidast/.kube/config:Z -v %s:/test:Z -v %s:/opt/rapidast/results:Z quay.io/redhatproductsecurity/rapidast:2.7.0 rapidast.py --config /test/%s",
+				kubeconfigPath,
+				dirname,
+				resultsDirname,
+				rhwaparams.RapidastTemplateFile,
+			)
+			By("Running podman command")
+			rapiDastOutput, err := exec.Command("bash", "-c", rapiDastCmd).Output()
+			Expect(err).NotTo(HaveOccurred(), "Error occured during execution of RapiDast test")
+			glog.V(rhwaparams.RhwaLogLevel).Infof("RapiDast test execution output is %s\n", rapiDastOutput)
+
+			// Check if vulnerabilities have been detected by trivy
+			if !strings.Contains(string(rapiDastOutput), `"Severity": "HIGH"`) {
+				glog.V(rhwaparams.RhwaLogLevel).Infof("Trivy scan has been executed successfully, no issues detected")
+			} else {
+				glog.V(rhwaparams.RhwaLogLevel).Infof("Check trivy scan result and see if any vulnerabilities has been detected")
+			}
+		})
 	})
+
+func prepareRapidastConfig(destinationPath string) error {
+
+	workingDir, err := os.Getwd()
+	Expect(err).ToNot(HaveOccurred(), err)
+
+	templateDir := filepath.Join(workingDir, rhwaparams.RapidastTemplateFolder)
+	rapidastConfigFile := filepath.Join(templateDir, rhwaparams.RapidastTemplateFile)
+
+	f, err := os.Open(rapidastConfigFile)
+	Expect(err).NotTo((HaveOccurred()))
+	defer f.Close()
+
+	content, err := io.ReadAll(f)
+	Expect(err).NotTo((HaveOccurred()))
+
+	yamlData := make(map[string]interface{})
+	err = yaml.Unmarshal(content, &yamlData)
+	Expect(err).NotTo((HaveOccurred()))
+
+	sc := yamlData["scanners"].(map[string]interface{})
+	genericTrivy := sc["generic_trivy"].(map[string]interface{})
+	genericTrivy["inline"] = fmt.Sprintf("trivy k8s --kubeconfig=/home/rapidast/.kube/config -n %s pod --severity=HIGH,CRITICAL --scanners=misconfig --report all --format json", rhwaparams.RhwaOperatorNs)
+
+	modifiedYaml, err := yaml.Marshal(yamlData)
+	Expect(err).NotTo((HaveOccurred()))
+
+	filePath := filepath.Join(destinationPath, rhwaparams.RapidastTemplateFile)
+	rapidastConfig, err := os.Create(filePath)
+	Expect(err).NotTo((HaveOccurred()))
+	defer rapidastConfig.Close()
+
+	_, err = rapidastConfig.Write(modifiedYaml)
+	Expect(err).NotTo((HaveOccurred()))
+
+	err = rapidastConfig.Close()
+	Expect(err).NotTo((HaveOccurred()))
+
+	return nil
+}

--- a/tests/rhwa/far-operator/tests/far.go
+++ b/tests/rhwa/far-operator/tests/far.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
 
 	"github.com/openshift-kni/eco-gotests/tests/rhwa/far-operator/internal/farparams"
+	"github.com/openshift-kni/eco-gotests/tests/rhwa/internal/dast"
 	. "github.com/openshift-kni/eco-gotests/tests/rhwa/internal/rhwainittools"
 	"github.com/openshift-kni/eco-gotests/tests/rhwa/internal/rhwaparams"
 
@@ -78,7 +79,7 @@ var _ = Describe(
 			Expect(kubeconfigPath).NotTo(BeNil())
 
 			By("Creating rapidast configuration")
-			err = prepareRapidastConfig(dirname)
+			err = dast.PrepareRapidastConfig(dirname)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Creating podman command")

--- a/tests/rhwa/far-operator/tests/far.go
+++ b/tests/rhwa/far-operator/tests/far.go
@@ -38,6 +38,7 @@ var _ = Describe(
 			By("Verify FAR deployment is Ready")
 			Expect(farDeployment.IsReady(rhwaparams.DefaultTimeout)).To(BeTrue(), "FAR deployment is not Ready")
 		})
+
 		It("Verify Fence Agents Remediation Operator pod is running", reportxml.ID("66026"), func() {
 
 			listOptions := metav1.ListOptions{
@@ -52,17 +53,13 @@ var _ = Describe(
 			Expect(err).ToNot(HaveOccurred(), "Pod is not ready")
 		})
 
-		It("Verify Fence Agents Remediation Operator passes trivy scan without vulnerabilities found", reportxml.ID("76877"), func() {
+		It("Verify Fence Agents Remediation Operator passes trivy scan without vulnerabilities", reportxml.ID("76877"), func() {
 
 			By("Creating temp directory")
 			dirname, err := os.MkdirTemp("", "case76877_*")
 			os.Chmod(dirname, 0755)
 			Expect(err).NotTo(HaveOccurred())
 			defer os.RemoveAll(dirname)
-
-			By("Creating rapidast configuration")
-			err = prepareRapidastConfig(dirname)
-			Expect(err).NotTo(HaveOccurred())
 
 			By("Creating rapidast output folder")
 			resultsDirname := fmt.Sprintf("%s/results", dirname)
@@ -73,9 +70,7 @@ var _ = Describe(
 			defer func() {
 				command := fmt.Sprintf("sudo chown $USER -R %s", resultsDirname)
 				_, permErrResultsDir := exec.Command("bash", "-c", command).Output()
-				if permErrResultsDir != nil {
-					glog.V(rhwaparams.RhwaLogLevel).Infof("Error %s occurred restoring of permission for results directory", resultsDirname)
-				}
+				Expect(permErrResultsDir).To(BeNil(), "Error occurred restoring of permission for results directory")
 			}()
 			command := fmt.Sprintf("podman unshare chown 1000 %s", resultsDirname)
 			_, permErrResultsDir := exec.Command("bash", "-c", command).Output()
@@ -85,11 +80,16 @@ var _ = Describe(
 			kubeconfigPath := os.Getenv("KUBECONFIG")
 			Expect(kubeconfigPath).NotTo(BeNil())
 
+			By("Creating rapidast configuration")
+			err = prepareRapidastConfig(dirname)
+			Expect(err).NotTo(HaveOccurred())
+
 			By("Creating podman command")
-			rapiDastCmd := fmt.Sprintf("podman run -it --rm -v %s:/home/rapidast/.kube/config:Z -v %s:/test:Z -v %s:/opt/rapidast/results:Z quay.io/redhatproductsecurity/rapidast:2.7.0 rapidast.py --config /test/%s",
+			rapiDastCmd := fmt.Sprintf("podman run -it --rm -v %s:/home/rapidast/.kube/config:Z -v %s:/test:Z -v %s:/opt/rapidast/results:Z %s rapidast.py --config /test/%s",
 				kubeconfigPath,
 				dirname,
 				resultsDirname,
+				rhwaparams.RapidastImage,
 				rhwaparams.RapidastTemplateFile,
 			)
 			By("Running podman command")
@@ -97,12 +97,9 @@ var _ = Describe(
 			Expect(err).NotTo(HaveOccurred(), "Error occured during execution of RapiDast test")
 			glog.V(rhwaparams.RhwaLogLevel).Infof("RapiDast test execution output is %s\n", rapiDastOutput)
 
-			// Check if vulnerabilities have been detected by trivy
-			if !strings.Contains(string(rapiDastOutput), `"Severity": "HIGH"`) {
-				glog.V(rhwaparams.RhwaLogLevel).Infof("Trivy scan has been executed successfully, no issues detected")
-			} else {
-				glog.V(rhwaparams.RhwaLogLevel).Infof("Check trivy scan result and see if any vulnerabilities has been detected")
-			}
+			By("Checking output of trivy scan")
+			Expect(strings.Contains(string(rapiDastOutput), `"Severity": "HIGH"`)).NotTo(BeTrue(),
+				"Trivy scan report contains High severity vulnerabilities")
 		})
 	})
 
@@ -127,7 +124,8 @@ func prepareRapidastConfig(destinationPath string) error {
 
 	sc := yamlData["scanners"].(map[string]interface{})
 	genericTrivy := sc["generic_trivy"].(map[string]interface{})
-	genericTrivy["inline"] = fmt.Sprintf("trivy k8s --kubeconfig=/home/rapidast/.kube/config -n %s pod --severity=HIGH,CRITICAL --scanners=misconfig --report all --format json", rhwaparams.RhwaOperatorNs)
+	genericTrivy["inline"] = fmt.Sprintf("trivy k8s --kubeconfig=/home/rapidast/.kube/config -n %s pod --severity=HIGH,CRITICAL --scanners=misconfig --report all --format json",
+		rhwaparams.RhwaOperatorNs)
 
 	modifiedYaml, err := yaml.Marshal(yamlData)
 	Expect(err).NotTo((HaveOccurred()))

--- a/tests/rhwa/internal/dast/config-files/rapidastConfig.yaml
+++ b/tests/rhwa/internal/dast/config-files/rapidastConfig.yaml
@@ -1,0 +1,46 @@
+# This is a configuration template file to perform scans using user-defined container images or scripts
+#
+# Author: Red Hat Product Security
+config:
+  # WARNING: `configVersion` indicates the schema version of the config file.
+  # This value tells RapiDAST what schema should be used to read this configuration.
+  # Therefore you should only change it if you update the configuration to a newer schema
+  # It is intended to keep backward compatibility (newer RapiDAST running an older config)
+  configVersion: 5
+# `application` contains data related to the application, not to the scans.
+application:
+  shortName: "trivy"
+# `general` is a section that will be applied to all scanners.
+general:
+  container:
+    # This configures what technology is to be used for RapiDAST to run each scanner.
+    # Currently supported: `podman`  and `none`
+    #   none: Default. RapiDAST runs each scanner in the same host or inside the RapiDAST image container
+    #   podman: RapiDAST orchestrates each scanner on its own using podman
+    # When undefined, relies on rapidast-defaults.yaml, or `none` if nothing is set
+    type: "none"
+# `scanners' is a section that configures scanning options
+scanners:
+  #generic_oobt:
+  #  #results: "/opt/rapidast/results/oobtkube.sarif.json"   # if None or "*stdout", the command's standard output is selected
+  #  # toolDir: scanners/generic/tools
+  #  inline: "python3 oobtkube.py -d 120 -p 12345 -i  10.74.16.40 -f /test/far_template.yaml -o oobtkube.sarif.json"
+  generic_trivy:
+    # results:
+    #   An absolute path to file or directory where results are stored on the host.
+    #   if it is "*stdout" or unspecified, the command's standard output will be selected
+    #   When container.type is 'podman', this needs to be used along with the container.volumes configuration below
+    #   If the result needs to be sent to DefectDojo, this must be a SARIF format file
+    #results: "/test/results/oobttest"
+    # Example: scan a k8s cluster for misconfiguration issue
+    #  - kubeconfig file for the cluster is required
+    #  - See https://aquasecurity.github.io/trivy/v0.49/docs/target/kubernetes/ for more information on 'trivy k8s' scan
+    #  - scanners/generic/tools/convert_trivy_k8s_to_sarif.py converts the Trivy json result to the SARIF format
+    # 'inline' is used when container.type is not 'podman'
+    # 'toolDir' specifies the default directory where inline scripts are located
+    #toolDir: scanners/generic/tools
+    inline: "trivy k8s --kubeconfig=/home/rapidast/.kube/config -n openshift-workload-availability pod --severity=HIGH,CRITICAL --scanners=misconfig --report all --format json"
+    container:
+      parameters:
+        # Optional: list of expected return codes, anything else will be considered as an error. by default: [0]
+        validReturns: [ 0 ]

--- a/tests/rhwa/internal/dast/dast.go
+++ b/tests/rhwa/internal/dast/dast.go
@@ -1,0 +1,53 @@
+package dast
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/gomega"
+	"github.com/openshift-kni/eco-gotests/tests/rhwa/internal/rhwaparams"
+	"gopkg.in/yaml.v3"
+)
+
+func prepareRapidastConfig(destinationPath string) error {
+
+	workingDir, err := os.Getwd()
+	Expect(err).ToNot(HaveOccurred(), err)
+
+	templateDir := filepath.Join(workingDir, rhwaparams.RapidastTemplateFolder)
+	rapidastConfigFile := filepath.Join(templateDir, rhwaparams.RapidastTemplateFile)
+
+	f, err := os.Open(rapidastConfigFile)
+	Expect(err).NotTo((HaveOccurred()))
+	defer f.Close()
+
+	content, err := io.ReadAll(f)
+	Expect(err).NotTo((HaveOccurred()))
+
+	yamlData := make(map[string]interface{})
+	err = yaml.Unmarshal(content, &yamlData)
+	Expect(err).NotTo((HaveOccurred()))
+
+	sc := yamlData["scanners"].(map[string]interface{})
+	genericTrivy := sc["generic_trivy"].(map[string]interface{})
+	genericTrivy["inline"] = fmt.Sprintf("trivy k8s --kubeconfig=/home/rapidast/.kube/config -n %s pod --severity=HIGH,CRITICAL --scanners=misconfig --report all --format json",
+		rhwaparams.RhwaOperatorNs)
+
+	modifiedYaml, err := yaml.Marshal(yamlData)
+	Expect(err).NotTo((HaveOccurred()))
+
+	filePath := filepath.Join(destinationPath, rhwaparams.RapidastTemplateFile)
+	rapidastConfig, err := os.Create(filePath)
+	Expect(err).NotTo((HaveOccurred()))
+	defer rapidastConfig.Close()
+
+	_, err = rapidastConfig.Write(modifiedYaml)
+	Expect(err).NotTo((HaveOccurred()))
+
+	err = rapidastConfig.Close()
+	Expect(err).NotTo((HaveOccurred()))
+
+	return nil
+}

--- a/tests/rhwa/internal/dast/dast.go
+++ b/tests/rhwa/internal/dast/dast.go
@@ -6,48 +6,78 @@ import (
 	"os"
 	"path/filepath"
 
-	. "github.com/onsi/gomega"
 	"github.com/openshift-kni/eco-gotests/tests/rhwa/internal/rhwaparams"
 	"gopkg.in/yaml.v3"
 )
 
+// PrepareRapidastConfig builds the trivy command and updates the rapidast configuration file.
 func PrepareRapidastConfig(destinationPath string) error {
-
 	workingDir, err := os.Getwd()
-	Expect(err).ToNot(HaveOccurred(), err)
+	if err != nil {
+		return err
+	}
 
 	templateDir := filepath.Join(workingDir, rhwaparams.RapidastTemplateFolder)
 	rapidastConfigFile := filepath.Join(templateDir, rhwaparams.RapidastTemplateFile)
 
-	f, err := os.Open(rapidastConfigFile)
-	Expect(err).NotTo((HaveOccurred()))
-	defer f.Close()
+	file, err := os.Open(rapidastConfigFile)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
 
-	content, err := io.ReadAll(f)
-	Expect(err).NotTo((HaveOccurred()))
+	content, err := io.ReadAll(file)
+	if err != nil {
+		return err
+	}
 
 	yamlData := make(map[string]interface{})
-	err = yaml.Unmarshal(content, &yamlData)
-	Expect(err).NotTo((HaveOccurred()))
 
-	sc := yamlData["scanners"].(map[string]interface{})
-	genericTrivy := sc["generic_trivy"].(map[string]interface{})
-	genericTrivy["inline"] = fmt.Sprintf("trivy k8s --kubeconfig=/home/rapidast/.kube/config -n %s pod --severity=HIGH,CRITICAL --scanners=misconfig --report all --format json",
+	err = yaml.Unmarshal(content, &yamlData)
+	if err != nil {
+		return err
+	}
+
+	sc, successful := yamlData["scanners"].(map[string]interface{})
+	if sc == nil || !successful {
+		return fmt.Errorf("yamlData is missing key \"scanners\"")
+	}
+
+	genericTrivy, successful := sc["generic_trivy"].(map[string]interface{})
+	if genericTrivy == nil || !successful {
+		return fmt.Errorf("yamlData is missing key \"generic_trivy\"")
+	}
+
+	genericTrivy["inline"] = fmt.Sprintf("trivy k8s --kubeconfig=/home/rapidast/.kube/config "+
+		"-n %s pod "+
+		"--severity=HIGH,CRITICAL "+
+		"--scanners=misconfig "+
+		"--report all "+
+		"--format json",
 		rhwaparams.RhwaOperatorNs)
 
 	modifiedYaml, err := yaml.Marshal(yamlData)
-	Expect(err).NotTo((HaveOccurred()))
+	if err != nil {
+		return err
+	}
 
 	filePath := filepath.Join(destinationPath, rhwaparams.RapidastTemplateFile)
+
 	rapidastConfig, err := os.Create(filePath)
-	Expect(err).NotTo((HaveOccurred()))
+	if err != nil {
+		return err
+	}
 	defer rapidastConfig.Close()
 
 	_, err = rapidastConfig.Write(modifiedYaml)
-	Expect(err).NotTo((HaveOccurred()))
+	if err != nil {
+		return err
+	}
 
 	err = rapidastConfig.Close()
-	Expect(err).NotTo((HaveOccurred()))
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/tests/rhwa/internal/dast/dast.go
+++ b/tests/rhwa/internal/dast/dast.go
@@ -11,7 +11,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func prepareRapidastConfig(destinationPath string) error {
+func PrepareRapidastConfig(destinationPath string) error {
 
 	workingDir, err := os.Getwd()
 	Expect(err).ToNot(HaveOccurred(), err)

--- a/tests/rhwa/internal/dast/dast.go
+++ b/tests/rhwa/internal/dast/dast.go
@@ -74,10 +74,5 @@ func PrepareRapidastConfig(destinationPath string) error {
 		return err
 	}
 
-	err = rapidastConfig.Close()
-	if err != nil {
-		return err
-	}
-
 	return nil
 }

--- a/tests/rhwa/internal/rhwaparams/const.go
+++ b/tests/rhwa/internal/rhwaparams/const.go
@@ -12,9 +12,9 @@ const (
 	// DefaultTimeout represents the default timeout.
 	DefaultTimeout = 300 * time.Second
 
-	// RhwaLogLevel represents the default log level for this suite.
 	RhwaLogLevel = 90
 
 	RapidastTemplateFolder = "../internal/dast/config-files"
 	RapidastTemplateFile   = "rapidastConfig.yaml"
+	RapidastImage          = "quay.io/redhatproductsecurity/rapidast:2.7.0"
 )

--- a/tests/rhwa/internal/rhwaparams/const.go
+++ b/tests/rhwa/internal/rhwaparams/const.go
@@ -12,15 +12,15 @@ const (
 	// DefaultTimeout represents the default timeout.
 	DefaultTimeout = 300 * time.Second
 
-	// RhwaLogLevel represents the log level used in Glog statements
+	// RhwaLogLevel represents the log level used in Glog statements.
 	RhwaLogLevel = 90
 
-	// RapidastTemplateFolder represents the relative route of the folder storing the needed templates
+	// RapidastTemplateFolder represents the relative route of the folder storing the needed templates.
 	RapidastTemplateFolder = "../internal/dast/config-files"
 
-	// RapidastTemplateFile represents the file name used for rapiDast configuration
+	// RapidastTemplateFile represents the file name used for rapiDast configuration.
 	RapidastTemplateFile = "rapidastConfig.yaml"
 
-	// RapidastImage represents the rapidast container image used for dast testing
+	// RapidastImage represents the rapidast container image used for dast testing.
 	RapidastImage = "quay.io/redhatproductsecurity/rapidast:2.7.0"
 )

--- a/tests/rhwa/internal/rhwaparams/const.go
+++ b/tests/rhwa/internal/rhwaparams/const.go
@@ -12,9 +12,15 @@ const (
 	// DefaultTimeout represents the default timeout.
 	DefaultTimeout = 300 * time.Second
 
+	// RhwaLogLevel represents the log level used in Glog statements
 	RhwaLogLevel = 90
 
+	// RapidastTemplateFolder represents the relative route of the folder storing the needed templates
 	RapidastTemplateFolder = "../internal/dast/config-files"
-	RapidastTemplateFile   = "rapidastConfig.yaml"
-	RapidastImage          = "quay.io/redhatproductsecurity/rapidast:2.7.0"
+
+	// RapidastTemplateFile represents the file name used for rapiDast configuration
+	RapidastTemplateFile = "rapidastConfig.yaml"
+
+	// RapidastImage represents the rapidast container image used for dast testing
+	RapidastImage = "quay.io/redhatproductsecurity/rapidast:2.7.0"
 )

--- a/tests/rhwa/internal/rhwaparams/const.go
+++ b/tests/rhwa/internal/rhwaparams/const.go
@@ -11,4 +11,10 @@ const (
 	RhwaOperatorNs = "openshift-workload-availability"
 	// DefaultTimeout represents the default timeout.
 	DefaultTimeout = 300 * time.Second
+
+	// RhwaLogLevel represents the default log level for this suite.
+	RhwaLogLevel = 90
+
+	RapidastTemplateFolder = "../internal/dast/config-files"
+	RapidastTemplateFile   = "rapidastConfig.yaml"
 )


### PR DESCRIPTION
Adds a test that runs rapidast scan for the FAR operator installed in the cluster.

It configures the rapidast for the execution of the trivy scan, looking for misconfigurations on the pods running on the namespace where the operator is installed.

The test fails if any High severity vulnerability is found, providing in the console output the details of the detection.