### PR TITLE
assisted ztp: add https-webserver test namespace pods to report dump

### DIFF
--- a/tests/assisted/ztp/operator/internal/tsparams/operatorvars.go
+++ b/tests/assisted/ztp/operator/internal/tsparams/operatorvars.go
@@ -21,6 +21,7 @@ var (
 
 	// ReporterCRDsToDump tells to the reporter what CRs to dump.
 	ReporterCRDsToDump = []k8sreporter.CRData{
+		{Cr: &corev1.PodList{}},
 		{Cr: &corev1.SecretList{}},
 		{Cr: &agentInstallV1Beta1.AgentServiceConfigList{}},
 		{Cr: &hivev1.ClusterDeploymentList{}},

--- a/tests/assisted/ztp/operator/tests/https-webserver-setup-test.go
+++ b/tests/assisted/ztp/operator/tests/https-webserver-setup-test.go
@@ -45,6 +45,8 @@ var _ = Describe(
 					Skip(msg)
 				}
 
+				tsparams.ReporterNamespacesToDump[nsname] = "httpdtest namespace"
+
 				By("Creating httpd-test namespace")
 				testNS, err := namespace.NewBuilder(HubAPIClient, nsname).Create()
 				Expect(err).ToNot(HaveOccurred(), "error creating namespace")


### PR DESCRIPTION
- Add pods to reporter in operator test suite
- Add httpdtest namespace to reporter for debugging failures