### PR TITLE
reporter,cnf ran: add CSRs to spoke resources reported

### DIFF
--- a/tests/cnf/ran/gitopsztp/internal/tsparams/ztpvars.go
+++ b/tests/cnf/ran/gitopsztp/internal/tsparams/ztpvars.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/ranparam"
 	"github.com/openshift-kni/k8sreporter"
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
+	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -64,6 +65,7 @@ var (
 		{Cr: &sriovv1.SriovNetworkList{}, Namespace: ptr.To(RANConfig.SriovOperatorNamespace)},
 		{Cr: &sriovv1.SriovNetworkList{}, Namespace: ptr.To(TestNamespace)},
 		{Cr: &imageregistryv1.ConfigList{}},
+		{Cr: &certificatesv1.CertificateSigningRequestList{}},
 	}
 
 	// ArgoCdApps is the slice of the Argo CD app names defined in this package.

--- a/tests/internal/reporter/schemes.go
+++ b/tests/internal/reporter/schemes.go
@@ -27,6 +27,7 @@ import (
 	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	mcmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api-hub/v1beta1"
 	modulev1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	certificatesv1 "k8s.io/api/certificates/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 	policiesv1beta1 "open-cluster-management.io/governance-policy-propagator/api/v1beta1"
@@ -62,6 +63,7 @@ var reporterSchemes = []clients.SchemeAttacher{
 	lcav1.AddToScheme,
 	ibiv1alpha1.AddToScheme,
 	siteconfigv1alpha1.AddToScheme,
+	certificatesv1.AddToScheme,
 }
 
 func setReporterSchemes(scheme *runtime.Scheme) error {


### PR DESCRIPTION
In the reporter package, this adds the certificatesv1 schema to the client for reporting.

In the cnf/ran/gitopsztp package, this adds the CertificateSigningRequest to the list of spoke CRs to dump on test failure.