### PR TITLE
ci: add reviewers to eco-goinfra bumps

### DIFF
--- a/.github/workflows/eco-goinfra-bump.yml
+++ b/.github/workflows/eco-goinfra-bump.yml
@@ -38,3 +38,4 @@ jobs:
           title: Bump eco-goinfra dependency
           branch: eco-goinfra-bump
           delete-branch: true
+          reviewers: achuzhoy,cdvultur,klaskosk,kononovn,trewest


### PR DESCRIPTION
Tested on my own repo, it won't break the CI run even if it can't add the reviewers (which it couldn't since not everyone is a contributor on my fork).