### PR TITLE
cnf ran: Add siteconfig operator day-two test

### DIFF
--- a/tests/cnf/ran/gitopsztp/internal/helper/helper.go
+++ b/tests/cnf/ran/gitopsztp/internal/helper/helper.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/imageregistry"
 	"github.com/openshift-kni/eco-goinfra/pkg/ocm"
 	"github.com/openshift-kni/eco-goinfra/pkg/serviceaccount"
+	"github.com/openshift-kni/eco-goinfra/pkg/siteconfig"
 	"github.com/openshift-kni/eco-goinfra/pkg/storage"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/gitopsztp/internal/tsparams"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/ranhelper"
@@ -156,4 +157,17 @@ func CleanupImageRegistryConfig(client *clients.Settings) error {
 	}
 
 	return nil
+}
+
+// DoesCIExtraLabelsExists looks for a extraLabels on a cluster instance CR and returns true if it exists.
+func DoesCIExtraLabelsExists(
+	client *clients.Settings, name string, namespace string, testKey string, testLabelKey string) (bool, error) {
+	clusterInstance, err := siteconfig.PullClusterInstance(client, name, namespace)
+	if err != nil {
+		return false, err
+	}
+
+	_, exists := clusterInstance.Object.Spec.ExtraLabels[testKey][testLabelKey]
+
+	return exists, nil
 }

