### PR TITLE
ibi mgmt: add static network configuration to IBI deploy test

### DIFF
--- a/tests/lca/imagebasedinstall/mgmt/deploy/internal/networkconfig/networkconfig_types.go
+++ b/tests/lca/imagebasedinstall/mgmt/deploy/internal/networkconfig/networkconfig_types.go
@@ -1,0 +1,55 @@
+package networkconfig
+
+// NetworkConfig is the top-level struct containing
+// a full nmstate network configuration.
+type NetworkConfig struct {
+	Interfaces  []Interface `yaml:"interfaces"`
+	Routes      Routes      `yaml:"routes"`
+	DNSResolver DNSResolver `yaml:"dns-resolver"`
+}
+
+// Interface defines an nmstate interface and its properties.
+type Interface struct {
+	Name       string   `yaml:"name"`
+	Type       string   `yaml:"type"`
+	State      string   `yaml:"state"`
+	Identifier string   `yaml:"identifier"`
+	MACAddress string   `yaml:"mac-address"`
+	IPv4       IPConfig `yaml:"ipv4"`
+	IPv6       IPConfig `yaml:"ipv6"`
+}
+
+// Routes contains the route configuration portion of the nmstate configuration.
+type Routes struct {
+	Config []RouteConfig `yaml:"config"`
+}
+
+// RouteConfig defines an nmstate route and its properties.
+type RouteConfig struct {
+	Destination      string `yaml:"destination"`
+	NextHopAddress   string `yaml:"next-hop-address"`
+	NextHopInterface string `yaml:"next-hop-interface"`
+}
+
+// DNSResolver contains the dns-resolver configuration portion of the nmstate configuration.
+type DNSResolver struct {
+	Config DNSResolverConfig `yaml:"config"`
+}
+
+// DNSResolverConfig defines an nmstate dns-resolver and its properties.
+type DNSResolverConfig struct {
+	Server []string `yaml:"server"`
+}
+
+// IPConfig defines the IP configuration applied to an interface.
+type IPConfig struct {
+	DHCP    bool        `yaml:"dhcp"`
+	Address []IPAddress `yaml:"address"`
+	Enabled bool        `yaml:"enabled"`
+}
+
+// IPAddress provides the IP address details to an IP configuration.
+type IPAddress struct {
+	IP           string `yaml:"ip"`
+	PrefixLength string `yaml:"prefix-length"`
+}

