### PR TITLE
infra: add systemreporter pkg

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,7 @@ linters-settings:
         deny:
         - pkg: "github.com/onsi**"
         allow:
+        - "github.com/onsi/ginkgo/v2/types"
         - "k8s.io/apimachinery"
         - "k8s.io/api"
         - "k8s.io/kubelet"

--- a/tests/internal/config/config.go
+++ b/tests/internal/config/config.go
@@ -24,6 +24,8 @@ type GeneralConfig struct {
 	DumpFailedTests           bool   `yaml:"dump_failed_tests" envconfig:"ECO_DUMP_FAILED_TESTS"`
 	EnableReport              bool   `yaml:"enable_report" envconfig:"ECO_ENABLE_REPORT"`
 	DryRun                    bool   `yaml:"dry_run" envconfig:"ECO_DRY_RUN"`
+	SSHKeyPath                string `envconfig:"ECO_SSH_KEY_PATH"`
+	SSHUser                   string `yaml:"ssh_user" envconfig:"ECO_SSH_USER"`
 	KubernetesRolePrefix      string `yaml:"kubernetes_role_prefix" envconfig:"ECO_KUBERNETES_ROLE_PREFIX"`
 	WorkerLabelEnvVar         string `yaml:"worker_label" envconfig:"ECO_WORKER_LABEL"`
 	WorkerLabel               string

--- a/tests/internal/config/default.yaml
+++ b/tests/internal/config/default.yaml
@@ -15,3 +15,4 @@ logging_operator_namespace: "openshift-logging"
 sriov_operator_namespace: "openshift-sriov-network-operator"
 nmstate_operator_namespace: "openshift-nmstate"
 sriov_fec_operator_namespace: "vran-acceleration-operators"
+ssh_user: core

--- a/tests/internal/systemreporter/systemreporter.go
+++ b/tests/internal/systemreporter/systemreporter.go
@@ -1,0 +1,187 @@
+package systemreporter
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	re "regexp"
+	"strings"
+
+	"github.com/golang/glog"
+	"github.com/onsi/ginkgo/v2/types"
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/openshift-kni/eco-gotests/tests/internal/cluster"
+	. "github.com/openshift-kni/eco-gotests/tests/internal/inittools"
+	"golang.org/x/crypto/ssh"
+)
+
+var (
+	// Matches option hypens, spaces, and special characters.
+	specialChars = re.MustCompile(`-?\s-?|[/|'"\.\[\]]`)
+
+	// Matches duplicate underscores.
+	dupUnderscores = re.MustCompile(`__+`)
+
+	// Matches leading and trailing underscores.
+	leadAndTrailUnderscores = re.MustCompile(`^_|_$`)
+)
+
+// ReportIfFailedFromClient dumps the requested command output
+// from nodes pulled from specified apiClient if test case fails.
+func ReportIfFailedFromClient(
+	report types.SpecReport, testSuite string, commands []string, apiClient *clients.Settings) {
+	if types.SpecStateFailureStates.Is(report.State) {
+		if apiClient == nil {
+			glog.Errorf("cannot gather system report from nil apiClient")
+
+			return
+		}
+
+		dumpDir := GeneralConfig.GetDumpFailedTestReportLocation(testSuite)
+
+		tcReportFolderName := strings.ReplaceAll(report.FullText(), " ", "_")
+
+		systemFolder := fmt.Sprintf("%s/%s/system", dumpDir, tcReportFolderName)
+
+		err := os.MkdirAll(systemFolder, 0755)
+		if err != nil {
+			glog.Errorf("failed creating dir for system info: %s", err)
+
+			return
+		}
+
+		GatherInfoThroughKubeClient(commands, systemFolder, apiClient)
+	}
+}
+
+// ReportIfFailedFromNodeList dumps the requested command output from specified nodes through SSH if test case fails.
+func ReportIfFailedFromNodeList(report types.SpecReport, testSuite string, commands []string, nodes []string) {
+	if types.SpecStateFailureStates.Is(report.State) {
+		dumpDir := GeneralConfig.GetDumpFailedTestReportLocation(testSuite)
+
+		tcReportFolderName := strings.ReplaceAll(report.FullText(), " ", "_")
+
+		systemFolder := fmt.Sprintf("%s/%s/system", dumpDir, tcReportFolderName)
+
+		err := os.MkdirAll(systemFolder, 0755)
+		if err != nil {
+			glog.Errorf("failed to create directory for storing system info %s", err)
+
+			return
+		}
+
+		GatherInfoThroughSSH(commands, systemFolder, GeneralConfig.SSHKeyPath, nodes)
+	}
+}
+
+// GatherInfoThroughSSH gathers command output from specified nodes
+// and writes output to specified directory.
+func GatherInfoThroughSSH(commands []string, outputdir string, sshKeyPath string, nodes []string) {
+	if sshKeyPath == "" {
+		glog.Errorf("cannot gather system information without providing ssh key path")
+
+		return
+	}
+
+	privateKey, err := os.ReadFile(sshKeyPath)
+	if err != nil {
+		glog.Errorf("failed to read private ssh key from system: %s", err)
+
+		return
+	}
+
+	signer, err := ssh.ParsePrivateKey(privateKey)
+	if err != nil {
+		glog.Errorf("failed to parse private ssh key: %s", err)
+
+		return
+	}
+
+	config := ssh.ClientConfig{
+		User:            GeneralConfig.SSHUser,
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Auth: []ssh.AuthMethod{
+			ssh.PublicKeys(signer),
+		},
+	}
+
+	for _, node := range nodes {
+		client, err := ssh.Dial("tcp", fmt.Sprintf("%s:22", node), &config)
+		if err != nil {
+			glog.Errorf("failed to establish SSH connection to %s: %s", node, err)
+
+			continue
+		}
+
+		defer client.Close()
+
+		for _, command := range commands {
+			var output bytes.Buffer
+
+			var stderr bytes.Buffer
+
+			session, err := client.NewSession()
+			if err != nil {
+				glog.Errorf("failed to create SSH session on %s: %s", node, err)
+
+				break
+			}
+
+			defer session.Close()
+
+			session.Stdout = &output
+			session.Stderr = &stderr
+
+			err = session.Run(command)
+			if err == nil {
+				err = os.WriteFile(outputdir+"/"+node+"_"+fileNameFromCommand(command), output.Bytes(), 0650)
+				if err != nil {
+					glog.Errorf("error writing to file: %s", err)
+				}
+			} else {
+				glog.Errorf("error executing command '%s' on %s: %s", command, node, stderr.String())
+			}
+		}
+	}
+}
+
+// GatherInfoThroughKubeClient gathers command output from nodes accessible from APIClient
+// and writes output to specified directory.
+func GatherInfoThroughKubeClient(commands []string, outputdir string, apiClient *clients.Settings) {
+	if apiClient == nil {
+		glog.Errorf("cannot gather system information from nil APIClient")
+
+		return
+	}
+
+	for _, command := range commands {
+		output, err := cluster.ExecCmdWithStdout(apiClient, command)
+		if err != nil {
+			glog.Errorf("error occurred while executing command: %s", err)
+
+			continue
+		}
+
+		for node, results := range output {
+			err = os.WriteFile(outputdir+"/"+node+"_"+fileNameFromCommand(command), []byte(results), 0650)
+			if err != nil {
+				glog.Errorf("error writing to file: %s", err)
+			}
+		}
+	}
+}
+
+func fileNameFromCommand(command string) string {
+	fileName := command
+
+	// Replace option hypens, spaces, and special characters with underscores everywhere in the command.
+	fileName = specialChars.ReplaceAllString(fileName, "_")
+
+	// Remove repeated underscores
+	fileName = dupUnderscores.ReplaceAllString(fileName, "_")
+
+	// Remove leading and trailing underscores
+	fileName = leadAndTrailUnderscores.ReplaceAllString(fileName, "")
+
+	return fileName
+}


### PR DESCRIPTION
- Adds systemreporter pkg
- Adds ability to gather command output from machine under test through kube-api 
- Adds ability to gather command output from machine under test through ssh connection
- Adds ECO_SSH_KEY_PATH and ECO_SSH_USER to GeneralConfig in order to to provide SSH access to nodes under test