--- a/tests/cnf/ran/gitopsztp/internal/tsparams/consts.go
+++ b/tests/cnf/ran/gitopsztp/internal/tsparams/consts.go
@@ -31,6 +31,8 @@ const (
 	LabelSiteconfigFailoverTestCases = "ztp-siteconfig-failover"
 	// LabelSiteconfigNegativeTestCases is the label for the siteconfig operator's negative test cases.
 	LabelSiteconfigNegativeTestCases = "ztp-siteconfig-negative"
+	// LabelSiteconfigDayTwoConfigTestCase is the label for the siteconfig operator's day 2 configuration test.
+	LabelSiteconfigDayTwoConfigTestCase = "ztp-siteconfig-day-two"
 
 	// LabelBiosDayZeroTests is the label for a particuarl set of test cases.
 	LabelBiosDayZeroTests = "ztp-bios-day-zero"
@@ -106,6 +108,8 @@ const (
 	ZtpTestPathUniqueClusterName = "ztp-test/siteconfig-operator/unique-cluster-name"
 	// ZtpTestPathDuplicateClusterName is the git path for the siteconfig operator duplicate cluster name test.
 	ZtpTestPathDuplicateClusterName = "ztp-test/siteconfig-operator/duplicate-cluster-name"
+	// ZtpTestPathNewClusterLabel is the git path for the siteconfig operator new cluster label test.
+	ZtpTestPathNewClusterLabel = "ztp-test/siteconfig-operator/new-cluster-label"
 	// ZtpKustomizationPath is the path to the kustomization file in the ztp test.
 	ZtpKustomizationPath = "/kustomization.yaml"
 
@@ -152,6 +156,10 @@ const (
 	DefaultAINodeTemplatesConfigMapName = "ai-node-templates-v1"
 	// SiteconfigOperatorPodLabel is the name of siteconfig operator pod label selector.
 	SiteconfigOperatorPodLabel = "app.kubernetes.io/name=siteconfig-controller"
+	// CIExtraLabelsKey is the key name of 'extraLabels:' field in ClusterInstance CR.
+	CIExtraLabelsKey = "ManagedCluster"
+	// TestLabelKey represents day-2 cluster label key in ClusterInstance CR.
+	TestLabelKey = "custom-test"
 
 	// ClusterInstanceValidatedType is one of the type of ClusterInstance condition types.
 	ClusterInstanceValidatedType = "ClusterInstanceValidated"

--- a/tests/cnf/ran/gitopsztp/tests/ztp-siteconfig-day-two.go
+++ b/tests/cnf/ran/gitopsztp/tests/ztp-siteconfig-day-two.go
@@ -1,0 +1,107 @@
+package tests
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/gitopsztp/internal/gitdetails"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/gitopsztp/internal/helper"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/gitopsztp/internal/tsparams"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/rancluster"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/version"
+
+	. "github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/raninittools"
+)
+
+var _ = Describe("ZTP Siteconfig Operator's Day 2 configuration Test",
+	Label(tsparams.LabelSiteconfigDayTwoConfigTestCase), func() {
+		var earlyReturnSkip = true
+
+		// These tests use the hub and spoke architecture.
+		BeforeEach(func() {
+			By("verifying that ZTP meets the minimum version")
+			versionInRange, err := version.IsVersionStringInRange(RANConfig.ZTPVersion, "4.17", "")
+			Expect(err).ToNot(HaveOccurred(), "Failed to compare ZTP version string")
+
+			if !versionInRange {
+				Skip("ZTP Siteconfig operator tests require ZTP 4.17 or later")
+			}
+
+		})
+
+		AfterEach(func() {
+			if earlyReturnSkip {
+				return
+			}
+
+			// Remove newly added custom label from the ClusterInstance CR underneath “extraLabels” field
+			// after the spoke cluster deployed using git flow.
+			By("resetting the clusters app back to the original settings")
+			err := gitdetails.SetGitDetailsInArgoCd(
+				tsparams.ArgoCdClustersAppName, tsparams.ArgoCdAppDetails[tsparams.ArgoCdClustersAppName],
+				true, false)
+			Expect(err).ToNot(HaveOccurred(), "Failed to reset clusters app git details")
+
+			// Make sure the newly added cluster label removed from ClusterInstance CR on hub cluster.
+			// $ oc get clusterinstance <spoke cluster name> -n <spoke namespace>
+			// -o jsonpath='{.spec.extraLabels.ManagedCluster}' | jq
+			By("checking newly added cluster label removed from cluster instance CR")
+			extraLabelPresent, err := helper.DoesCIExtraLabelsExists(HubAPIClient, RANConfig.Spoke1Name, RANConfig.Spoke1Name,
+				tsparams.CIExtraLabelsKey, tsparams.TestLabelKey)
+			Expect(err).ToNot(HaveOccurred(), "Failed to check newly added cluster label "+
+				"removed from cluster instance CR")
+			Expect(extraLabelPresent).To(BeFalse(), "Day-2 cluster label was present "+
+				"on cluster instance CR")
+
+			// New siteconfig operator should honor day2 cluster label remove event and newly added cluster label.
+			// removed from ManagedCluster CR on hub cluster  using the command.
+			// $ oc get managedcluster <spoke cluster name> -o jsonpath='{.metadata.labels}' | jq.
+			By("checking newly added spoke cluster label removed from managed cluster CR")
+			labelPresent, err := rancluster.DoesClusterLabelExist(HubAPIClient, RANConfig.Spoke1Name,
+				tsparams.TestLabelKey)
+			Expect(err).ToNot(HaveOccurred(), "Failed to check newly added spoke cluster label "+
+				"removed from managed cluster CR")
+			Expect(labelPresent).To(BeFalse(), "Day-2 cluster label was present on spoke")
+		})
+
+		// 75342 - Verify modification of cluster labels in ClusterInstance CR using git flows after installation.
+		It("Verify modification of cluster labels in ClusterInstance CR using git flows after installation",
+			reportxml.ID("75342"), func() {
+
+				// Add a new custom label to the ClusterInstance CR underneath “extraLabels” field.
+				// after the spoke cluster deployed using git flow.
+				// Test step 1-Update the ztp-test git path to reference a new custom label addition.
+				// in clusterinstance.yaml as day-2 configuration.
+				By("updating the Argo CD clusters app with the new custom label reference git path")
+				exists, err := gitdetails.UpdateArgoCdAppGitPath(tsparams.ArgoCdClustersAppName,
+					tsparams.ZtpTestPathNewClusterLabel, true)
+				if !exists {
+					Skip(err.Error())
+				}
+
+				earlyReturnSkip = false
+				Expect(err).ToNot(HaveOccurred(), "Failed to update Argo CD clusters app with new git path")
+
+				// Make sure the ClusterInstance CR on hub cluster updated with newly added cluster label.
+				// $ oc get clusterinstance <spoke cluster name> -n <spoke namespace>
+				// -o jsonpath='{.spec.extraLabels.ManagedCluster}' | jq
+				// Test step 1.a expected result validation.
+				By("checking cluster instance CR updated with newly added cluster label on hub")
+				extraLabelPresent, err := helper.DoesCIExtraLabelsExists(HubAPIClient, RANConfig.Spoke1Name, RANConfig.Spoke1Name,
+					tsparams.CIExtraLabelsKey, tsparams.TestLabelKey)
+				Expect(err).ToNot(HaveOccurred(), "Failed to check if cluster instance "+
+					"has newly added cluster label")
+				Expect(extraLabelPresent).To(BeTrue(), "Day-2 cluster label was not present "+
+					"on cluster instance CR")
+
+				// New siteconfig operator should honor day2 cluster label add event and cluster label added
+				// to ManagedCluster CR on hub cluster using below command,
+				// $ oc get managedcluster <spoke cluster name> -o jsonpath='{.metadata.labels}' | jq
+				// Test step 1.b expected result validation.
+				By("checking managed cluster CR updated with newly added spoke cluster label on hub")
+				labelPresent, err := rancluster.DoesClusterLabelExist(HubAPIClient, RANConfig.Spoke1Name,
+					tsparams.TestLabelKey)
+				Expect(err).ToNot(HaveOccurred(), "Failed to check if spoke has newly added cluster label")
+				Expect(labelPresent).To(BeTrue(), "Day-2 cluster label was not present on spoke")
+			})
+	})

--- a/tests/cnf/ran/internal/rancluster/rancluster.go
+++ b/tests/cnf/ran/internal/rancluster/rancluster.go
@@ -8,6 +8,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/nodes"
+	"github.com/openshift-kni/eco-goinfra/pkg/ocm"
 	. "github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/raninittools"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/ranparam"
 	"github.com/openshift-kni/eco-gotests/tests/system-tests/diskencryption/tsparams"
@@ -139,4 +140,16 @@ func CheckSpokeClusterType(client *clients.Settings) (ranparam.ClusterType, erro
 	}
 
 	return ranparam.HighlyAvailableCluster, fmt.Errorf("could not determine spoke cluster type")
+}
+
+// DoesClusterLabelExist looks for a label on a managed cluster and returns true if it exists.
+func DoesClusterLabelExist(client *clients.Settings, clusterName string, label string) (bool, error) {
+	managedCluster, err := ocm.PullManagedCluster(client, clusterName)
+	if err != nil {
+		return false, err
+	}
+
+	_, exists := managedCluster.Object.Labels[label]
+
+	return exists, nil
 }


### PR DESCRIPTION
Hello @klaskosk , @dgonyier , @josclark42.
Please help to review this PR when you have a time. Thanks!

Adding siteconfig operator day-two test case.

[OCP-75342](https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-75342)

Manual Test Logs:
https://docs.google.com/document/d/145d7cctxZwmvKepNiaZw2v3cQtezCCPHXjQ3r6ySCZM/edit?usp=sharing

Test automation code validation logs:
https://docs.google.com/document/d/1aP028ofPtOZnL7ju21EZyCD0NQhMAF1gUtQFU9ZE-Jg/edit?usp=sharing
