### PR TITLE
cnf ran: fix ZTP suite automation issues

### DIFF
--- a/tests/cnf/ran/gitopsztp/internal/tsparams/consts.go
+++ b/tests/cnf/ran/gitopsztp/internal/tsparams/consts.go
@@ -138,8 +138,6 @@ const (
 	CustomSourceCrPolicyName = "custom-source-cr-policy-config"
 	// CustomSourceCrName is the name of the custom source CR itself.
 	CustomSourceCrName = "custom-source-cr"
-	// CustomSourceTestNamespace is the test namespace for the custom source test.
-	CustomSourceTestNamespace = "default"
 	// CustomSourceStorageClass is the storage class used in the custom source test.
 	CustomSourceStorageClass = "example-storage-class"
 	// ImageRegistrySC is the storage class created by the policies app image registry tests.

--- a/tests/cnf/ran/gitopsztp/internal/tsparams/ztpvars.go
+++ b/tests/cnf/ran/gitopsztp/internal/tsparams/ztpvars.go
@@ -61,7 +61,7 @@ var (
 		{Cr: &corev1.PersistentVolumeList{}},
 		{Cr: &corev1.PersistentVolumeClaimList{}, Namespace: ptr.To(ImageRegistryNamespace)},
 		{Cr: &storagev1.StorageClassList{}},
-		{Cr: &corev1.ServiceAccountList{}, Namespace: ptr.To(CustomSourceTestNamespace)},
+		{Cr: &corev1.ServiceAccountList{}, Namespace: ptr.To(TestNamespace)},
 		{Cr: &sriovv1.SriovNetworkList{}, Namespace: ptr.To(RANConfig.SriovOperatorNamespace)},
 		{Cr: &sriovv1.SriovNetworkList{}, Namespace: ptr.To(TestNamespace)},
 		{Cr: &imageregistryv1.ConfigList{}},

--- a/tests/cnf/ran/gitopsztp/ztp_suite_test.go
+++ b/tests/cnf/ran/gitopsztp/ztp_suite_test.go
@@ -38,18 +38,25 @@ var _ = BeforeSuite(func() {
 
 	err := gitdetails.GetArgoCdAppGitDetails()
 	Expect(err).ToNot(HaveOccurred(), "Failed to get current data from ArgoCD")
+})
 
-	By("deleting and recreating ZTP test namespace to ensure a blank state")
-	err = namespace.NewBuilder(HubAPIClient, tsparams.TestNamespace).DeleteAndWait(5 * time.Minute)
-	Expect(err).ToNot(HaveOccurred(), "Failed to delete ZTP test namespace")
+var _ = BeforeEach(func() {
+	By("deleting and recreating test namespace to ensure blank state")
+	for _, client := range []*clients.Settings{HubAPIClient, Spoke1APIClient} {
+		err := namespace.NewBuilder(client, tsparams.TestNamespace).DeleteAndWait(5 * time.Minute)
+		Expect(err).ToNot(HaveOccurred(), "Failed to delete ZTP test namespace")
 
-	_, err = namespace.NewBuilder(HubAPIClient, tsparams.TestNamespace).Create()
-	Expect(err).ToNot(HaveOccurred(), "Failed to create ZTP test namespace")
+		_, err = namespace.NewBuilder(client, tsparams.TestNamespace).Create()
+		Expect(err).ToNot(HaveOccurred(), "Failed to create ZTP test namespace")
+	}
 })
 
 var _ = AfterSuite(func() {
-	err := namespace.NewBuilder(HubAPIClient, tsparams.TestNamespace).DeleteAndWait(5 * time.Minute)
-	Expect(err).ToNot(HaveOccurred(), "Failed to delete ZTP test namespace")
+	By("deleting test namespace")
+	for _, client := range []*clients.Settings{HubAPIClient, Spoke1APIClient} {
+		err := namespace.NewBuilder(client, tsparams.TestNamespace).DeleteAndWait(5 * time.Minute)
+		Expect(err).ToNot(HaveOccurred(), "Failed to delete ZTP test namespace")
+	}
 })
 
 var _ = JustAfterEach(func() {


### PR DESCRIPTION
* Add a workaround for an issue where the policy definition would be nil. Failures only commonly occur during this ocm.PullPolicy specifically so a workaround here is sufficient.
* Switches the custom source CR service account namespace to the test namespace which requires creating the namespace on the spoke too.
* Change to recreating the test namespace per test case rather than per suite. This should improve the isolation between tests and fix some of the automation issues related to namespaces.