### PR TITLE
save original boot order instead of reading current value and swapping when recovering

### DIFF
--- a/tests/system-tests/diskencryption/tests/tpm2.go
+++ b/tests/system-tests/diskencryption/tests/tpm2.go
@@ -5,6 +5,7 @@ import (
 
 	"regexp"
 
+	"github.com/golang/glog"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/openshift-kni/eco-goinfra/pkg/nodes"
@@ -427,7 +428,7 @@ var _ = Describe("TPM2", func() {
 			WithPolling(tsparams.PollingIntervalBMC).
 			ShouldNot(HaveOccurred(), "getting boot order should not return an error")
 
-		By(fmt.Sprintf("listing original boot Order: %s", originalBootOrder))
+		glog.V(tsparams.LogLevel).Infof("listing original boot Order: %s", originalBootOrder)
 
 		By("changing the server boot order")
 		swapFirstSecondBootItems()

--- a/tests/system-tests/diskencryption/tests/tpm2.go
+++ b/tests/system-tests/diskencryption/tests/tpm2.go
@@ -413,6 +413,22 @@ var _ = Describe("TPM2", func() {
 		isRootDiskReservedSlotPresent := helper.LuksListContainsReservedSlot(luksListOutput)
 		Expect(isRootDiskReservedSlotPresent).To(BeFalse(), "there should be no reserved slot present at this point")
 
+		By("saving the original server boot order")
+		var originalBootOrder []string
+		Eventually(func() error {
+			originalBootOrder, err = BMCClient.SystemBootOrderReferences()
+
+			if len(originalBootOrder) < 2 {
+				return fmt.Errorf("need at least 2 boot entries")
+			}
+
+			return err
+		}).WithTimeout(tsparams.TimeoutWaitingOnBMC).
+			WithPolling(tsparams.PollingIntervalBMC).
+			ShouldNot(HaveOccurred(), "getting boot order should not return an error")
+
+		By(fmt.Sprintf("listing original boot Order: %s", originalBootOrder))
+
 		By("changing the server boot order")
 		swapFirstSecondBootItems()
 
@@ -439,8 +455,10 @@ var _ = Describe("TPM2", func() {
 		Expect(err).ToNot(HaveOccurred(), "WaitForRegex should not fail")
 		Expect(matchIndex).To(Equal(0), "WaitForRegex should match TPM failed (0)")
 
-		By("changing the server boot order back to defaults")
-		swapFirstSecondBootItems()
+		By("changing the server boot order back to original settings")
+		Eventually(BMCClient.SetSystemBootOrderReferences).WithTimeout(tsparams.TimeoutWaitingOnBMC).
+			WithPolling(tsparams.PollingIntervalBMC).WithArguments(originalBootOrder).ShouldNot(HaveOccurred(),
+			"changing boot order should not return an error")
 
 		By("power cycling node")
 		Eventually(BMCClient.SystemPowerCycle).WithTimeout(tsparams.TimeoutWaitingOnBMC).


### PR DESCRIPTION
In latest tests (new dell platform), reading swapped boot order seems to return wrong value (not swapped) on second boot but looks correct in the bios. So if just reading and swapping back the boot order with lead to no changes (e.g. not swapped -> swapped again).

Instead of reading latest boot order and swapping back and forth, back up original boot order and restore it after testing with swapped boot order. 
