### PR TITLE
lca ibi: add validation for extra partition

### DIFF
--- a/tests/lca/imagebasedinstall/mgmt/deploy/tests/e2e-deploy-test.go
+++ b/tests/lca/imagebasedinstall/mgmt/deploy/tests/e2e-deploy-test.go
@@ -162,6 +162,30 @@ var _ = Describe(
 				"error: extra manifest configmap has incorrect content")
 		})
 
+		It("successfully creates extra partition", reportxml.ID("79049"), func() {
+			if MGMTConfig.ExtraPartName == "" {
+				Skip("Cluster not configured with extra partition")
+			}
+
+			By("Get spoke client")
+			spokeClient = getSpokeClient()
+
+			By("Validate the value of ExtraPartSizeMib variable")
+			extraPartSizeMibInt, err := strconv.ParseInt(MGMTConfig.ExtraPartSizeMib, 10, 0)
+			Expect(err).ToNot(HaveOccurred(), "failed to convert the extra partition size to int64: %s", err)
+
+			By("Validate size of extra partition")
+			execCmd := "lsblk -o size -b -n " + MGMTConfig.ExtraPartName
+			cmdOutput, err := cluster.ExecCmdWithStdout(spokeClient, execCmd)
+			Expect(err).ToNot(HaveOccurred(), "failed getting the size for extrapartition: %s", err)
+			for _, stdout := range cmdOutput {
+				Expect(strings.ReplaceAll(stdout, "\n", "")).To(Equal(
+					strconv.Itoa(int(extraPartSizeMibInt)*1024*1024)),
+					"error: the extra partition size doesn't match the expected value")
+			}
+
+		})
+
 		It("successfully adds CA bundle", reportxml.ID("77795"), func() {
 			if !MGMTConfig.CABundle {
 				Skip("Cluster not configured with CA bundle")

--- a/tests/lca/imagebasedinstall/mgmt/internal/mgmtconfig/config.go
+++ b/tests/lca/imagebasedinstall/mgmt/internal/mgmtconfig/config.go
@@ -66,10 +66,12 @@ type MGMTConfig struct {
 	SeedClusterInfo  *seedimage.SeedImageContent
 	SSHKeyPath       string `envconfig:"ECO_LCA_IBI_MGMT_SSHKEY_PATH"`
 	PublicSSHKey     string
-	StaticNetworking bool `envconfig:"ECO_LCA_IBI_MGMT_STATIC_NETWORK" default:"false"`
-	ExtraManifests   bool `envconfig:"ECO_LCA_IBI_EXTRA_MANIFESTS" default:"true"`
-	CABundle         bool `envconfig:"ECO_LCA_IBI_CA_BUNDLE" default:"true"`
-	SiteConfig       bool `envconfig:"ECO_LCA_IBI_SITECONFIG" default:"true"`
+	StaticNetworking bool   `envconfig:"ECO_LCA_IBI_MGMT_STATIC_NETWORK" default:"false"`
+	ExtraManifests   bool   `envconfig:"ECO_LCA_IBI_EXTRA_MANIFESTS" default:"true"`
+	CABundle         bool   `envconfig:"ECO_LCA_IBI_CA_BUNDLE" default:"true"`
+	SiteConfig       bool   `envconfig:"ECO_LCA_IBI_SITECONFIG" default:"true"`
+	ExtraPartName    string `envconfig:"ECO_LCA_IBI_MGMT_EXTRA_PARTITION_NAME" default:""`
+	ExtraPartSizeMib string `envconfig:"ECO_LCA_IBI_MGMT_EXTRA_PARTITION_SIZE" default:"50000"`
 }
 
 // NewMGMTConfig returns instance of MGMTConfig type.


### PR DESCRIPTION
The validation includes the presence and size
of the partition provided via argument