### PR TITLE
cnf network: fix test issues

### DIFF
--- a/tests/cnf/core/network/sriov/tests/metricsExporter.go
+++ b/tests/cnf/core/network/sriov/tests/metricsExporter.go
@@ -50,7 +50,7 @@ var _ = Describe("SriovMetricsExporter", Ordered, Label(tsparams.LabelSriovMetri
 			workerNodeList           []*nodes.Builder
 			sriovmetricsdaemonset    *daemonset.Builder
 			sriovInterfacesUnderTest []string
-			sriovDeviceID            string
+			sriovVendorID            string
 		)
 
 		BeforeAll(func() {
@@ -71,8 +71,8 @@ var _ = Describe("SriovMetricsExporter", Ordered, Label(tsparams.LabelSriovMetri
 			Expect(err).ToNot(HaveOccurred(), "Failed to retrieve SR-IOV interfaces for testing")
 
 			By("Fetching SR-IOV Device ID for interface under test")
-			sriovDeviceID = discoverInterfaceUnderTestDeviceID(sriovInterfacesUnderTest[0], workerNodeList[0].Definition.Name)
-			Expect(sriovDeviceID).ToNot(BeEmpty(), "Expected sriovDeviceID not to be empty")
+			sriovVendorID = discoverInterfaceUnderTestVendorID(sriovInterfacesUnderTest[0], workerNodeList[0].Definition.Name)
+			Expect(sriovVendorID).ToNot(BeEmpty(), "Expected sriovDeviceID not to be empty")
 
 			By("Enable Sriov Metrics Exporter feature in default SriovOperatorConfig CR")
 			setMetricsExporter(true)
@@ -122,15 +122,15 @@ var _ = Describe("SriovMetricsExporter", Ordered, Label(tsparams.LabelSriovMetri
 		Context("Netdevice to Netdevice", func() {
 			It("Same PF", reportxml.ID("74762"), func() {
 				runNettoNetTests(sriovInterfacesUnderTest[0], sriovInterfacesUnderTest[0],
-					workerNodeList[0].Object.Name, workerNodeList[0].Object.Name, sriovDeviceID)
+					workerNodeList[0].Object.Name, workerNodeList[0].Object.Name, sriovVendorID)
 			})
 			It("Different PF", reportxml.ID("75929"), func() {
 				runNettoNetTests(sriovInterfacesUnderTest[0], sriovInterfacesUnderTest[1],
-					workerNodeList[0].Object.Name, workerNodeList[0].Object.Name, sriovDeviceID)
+					workerNodeList[0].Object.Name, workerNodeList[0].Object.Name, sriovVendorID)
 			})
 			It("Different Worker", reportxml.ID("75930"), func() {
 				runNettoNetTests(sriovInterfacesUnderTest[0], sriovInterfacesUnderTest[0],
-					workerNodeList[0].Object.Name, workerNodeList[1].Object.Name, sriovDeviceID)
+					workerNodeList[0].Object.Name, workerNodeList[1].Object.Name, sriovVendorID)
 			})
 		})
 
@@ -152,15 +152,15 @@ var _ = Describe("SriovMetricsExporter", Ordered, Label(tsparams.LabelSriovMetri
 			})
 			It("Same PF", reportxml.ID("74797"), func() {
 				runNettoVfioTests(sriovInterfacesUnderTest[0], sriovInterfacesUnderTest[0],
-					workerNodeList[0].Object.Name, workerNodeList[0].Object.Name, sriovDeviceID)
+					workerNodeList[0].Object.Name, workerNodeList[0].Object.Name, sriovVendorID)
 			})
 			It("Different PF", reportxml.ID("75931"), func() {
 				runNettoVfioTests(sriovInterfacesUnderTest[0], sriovInterfacesUnderTest[1],
-					workerNodeList[0].Object.Name, workerNodeList[0].Object.Name, sriovDeviceID)
+					workerNodeList[0].Object.Name, workerNodeList[0].Object.Name, sriovVendorID)
 			})
 			It("Different Worker", reportxml.ID("75932"), func() {
 				runNettoVfioTests(sriovInterfacesUnderTest[0], sriovInterfacesUnderTest[0],
-					workerNodeList[0].Object.Name, workerNodeList[1].Object.Name, sriovDeviceID)
+					workerNodeList[0].Object.Name, workerNodeList[1].Object.Name, sriovVendorID)
 			})
 		})
 
