### PR TITLE
Fix default namespace for RHWA operators tests

### DIFF
--- a/tests/rhwa/internal/rhwaparams/const.go
+++ b/tests/rhwa/internal/rhwaparams/const.go
@@ -8,7 +8,7 @@ const (
 	// Label represents rhwa label that can be used for test cases selection.
 	Label = "rhwa"
 	// RhwaOperatorNs custom namespace of rhwa operators.
-	RhwaOperatorNs = "openshift-operators"
+	RhwaOperatorNs = "openshift-workload-availability"
 	// DefaultTimeout represents the default timeout.
 	DefaultTimeout = 300 * time.Second
 )


### PR DESCRIPTION
Default namespace for RHWA operators was changed to "openshift-workload-availability". Fixed default namespace in tests to align to existing default value.