### PR TITLE
system-test: wait for pod to be ready for EgressIP test

### DIFF
--- a/tests/system-tests/rdscore/internal/rdscorecommon/egress-ip.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/egress-ip.go
@@ -324,7 +324,14 @@ func sendTrafficCheckIP(clientPods []*pod.Builder, isIPv6 bool, expectedIPs []st
 	for _, clientPod := range clientPods {
 		var parsedIP string
 
-		err := wait.PollUntilContextTimeout(
+		glog.V(100).Infof("Wait 5 minutes for pod %q to be Ready", clientPod.Definition.Name)
+
+		err := clientPod.WaitUntilReady(5 * time.Minute)
+
+		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Pod %q in %q namespace is not Ready",
+			clientPod.Definition.Name, clientPod.Definition.Namespace))
+
+		err = wait.PollUntilContextTimeout(
 			context.TODO(),
 			time.Second,
 			time.Second*5,


### PR DESCRIPTION
After node is rebooted it takes some time for the pod to start hence extra check is added to ensure pod is `Ready` before trying to execute commands from it.