@@ -183,15 +183,15 @@ var _ = Describe("SriovMetricsExporter", Ordered, Label(tsparams.LabelSriovMetri
 			})
 			It("Same PF", reportxml.ID("74800"), func() {
 				runVfiotoVfioTests(sriovInterfacesUnderTest[0], sriovInterfacesUnderTest[0],
-					workerNodeList[0].Object.Name, workerNodeList[0].Object.Name, sriovDeviceID)
+					workerNodeList[0].Object.Name, workerNodeList[0].Object.Name, sriovVendorID)
 			})
 			It("Different PF", reportxml.ID("75933"), func() {
 				runVfiotoVfioTests(sriovInterfacesUnderTest[0], sriovInterfacesUnderTest[1],
-					workerNodeList[0].Object.Name, workerNodeList[0].Object.Name, sriovDeviceID)
+					workerNodeList[0].Object.Name, workerNodeList[0].Object.Name, sriovVendorID)
 			})
 			It("Different Worker", reportxml.ID("75934"), func() {
 				runVfiotoVfioTests(sriovInterfacesUnderTest[0], sriovInterfacesUnderTest[0],
-					workerNodeList[0].Object.Name, workerNodeList[1].Object.Name, sriovDeviceID)
+					workerNodeList[0].Object.Name, workerNodeList[1].Object.Name, sriovVendorID)
 			})
 		})
 
@@ -285,7 +285,7 @@ func definePolicy(role, devType, nicVendor, pfName string, vfRange int) *sriov.P
 			WithDevType("netdevice").
 			WithVFRange(vfRange, vfRange)
 	case "vfiopci":
-		if !(nicVendor == netparam.MlxDeviceID || nicVendor == netparam.MlxBFDeviceID) {
+		if nicVendor != netparam.MlxVendorID {
 			policy = sriov.NewPolicyBuilder(APIClient,
 				role+devType, NetConfig.SriovOperatorNamespace, role+devType, 2, []string{pfName}, NetConfig.WorkerLabelMap).
 				WithDevType("vfio-pci").

--- a/tests/cnf/core/network/sriov/tests/paralleldraining.go
+++ b/tests/cnf/core/network/sriov/tests/paralleldraining.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	"github.com/openshift-kni/eco-goinfra/pkg/nad"
 	"github.com/openshift-kni/eco-goinfra/pkg/namespace"
 	"github.com/openshift-kni/eco-goinfra/pkg/nodes"
 	"github.com/openshift-kni/eco-goinfra/pkg/pod"
@@ -59,6 +60,13 @@ var _ = Describe("ParallelDraining", Ordered, Label(tsparams.LabelParallelDraini
 			createSriovConfigurationParallelDrain(sriovInterfacesUnderTest[0])
 
 			By("Creating test pods and checking connectivity between the them")
+			Eventually(func() error {
+				_, err := nad.Pull(APIClient, sriovAndResourceNameParallelDrain, tsparams.TestNamespaceName)
+
+				return err
+			}, 10*time.Second, 1*time.Second).Should(BeNil(), fmt.Sprintf(
+				"Failed to pull NAD %s", sriovAndResourceNameParallelDrain))
+
 			err := sriovenv.CreatePodsAndRunTraffic(workerNodeList[0].Object.Name, workerNodeList[0].Object.Name,
 				sriovAndResourceNameParallelDrain, sriovAndResourceNameParallelDrain,
 				tsparams.ClientMacAddress, tsparams.ServerMacAddress,


### PR DESCRIPTION
- Parallel Draining: Added NAD creation checkpoint to prevent flaky [issues](https://jenkins-csb-kniqe-auto.dno.corp.redhat.com/job/ocp-eco-gotests/2147//testReport/junit/(root)/sriov/_It__ParallelDraining_without_SriovNetworkPoolConfig__paralleldraining__68640__test_id_68640_/)
- Sriov Metrics Exporter: Use VendorID instead of DeviceID (as it failed on [cluster14](https://jenkins-csb-kniqe-auto.dno.corp.redhat.com/job/ocp-eco-gotests/2147/testReport/(root)/sriov/))
- Rdma metrics API: Specific error messages added. eco-goinfra [PR](https://github.com/openshift-kni/eco-goinfra/pull/891) for CleanObjects is merged.