--- a/tests/lca/imagebasedinstall/mgmt/deploy/tests/e2e-deploy-test.go
+++ b/tests/lca/imagebasedinstall/mgmt/deploy/tests/e2e-deploy-test.go
@@ -3,6 +3,8 @@ package deploy_test
 import (
 	"context"
 	"fmt"
+	"net"
+	"strconv"
 	"strings"
 	"time"
 
@@ -17,12 +19,18 @@ import (
 	hiveV1 "github.com/openshift-kni/eco-goinfra/pkg/schemes/hive/api/v1"
 	"github.com/openshift-kni/eco-goinfra/pkg/schemes/hive/api/v1/none"
 	ibiv1alpha1 "github.com/openshift-kni/eco-goinfra/pkg/schemes/imagebasedinstall/api/hiveextensions/v1alpha1"
+	"gopkg.in/yaml.v3"
 
 	"github.com/openshift-kni/eco-goinfra/pkg/secret"
+	"github.com/openshift-kni/eco-gotests/tests/lca/imagebasedinstall/mgmt/deploy/internal/networkconfig"
 	"github.com/openshift-kni/eco-gotests/tests/lca/imagebasedinstall/mgmt/deploy/internal/tsparams"
 	. "github.com/openshift-kni/eco-gotests/tests/lca/imagebasedinstall/mgmt/internal/mgmtinittools"
 
 	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	interfaceName = "enp1s0"
 )
 
 var _ = Describe(
@@ -50,110 +58,179 @@ var _ = Describe(
 			ibiImageSetName = strings.Join(splitOCPVersion[:2], ".")
 		})
 
-		It("through IBI operator is successful in a connected environment", reportxml.ID("76641"), func() {
-
-			tsparams.ReporterNamespacesToDump[MGMTConfig.Cluster.Info.ClusterName] = "spoke namespace"
-
-			By("Create namespace for IBI installation")
-			_, err := namespace.NewBuilder(APIClient, MGMTConfig.Cluster.Info.ClusterName).Create()
-			Expect(err).NotTo(HaveOccurred(), "error creating namespace")
-
-			By("Get pull secret from hub cluster")
-			spokePullSecret, err := secret.Pull(APIClient, "pull-secret", "openshift-config")
-			Expect(err).NotTo(HaveOccurred(), "error getting pull-secret from hub cluster")
-
-			By("Create pull secret for spoke cluster")
-			spokePullSecret.Definition.Name = MGMTConfig.Cluster.Info.ClusterName
-			spokePullSecret.Definition.Namespace = MGMTConfig.Cluster.Info.ClusterName
-			spokePullSecret.Definition.ResourceVersion = ""
-			_, err = spokePullSecret.Create()
-			Expect(err).NotTo(HaveOccurred(), "error creating spoke pull-secret")
-
-			for host, info := range MGMTConfig.Cluster.Info.Hosts {
-				By("Create baremetalhost secret for " + host)
-				_, err = secret.NewBuilder(
-					APIClient, host, MGMTConfig.Cluster.Info.ClusterName, v1.SecretTypeOpaque).WithData(map[string][]byte{
-					"username": []byte(info.BMC.User),
-					"password": []byte(info.BMC.Password),
-				}).Create()
-				Expect(err).NotTo(HaveOccurred(), "error creating bmh secret")
-
-				By("Create baremetalhost for " + host)
-				hostBMH := bmh.NewBuilder(
-					APIClient, host, MGMTConfig.Cluster.Info.ClusterName, info.BMC.URLv4, host, info.BMC.MACAddress, "UEFI")
-				hostBMH.Definition.Spec.AutomatedCleaningMode = "disabled"
-
-				_, err = hostBMH.Create()
-				Expect(err).NotTo(HaveOccurred(), "error creating baremetalhost")
-			}
-
-			var snoNodeName string
-
-			for hostname := range MGMTConfig.Cluster.Info.Hosts {
-				snoNodeName = hostname
-
-				break
-			}
-
-			By("Create imageclusterinstall for IBI installation")
-			imageClusterInstall := ibi.NewImageClusterInstallBuilder(
-				APIClient, MGMTConfig.Cluster.Info.ClusterName, MGMTConfig.Cluster.Info.ClusterName, ibiImageSetName).
-				WithClusterDeployment(MGMTConfig.Cluster.Info.ClusterName).WithHostname(snoNodeName).
-				WithMachineNetwork(MGMTConfig.Cluster.Info.MachineCIDR.IPv4)
-
-			if MGMTConfig.PublicSSHKey != "" {
-				imageClusterInstall.WithSSHKey(MGMTConfig.PublicSSHKey)
-			}
-
-			imageClusterInstall.Definition.Spec.BareMetalHostRef = &ibiv1alpha1.BareMetalHostReference{}
-			imageClusterInstall.Definition.Spec.BareMetalHostRef.Name = snoNodeName
-			imageClusterInstall.Definition.Spec.BareMetalHostRef.Namespace = MGMTConfig.Cluster.Info.ClusterName
-			_, err = imageClusterInstall.Create()
-			Expect(err).NotTo(HaveOccurred(), "error creating imageclusterinstall")
-
-			By("Create cluster deployment for IBI installation")
-			_, err = hive.NewClusterDeploymentByInstallRefBuilder(
-				APIClient, MGMTConfig.Cluster.Info.ClusterName,
-				MGMTConfig.Cluster.Info.ClusterName, MGMTConfig.Cluster.Info.ClusterName,
-				MGMTConfig.Cluster.Info.BaseDomain, hiveV1.ClusterInstallLocalReference{
-					Group:   ibiv1alpha1.Group,
-					Version: ibiv1alpha1.Version,
-					Kind:    "ImageClusterInstall",
-					Name:    MGMTConfig.Cluster.Info.ClusterName,
-				}, hiveV1.Platform{
-					None: &none.Platform{},
-				}).
-				WithPullSecret(MGMTConfig.Cluster.Info.ClusterName).Create()
-			Expect(err).NotTo(HaveOccurred(), "error creating cluster deployment")
-
-			By("Create managedcluster for IBI cluster")
-			managedCluster := ocm.NewManagedClusterBuilder(APIClient, MGMTConfig.Cluster.Info.ClusterName).
-				WithOptions(withHubAcceptsClient)
-
-			if !managedCluster.Exists() {
-				err = APIClient.Create(context.TODO(), managedCluster.Definition)
-				if err == nil {
-					managedCluster.Object = managedCluster.Definition
-				}
-			}
-			Expect(err).NotTo(HaveOccurred(), "error creating managedcluster resource")
-
-			Eventually(func() (bool, error) {
-				imageClusterInstall.Object, err = imageClusterInstall.Get()
-				if err != nil {
-					return false, err
+		It("through IBI operator is successful in a connected environment with static networking",
+			reportxml.ID("76641"), func() {
+				if !MGMTConfig.StaticNetworking {
+					Skip("Cluster must use static networking")
 				}
 
-				condition, err := imageClusterInstall.GetCompletedCondition()
-				if err != nil {
-					return false, err
+				tsparams.ReporterNamespacesToDump[MGMTConfig.Cluster.Info.ClusterName] = "spoke namespace"
+
+				By("Create namespace for IBI installation")
+				_, err := namespace.NewBuilder(APIClient, MGMTConfig.Cluster.Info.ClusterName).Create()
+				Expect(err).NotTo(HaveOccurred(), "error creating namespace")
+
+				By("Get pull secret from hub cluster")
+				spokePullSecret, err := secret.Pull(APIClient, "pull-secret", "openshift-config")
+				Expect(err).NotTo(HaveOccurred(), "error getting pull-secret from hub cluster")
+
+				By("Create pull secret for spoke cluster")
+				spokePullSecret.Definition.Name = MGMTConfig.Cluster.Info.ClusterName
+				spokePullSecret.Definition.Namespace = MGMTConfig.Cluster.Info.ClusterName
+				spokePullSecret.Definition.ResourceVersion = ""
+				_, err = spokePullSecret.Create()
+				Expect(err).NotTo(HaveOccurred(), "error creating spoke pull-secret")
+
+				for host, info := range MGMTConfig.Cluster.Info.Hosts {
+					By("Create baremetalhost secret for " + host)
+					_, err = secret.NewBuilder(
+						APIClient, host, MGMTConfig.Cluster.Info.ClusterName, v1.SecretTypeOpaque).WithData(map[string][]byte{
+						"username": []byte(info.BMC.User),
+						"password": []byte(info.BMC.Password),
+					}).Create()
+					Expect(err).NotTo(HaveOccurred(), "error creating bmh secret")
+
+					By("Create secret for static networking configuration")
+					var nodeNetworkingConfig networkconfig.NetworkConfig
+
+					if len(info.Network.Interfaces) != 1 {
+						Skip("Cannot support nodes with more than one network interface")
+					}
+
+					for _, iface := range info.Network.Interfaces {
+
+						nodeIPAddr, nodeIPNetwork, err := net.ParseCIDR(info.Network.Address.IPv4)
+						Expect(err).NotTo(HaveOccurred(), "error gathering network info from provided address")
+						cidr, _ := nodeIPNetwork.Mask.Size()
+
+						nodeNetworkingConfig = networkconfig.NetworkConfig{
+							Interfaces: []networkconfig.Interface{
+								{
+									Name:       interfaceName,
+									Type:       "ethernet",
+									State:      "up",
+									Identifier: "mac-address",
+									MACAddress: iface.MACAddress,
+									IPv4: networkconfig.IPConfig{
+										DHCP: false,
+										Address: []networkconfig.IPAddress{
+											{
+												IP:           nodeIPAddr.String(),
+												PrefixLength: strconv.Itoa(cidr),
+											},
+										},
+										Enabled: true,
+									},
+									IPv6: networkconfig.IPConfig{
+										Enabled: false,
+									},
+								},
+							},
+							Routes: networkconfig.Routes{
+								Config: []networkconfig.RouteConfig{
+									{
+										Destination:      "0.0.0.0/0",
+										NextHopAddress:   info.Network.Gateway.IPv4,
+										NextHopInterface: interfaceName,
+									},
+								},
+							},
+							DNSResolver: networkconfig.DNSResolver{
+								Config: networkconfig.DNSResolverConfig{
+									Server: []string{
+										info.Network.DNS.IPv4,
+									},
+								},
+							},
+						}
+					}
+
+					networkSecretContent, err := yaml.Marshal(&nodeNetworkingConfig)
+					Expect(err).NotTo(HaveOccurred(), "error marshaling network configuration")
+
+					_, err = secret.NewBuilder(APIClient, fmt.Sprintf("%s-nmstate-config", host),
+						MGMTConfig.Cluster.Info.ClusterName, v1.SecretTypeOpaque).WithData(map[string][]byte{
+						"nmstate": networkSecretContent,
+					}).Create()
+					Expect(err).NotTo(HaveOccurred(), "error creating network configuration secret")
+
+					By("Create baremetalhost for " + host)
+					hostBMH := bmh.NewBuilder(
+						APIClient, host, MGMTConfig.Cluster.Info.ClusterName, info.BMC.URLv4, host, info.BMC.MACAddress, "UEFI")
+					hostBMH.Definition.Spec.AutomatedCleaningMode = "disabled"
+					hostBMH.Definition.Spec.PreprovisioningNetworkDataName = fmt.Sprintf("%s-nmstate-config", host)
+
+					_, err = hostBMH.Create()
+					Expect(err).NotTo(HaveOccurred(), "error creating baremetalhost")
 				}
 
-				return condition.Status == "True" && condition.Reason == ibiv1alpha1.InstallSucceededReason, nil
+				var snoNodeName string
 
-			}).WithTimeout(time.Minute*20).WithPolling(time.Second*5).Should(
-				BeTrue(), "error waiting for imageclusterinstall to complete")
-		})
+				for hostname := range MGMTConfig.Cluster.Info.Hosts {
+					snoNodeName = hostname
+
+					break
+				}
+
+				By("Create imageclusterinstall for IBI installation")
+				imageClusterInstall := ibi.NewImageClusterInstallBuilder(
+					APIClient, MGMTConfig.Cluster.Info.ClusterName, MGMTConfig.Cluster.Info.ClusterName, ibiImageSetName).
+					WithClusterDeployment(MGMTConfig.Cluster.Info.ClusterName).WithHostname(snoNodeName).
+					WithMachineNetwork(MGMTConfig.Cluster.Info.MachineCIDR.IPv4)
+
+				if MGMTConfig.PublicSSHKey != "" {
+					imageClusterInstall.WithSSHKey(MGMTConfig.PublicSSHKey)
+				}
+
+				imageClusterInstall.Definition.Spec.BareMetalHostRef = &ibiv1alpha1.BareMetalHostReference{}
+				imageClusterInstall.Definition.Spec.BareMetalHostRef.Name = snoNodeName
+				imageClusterInstall.Definition.Spec.BareMetalHostRef.Namespace = MGMTConfig.Cluster.Info.ClusterName
+				_, err = imageClusterInstall.Create()
+				Expect(err).NotTo(HaveOccurred(), "error creating imageclusterinstall")
+
+				By("Create cluster deployment for IBI installation")
+				_, err = hive.NewClusterDeploymentByInstallRefBuilder(
+					APIClient, MGMTConfig.Cluster.Info.ClusterName,
+					MGMTConfig.Cluster.Info.ClusterName, MGMTConfig.Cluster.Info.ClusterName,
+					MGMTConfig.Cluster.Info.BaseDomain, hiveV1.ClusterInstallLocalReference{
+						Group:   ibiv1alpha1.Group,
+						Version: ibiv1alpha1.Version,
+						Kind:    "ImageClusterInstall",
+						Name:    MGMTConfig.Cluster.Info.ClusterName,
+					}, hiveV1.Platform{
+						None: &none.Platform{},
+					}).
+					WithPullSecret(MGMTConfig.Cluster.Info.ClusterName).Create()
+				Expect(err).NotTo(HaveOccurred(), "error creating cluster deployment")
+
+				By("Create managedcluster for IBI cluster")
+				managedCluster := ocm.NewManagedClusterBuilder(APIClient, MGMTConfig.Cluster.Info.ClusterName).
+					WithOptions(withHubAcceptsClient)
+
+				if !managedCluster.Exists() {
+					err = APIClient.Create(context.TODO(), managedCluster.Definition)
+					if err == nil {
+						managedCluster.Object = managedCluster.Definition
+					}
+				}
+				Expect(err).NotTo(HaveOccurred(), "error creating managedcluster resource")
+
+				Eventually(func() (bool, error) {
+					imageClusterInstall.Object, err = imageClusterInstall.Get()
+					if err != nil {
+						return false, err
+					}
+
+					condition, err := imageClusterInstall.GetCompletedCondition()
+					if err != nil {
+						return false, err
+					}
+
+					return condition.Status == "True" && condition.Reason == ibiv1alpha1.InstallSucceededReason, nil
+
+				}).WithTimeout(time.Minute*20).WithPolling(time.Second*5).Should(
+					BeTrue(), "error waiting for imageclusterinstall to complete")
+			})
 	})
 
 func withHubAcceptsClient(builder *ocm.ManagedClusterBuilder) (*ocm.ManagedClusterBuilder, error) {

--- a/tests/lca/imagebasedinstall/mgmt/internal/mgmtconfig/config.go
+++ b/tests/lca/imagebasedinstall/mgmt/internal/mgmtconfig/config.go
@@ -39,7 +39,7 @@ type Cluster struct {
 				Gateway struct {
 					IPv4 string `yaml:"ipv4"`
 					IPv6 string `yaml:"ipv6"`
-				} `yaml:"gateway"`
+				} `yaml:"default_gateway"`
 				DNS struct {
 					IPv4 string `yaml:"ipv4"`
 					IPv6 string `yaml:"ipv6"`
@@ -59,12 +59,13 @@ type Cluster struct {
 // MGMTConfig type contains mgmt configuration.
 type MGMTConfig struct {
 	*ibiconfig.IBIConfig
-	Cluster         *Cluster
-	ClusterInfoPath string `envconfig:"ECO_LCA_IBI_MGMT_CLUSTER_INFO"`
-	SeedImage       string `envconfig:"ECO_LCA_IBI_MGMT_SEED_IMAGE" default:"quay.io/ocp-edge-qe/ib-seedimage-public:ci"`
-	SeedClusterInfo *seedimage.SeedImageContent
-	SSHKeyPath      string `envconfig:"ECO_LCA_IBI_MGMT_SSHKEY_PATH"`
-	PublicSSHKey    string
+	Cluster          *Cluster
+	ClusterInfoPath  string `envconfig:"ECO_LCA_IBI_MGMT_CLUSTER_INFO"`
+	SeedImage        string `envconfig:"ECO_LCA_IBI_MGMT_SEED_IMAGE" default:"quay.io/ocp-edge-qe/ib-seedimage-public:ci"`
+	SeedClusterInfo  *seedimage.SeedImageContent
+	SSHKeyPath       string `envconfig:"ECO_LCA_IBI_MGMT_SSHKEY_PATH"`
+	PublicSSHKey     string
+	StaticNetworking bool `envconfig:"ECO_LCA_IBI_MGMT_STATIC_NETWORK" default:"false"`
 }
 
 // NewMGMTConfig returns instance of MGMTConfig type.


### PR DESCRIPTION
- Add configuration parameter for enabling static networking when configuring spoke
- Add networkconfig pkg to help generate static network configurations
- Add static network configuration to deploy test