### PR TITLE
cnf network: remove timers from frrconfig CR

### DIFF
--- a/tests/cnf/core/network/metallb/tests/frrk8-tests.go
+++ b/tests/cnf/core/network/metallb/tests/frrk8-tests.go
@@ -809,10 +809,8 @@ func createFrrConfiguration(name, bgpPeerIP string, remoteAS uint32, filteredIP 
 		frrConfig.WithEBGPMultiHop(0, 0)
 	}
 
-	// Set HoldTime, Keepalive, Password, and Port
+	// Set Password and Port
 	frrConfig.
-		WithHoldTime(metav1.Duration{Duration: 90 * time.Second}, 0, 0).
-		WithKeepalive(metav1.Duration{Duration: 30 * time.Second}, 0, 0).
 		WithBGPPassword("bgp-test", 0, 0).
 		WithPort(179, 0, 0)
 


### PR DESCRIPTION
backport of https://github.com/openshift-kni/eco-gotests/pull/267
