### PR TITLE
cnf network: skip frr alwaysBlock test case until Frr ns CNO is activ…

### DIFF
--- a/tests/cnf/core/network/metallb/tests/frrk8-tests.go
+++ b/tests/cnf/core/network/metallb/tests/frrk8-tests.go
@@ -108,6 +108,8 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelFRRTestCases), ContinueOnFa
 
 		It("Verify that prefixes configured with alwaysBlock are not received by the FRR speakers",
 			reportxml.ID("74270"), func() {
+				Skip("Skipping this test case. AlwaysBlock has been removed until the new Frr namespace " +
+					"CNO is activated in 4.19.")
 				prefixToBlock := externalAdvertisedIPv4Routes[0]
 
 				By("Creating a new instance of MetalLB Speakers on workers blocking specific incoming prefixes")


### PR DESCRIPTION
Skipping the alwaysBlock test case until 4.19 and CNO is activated