### PR TITLE
Update Go to v1.23.6

### DIFF
--- a/.github/workflows/eco-goinfra-bump.yml
+++ b/.github/workflows/eco-goinfra-bump.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go 1.23
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.2
+          go-version: 1.23.6
 
       - name: Run sync script
         run: make sync-eco-goinfra

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go 1.22
         uses: actions/setup-go@v3
         with:
-          go-version: 1.22.6
+          go-version: 1.23.6
 
       - uses: actions/checkout@v4
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi9/ubi:latest
 
-ARG GO_VER=go1.23.2
+ARG GO_VER=go1.23.6
 ARG GINKGO_VER=ginkgo@v2.20.2
 ARG CONTAINERUSER=testuser
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift-kni/eco-gotests
 
-go 1.23.5
+go 1.23.6
 
 require (
 	github.com/BurntSushi/toml v1.4.0


### PR DESCRIPTION
[Related to: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2609](https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2766)