### PR TITLE
Import consistency

### DIFF
--- a/tests/accel/upgrade/internal/upgradeparams/vars.go
+++ b/tests/accel/upgrade/internal/upgradeparams/vars.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/openshift-kni/eco-gotests/tests/accel/internal/accelparams"
 	"github.com/openshift-kni/k8sreporter"
-	v1 "github.com/openshift/api/config/v1"
+	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -28,8 +28,8 @@ var (
 	// ReporterCRDsToDump tells to the reporter what CRs to dump.
 	ReporterCRDsToDump = []k8sreporter.CRData{
 		{Cr: &corev1.PodList{}},
-		{Cr: &v1.ClusterOperatorList{}},
-		{Cr: &v1.ClusterVersionList{}},
+		{Cr: &configv1.ClusterOperatorList{}},
+		{Cr: &configv1.ClusterVersionList{}},
 	}
 	trueFlag  = true
 	falseFlag = false

--- a/tests/hw-accel/kmm/internal/kmmparams/kmmvars.go
+++ b/tests/hw-accel/kmm/internal/kmmparams/kmmvars.go
@@ -2,7 +2,7 @@ package kmmparams
 
 import (
 	"github.com/openshift-kni/eco-gotests/tests/hw-accel/internal/hwaccelparams"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 var (
@@ -22,17 +22,17 @@ var (
 	DTKImage = "image-registry.openshift-image-registry.svc:5000/openshift/driver-toolkit"
 
 	trueVar        = true
-	capabilityAll  = []v1.Capability{"ALL"}
+	capabilityAll  = []corev1.Capability{"ALL"}
 	defaultGroupID = int64(3000)
 	defaultUserID  = int64(2000)
 
 	// PrivilegedSC represents a privileged security context definition.
-	PrivilegedSC = &v1.SecurityContext{
+	PrivilegedSC = &corev1.SecurityContext{
 		Privileged:     &trueVar,
 		RunAsGroup:     &defaultGroupID,
 		RunAsUser:      &defaultUserID,
-		SeccompProfile: &v1.SeccompProfile{Type: "RuntimeDefault"},
-		Capabilities: &v1.Capabilities{
+		SeccompProfile: &corev1.SeccompProfile{Type: "RuntimeDefault"},
+		Capabilities: &corev1.Capabilities{
 			Add: capabilityAll,
 		},
 	}

--- a/tests/hw-accel/kmm/mcm/tests/clamav-test.go
+++ b/tests/hw-accel/kmm/mcm/tests/clamav-test.go
@@ -20,7 +20,7 @@ import (
 	. "github.com/openshift-kni/eco-gotests/tests/hw-accel/kmm/internal/kmminittools"
 	"github.com/openshift-kni/eco-gotests/tests/hw-accel/kmm/internal/kmmparams"
 	. "github.com/openshift-kni/eco-gotests/tests/internal/inittools"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("KMM-Hub", Ordered, Label(kmmparams.LabelSuite), func() {
@@ -69,7 +69,7 @@ var _ = Describe("KMM-Hub", Ordered, Label(kmmparams.LabelSuite), func() {
 
 		It("should pass malware testing", reportxml.ID("68376"), func() {
 			By("Obtain KMM images for test")
-			pods, _ := pod.List(APIClient, kmmparams.KmmHubOperatorNamespace, v1.ListOptions{
+			pods, _ := pod.List(APIClient, kmmparams.KmmHubOperatorNamespace, metav1.ListOptions{
 				FieldSelector: "status.phase=Running",
 			})
 

--- a/tests/lca/imagebasedinstall/mgmt/deploy/tests/common.go
+++ b/tests/lca/imagebasedinstall/mgmt/deploy/tests/common.go
@@ -15,7 +15,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/namespace"
 	"github.com/openshift-kni/eco-goinfra/pkg/ocm"
 	"github.com/openshift-kni/eco-goinfra/pkg/schemes/assisted/api/v1beta1"
-	hiveV1 "github.com/openshift-kni/eco-goinfra/pkg/schemes/hive/api/v1"
+	hivev1 "github.com/openshift-kni/eco-goinfra/pkg/schemes/hive/api/v1"
 	"github.com/openshift-kni/eco-goinfra/pkg/schemes/hive/api/v1/none"
 	ibiv1alpha1 "github.com/openshift-kni/eco-goinfra/pkg/schemes/imagebasedinstall/api/hiveextensions/v1alpha1"
 	siteconfigv1alpha1 "github.com/openshift-kni/eco-goinfra/pkg/schemes/siteconfig/v1alpha1"
@@ -26,7 +26,7 @@ import (
 	"github.com/openshift-kni/eco-gotests/tests/lca/imagebasedinstall/mgmt/internal/mgmtparams"
 	"github.com/openshift-kni/eco-gotests/tests/lca/internal/brutil"
 	"gopkg.in/yaml.v3"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sScheme "k8s.io/client-go/kubernetes/scheme"
 
@@ -90,7 +90,7 @@ func createSharedResources() {
 		By("Create configmap for extra manifests namespace")
 
 		extraNamespaceString, err := brutil.NewBackupRestoreObject(
-			extraNamespace.Definition, k8sScheme.Scheme, v1.SchemeGroupVersion).String()
+			extraNamespace.Definition, k8sScheme.Scheme, corev1.SchemeGroupVersion).String()
 		Expect(err).NotTo(HaveOccurred(), "error creating configmap data for extramanifest namespace")
 		_, err = configmap.NewBuilder(
 			APIClient, extraManifestNamespaceConfigmapName, MGMTConfig.Cluster.Info.ClusterName).WithData(map[string]string{
@@ -108,7 +108,7 @@ func createSharedResources() {
 		By("Create configmap for extramanifests configmap")
 
 		extraConfigmapString, err := brutil.NewBackupRestoreObject(
-			extraConfigmap.Definition, k8sScheme.Scheme, v1.SchemeGroupVersion).String()
+			extraConfigmap.Definition, k8sScheme.Scheme, corev1.SchemeGroupVersion).String()
 		Expect(err).NotTo(HaveOccurred(), "error creating configmap data for extramanifest configmap")
 		_, err = configmap.NewBuilder(
 			APIClient, extraManifestConfigmapConfigmapName, MGMTConfig.Cluster.Info.ClusterName).WithData(map[string]string{
@@ -131,7 +131,7 @@ func createSharedResources() {
 		By("Create baremetalhost secret for " + host)
 
 		_, err = secret.NewBuilder(
-			APIClient, host, MGMTConfig.Cluster.Info.ClusterName, v1.SecretTypeOpaque).WithData(map[string][]byte{
+			APIClient, host, MGMTConfig.Cluster.Info.ClusterName, corev1.SecretTypeOpaque).WithData(map[string][]byte{
 			"username": []byte(info.BMC.User),
 			"password": []byte(info.BMC.Password),
 		}).Create()
@@ -168,7 +168,7 @@ func createIBIOResouces(addressFamily string) {
 			Expect(err).NotTo(HaveOccurred(), "error marshaling network configuration")
 
 			_, err = secret.NewBuilder(APIClient, fmt.Sprintf("%s-nmstate-config", host),
-				MGMTConfig.Cluster.Info.ClusterName, v1.SecretTypeOpaque).WithData(map[string][]byte{
+				MGMTConfig.Cluster.Info.ClusterName, corev1.SecretTypeOpaque).WithData(map[string][]byte{
 				"nmstate": networkSecretContent,
 			}).Create()
 			Expect(err).NotTo(HaveOccurred(), "error creating network configuration secret")
@@ -231,12 +231,12 @@ func createIBIOResouces(addressFamily string) {
 	_, err = hive.NewClusterDeploymentByInstallRefBuilder(
 		APIClient, MGMTConfig.Cluster.Info.ClusterName,
 		MGMTConfig.Cluster.Info.ClusterName, MGMTConfig.Cluster.Info.ClusterName,
-		MGMTConfig.Cluster.Info.BaseDomain, hiveV1.ClusterInstallLocalReference{
+		MGMTConfig.Cluster.Info.BaseDomain, hivev1.ClusterInstallLocalReference{
 			Group:   ibiv1alpha1.Group,
 			Version: ibiv1alpha1.Version,
 			Kind:    "ImageClusterInstall",
 			Name:    MGMTConfig.Cluster.Info.ClusterName,
-		}, hiveV1.Platform{
+		}, hivev1.Platform{
 			None: &none.Platform{},
 		}).
 		WithPullSecret(MGMTConfig.Cluster.Info.ClusterName).Create()

--- a/tests/lca/imagebasedinstall/mgmt/deploy/tests/reinstall-test.go
+++ b/tests/lca/imagebasedinstall/mgmt/deploy/tests/reinstall-test.go
@@ -17,7 +17,7 @@ import (
 	siteconfigv1alpha1 "github.com/openshift-kni/eco-goinfra/pkg/schemes/siteconfig/v1alpha1"
 	"github.com/openshift-kni/eco-goinfra/pkg/secret"
 	"github.com/openshift-kni/eco-goinfra/pkg/siteconfig"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openshift-kni/eco-gotests/tests/lca/imagebasedinstall/mgmt/deploy/internal/tsparams"
 	. "github.com/openshift-kni/eco-gotests/tests/lca/imagebasedinstall/mgmt/internal/mgmtinittools"
@@ -71,7 +71,7 @@ var _ = Describe(
 				ibiAdminKubeconfigSecret, err := secret.Pull(APIClient, MGMTConfig.Cluster.Info.ClusterName+"-admin-kubeconfig",
 					MGMTConfig.Cluster.Info.ClusterName)
 				Expect(err).NotTo(HaveOccurred(), "error pulling admin-kubeconfig secret")
-				ibiAdminKubeconfigSecret.Definition.ObjectMeta.CreationTimestamp = v1.Time{}
+				ibiAdminKubeconfigSecret.Definition.ObjectMeta.CreationTimestamp = metav1.Time{}
 				ibiAdminKubeconfigSecret.Definition.ObjectMeta.OwnerReferences = nil
 				ibiAdminKubeconfigSecret.Definition.ObjectMeta.UID = ""
 				ibiAdminKubeconfigSecret.Definition.ObjectMeta.ResourceVersion = ""
@@ -80,7 +80,7 @@ var _ = Describe(
 				ibiAdminPasswordSecret, err := secret.Pull(APIClient, MGMTConfig.Cluster.Info.ClusterName+"-admin-password",
 					MGMTConfig.Cluster.Info.ClusterName)
 				Expect(err).NotTo(HaveOccurred(), "error pulling admin-password secret")
-				ibiAdminPasswordSecret.Definition.ObjectMeta.CreationTimestamp = v1.Time{}
+				ibiAdminPasswordSecret.Definition.ObjectMeta.CreationTimestamp = metav1.Time{}
 				ibiAdminPasswordSecret.Definition.ObjectMeta.OwnerReferences = nil
 				ibiAdminPasswordSecret.Definition.ObjectMeta.UID = ""
 				ibiAdminPasswordSecret.Definition.ObjectMeta.ResourceVersion = ""
@@ -90,7 +90,7 @@ var _ = Describe(
 					APIClient, MGMTConfig.Cluster.Info.ClusterName+"-seed-reconfiguration",
 					MGMTConfig.Cluster.Info.ClusterName)
 				Expect(err).NotTo(HaveOccurred(), "error pulling seed-reconfiguration secret")
-				ibiSeedRecoonfigurationSecret.Definition.ObjectMeta.CreationTimestamp = v1.Time{}
+				ibiSeedRecoonfigurationSecret.Definition.ObjectMeta.CreationTimestamp = metav1.Time{}
 				ibiSeedRecoonfigurationSecret.Definition.ObjectMeta.OwnerReferences = nil
 				ibiSeedRecoonfigurationSecret.Definition.ObjectMeta.UID = ""
 				ibiSeedRecoonfigurationSecret.Definition.ObjectMeta.ResourceVersion = ""

--- a/tests/lca/imagebasedupgrade/cnf/internal/validations/post_ibu_validations.go
+++ b/tests/lca/imagebasedupgrade/cnf/internal/validations/post_ibu_validations.go
@@ -17,7 +17,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/statefulset"
 	"github.com/openshift-kni/eco-gotests/tests/internal/cluster"
 	"github.com/openshift-kni/eco-gotests/tests/lca/internal/seedimage"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openshift-kni/eco-gotests/tests/lca/imagebasedupgrade/cnf/internal/cnfclusterinfo"
 	. "github.com/openshift-kni/eco-gotests/tests/lca/imagebasedupgrade/cnf/internal/cnfinittools"
@@ -120,7 +120,7 @@ func ValidateClusterID() {
 func ValidatePodsSeedName() {
 	It("Validate no pods using seed name", reportxml.ID("71389"), Label("ValidatePodsSeedName"), func() {
 		By("Validate no pods are using seed's name", func() {
-			podList, err := pod.ListInAllNamespaces(TargetSNOAPIClient, v1.ListOptions{})
+			podList, err := pod.ListInAllNamespaces(TargetSNOAPIClient, metav1.ListOptions{})
 			Expect(err).ToNot(HaveOccurred(), "Failed to list pods")
 
 			for _, pod := range podList {

--- a/tests/lca/imagebasedupgrade/cnf/upgrade-talm/internal/tsparams/upgradevars.go
+++ b/tests/lca/imagebasedupgrade/cnf/upgrade-talm/internal/tsparams/upgradevars.go
@@ -2,7 +2,7 @@ package tsparams
 
 import (
 	lcav1 "github.com/openshift-kni/lifecycle-agent/api/imagebasedupgrade/v1"
-	v1 "github.com/openshift/api/config/v1"
+	configv1 "github.com/openshift/api/config/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -44,7 +44,7 @@ var (
 		{Cr: &appsv1.DeploymentList{}},
 		{Cr: &corev1.ServiceList{}},
 		{Cr: &lcav1.ImageBasedUpgradeList{}},
-		{Cr: &v1.ClusterOperatorList{}},
+		{Cr: &configv1.ClusterOperatorList{}},
 	}
 
 	// TargetSnoClusterName is the name of target sno cluster.

--- a/tests/lca/imagebasedupgrade/mgmt/upgrade/internal/tsparams/upgradevars.go
+++ b/tests/lca/imagebasedupgrade/mgmt/upgrade/internal/tsparams/upgradevars.go
@@ -4,7 +4,7 @@ import (
 	"github.com/openshift-kni/eco-gotests/tests/lca/imagebasedupgrade/mgmt/internal/mgmtparams"
 	"github.com/openshift-kni/k8sreporter"
 	lcav1 "github.com/openshift-kni/lifecycle-agent/api/imagebasedupgrade/v1"
-	v1 "github.com/openshift/api/config/v1"
+	configv1 "github.com/openshift/api/config/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -29,6 +29,6 @@ var (
 		{Cr: &appsv1.DeploymentList{}},
 		{Cr: &corev1.ServiceList{}},
 		{Cr: &lcav1.ImageBasedUpgradeList{}},
-		{Cr: &v1.ClusterOperatorList{}},
+		{Cr: &configv1.ClusterOperatorList{}},
 	}
 )

--- a/tests/lca/imagebasedupgrade/mgmt/upgrade/tests/e2e-upgrade-test.go
+++ b/tests/lca/imagebasedupgrade/mgmt/upgrade/tests/e2e-upgrade-test.go
@@ -11,7 +11,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/strings/slices"
 
@@ -120,7 +120,7 @@ var _ = Describe(
 
 				By("Create string from the KMM module namespace definition")
 				kmmNamespaceString, err := brutil.NewBackupRestoreObject(
-					kmmNamespace.Definition, k8sScheme.Scheme, v1.SchemeGroupVersion).String()
+					kmmNamespace.Definition, k8sScheme.Scheme, corev1.SchemeGroupVersion).String()
 				Expect(err).NotTo(HaveOccurred(), "error creating configmap data for KMM namespace")
 
 				By("Create serviceaccount definition for KMM module")
@@ -132,7 +132,7 @@ var _ = Describe(
 
 				By("Create string from the KMM module serviceaccount definition")
 				kmmServiceAccountString, err := brutil.NewBackupRestoreObject(
-					kmmServiceAccount.Definition, k8sScheme.Scheme, v1.SchemeGroupVersion).String()
+					kmmServiceAccount.Definition, k8sScheme.Scheme, corev1.SchemeGroupVersion).String()
 				Expect(err).NotTo(HaveOccurred(), "error creating configmap data for KMM serviceaccount")
 
 				By("Create clusterrolebinding definition for KMM module")
@@ -198,7 +198,7 @@ var _ = Describe(
 
 				By("Create configmap for extra manifests namespace")
 				extraNamespaceString, err := brutil.NewBackupRestoreObject(
-					extraNamespace.Definition, k8sScheme.Scheme, v1.SchemeGroupVersion).String()
+					extraNamespace.Definition, k8sScheme.Scheme, corev1.SchemeGroupVersion).String()
 				Expect(err).NotTo(HaveOccurred(), "error creating configmap data for extramanifest namespace")
 				extraManifestsNamespaceConfigmap, err := configmap.NewBuilder(
 					APIClient, extraManifestNamespaceConfigmapName, mgmtparams.LCANamespace).WithData(map[string]string{
@@ -216,7 +216,7 @@ var _ = Describe(
 
 				By("Create configmap for extramanifests configmap")
 				extraConfigmapString, err := brutil.NewBackupRestoreObject(
-					extraConfigmap.Definition, k8sScheme.Scheme, v1.SchemeGroupVersion).String()
+					extraConfigmap.Definition, k8sScheme.Scheme, corev1.SchemeGroupVersion).String()
 				Expect(err).NotTo(HaveOccurred(), "error creating configmap data for extramanifest configmap")
 				extraManifestsConfigmapConfigmap, err := configmap.NewBuilder(
 					APIClient, extraManifesConfigmapConfigmapName, mgmtparams.LCANamespace).WithData(map[string]string{
@@ -703,10 +703,10 @@ func startTestWorkload() {
 	_, err = deployment.NewBuilder(
 		APIClient, mgmtparams.LCAWorkloadName, mgmtparams.LCAWorkloadName, map[string]string{
 			"app": mgmtparams.LCAWorkloadName,
-		}, v1.Container{
+		}, corev1.Container{
 			Name:  mgmtparams.LCAWorkloadName,
 			Image: MGMTConfig.IBUWorkloadImage,
-			Ports: []v1.ContainerPort{
+			Ports: []corev1.ContainerPort{
 				{
 					Name:          "http",
 					ContainerPort: 8080,
@@ -720,8 +720,8 @@ func startTestWorkload() {
 	_, err = service.NewBuilder(
 		APIClient, mgmtparams.LCAWorkloadName, mgmtparams.LCAWorkloadName, map[string]string{
 			"app": mgmtparams.LCAWorkloadName,
-		}, v1.ServicePort{
-			Protocol: v1.ProtocolTCP,
+		}, corev1.ServicePort{
+			Protocol: corev1.ProtocolTCP,
 			Port:     8080,
 		}).Create()
 	Expect(err).NotTo(HaveOccurred(), "error creating ibu workload service")

--- a/tests/system-tests/internal/imageregistryconfig/imageregistryconfig.go
+++ b/tests/system-tests/internal/imageregistryconfig/imageregistryconfig.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	v1 "github.com/openshift/api/operator/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 
 	"github.com/golang/glog"
 	"github.com/openshift-kni/eco-goinfra/pkg/apiservers"
@@ -21,7 +21,7 @@ var imageRegistryCoName = "image-registry"
 var imageRegistryDeploymentName = "image-registry"
 
 // SetManagementState returns true when succeeded to change imageRegistry operator management state.
-func SetManagementState(apiClient *clients.Settings, expectedManagementState v1.ManagementState) error {
+func SetManagementState(apiClient *clients.Settings, expectedManagementState operatorv1.ManagementState) error {
 	irConfigObj, err := imageregistry.Pull(apiClient, imageRegistryObjName)
 
 	if err != nil {

--- a/tests/system-tests/internal/reboot/reboot.go
+++ b/tests/system-tests/internal/reboot/reboot.go
@@ -11,7 +11,7 @@ import (
 	systemtestsscc "github.com/openshift-kni/eco-gotests/tests/system-tests/internal/scc"
 	. "github.com/openshift-kni/eco-gotests/tests/system-tests/internal/systemtestsinittools"
 	systemtestsparams "github.com/openshift-kni/eco-gotests/tests/system-tests/internal/systemtestsparams"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -36,8 +36,8 @@ func HardRebootNode(nodeName string, nsName string) error {
 		SystemTestsTestConfig.IpmiToolImage, []string{"sleep", "86400"})
 
 	trueVar := true
-	deployContainer = deployContainer.WithSecurityContext(&v1.SecurityContext{Privileged: &trueVar})
-	deployContainer = deployContainer.WithImagePullPolicy(v1.PullAlways)
+	deployContainer = deployContainer.WithSecurityContext(&corev1.SecurityContext{Privileged: &trueVar})
+	deployContainer = deployContainer.WithImagePullPolicy(corev1.PullAlways)
 
 	deployContainerCfg, err := deployContainer.GetContainerCfg()
 	if err != nil {

--- a/tests/system-tests/internal/remote/cmd.go
+++ b/tests/system-tests/internal/remote/cmd.go
@@ -11,7 +11,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-goinfra/pkg/pod"
 	. "github.com/openshift-kni/eco-gotests/tests/system-tests/internal/systemtestsinittools"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -19,7 +19,7 @@ import (
 
 // ExecuteOnNodeWithDebugPod executes a command on a node.
 func ExecuteOnNodeWithDebugPod(cmdToExec []string, nodeName string) (string, error) {
-	listOptions := v1.ListOptions{
+	listOptions := metav1.ListOptions{
 		FieldSelector: fields.SelectorFromSet(fields.Set{"spec.nodeName": nodeName}).String(),
 		LabelSelector: labels.SelectorFromSet(labels.Set{"k8s-app": SystemTestsTestConfig.MCOConfigDaemonName}).String(),
 	}
@@ -60,7 +60,7 @@ func ExecuteOnNodeWithPrivilegedDebugPod(apiClient *clients.Settings,
 	err := wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute, true,
 		func(context.Context) (bool, error) {
 			oldPods, err := pod.List(apiClient, SystemTestsTestConfig.MCONamespace,
-				v1.ListOptions{LabelSelector: podSelector})
+				metav1.ListOptions{LabelSelector: podSelector})
 
 			if err != nil {
 				glog.V(90).Infof("Error listing pods: %v", err)

--- a/tests/system-tests/internal/stability/stability.go
+++ b/tests/system-tests/internal/stability/stability.go
@@ -13,7 +13,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/ocm"
 	"github.com/openshift-kni/eco-goinfra/pkg/pod"
 	"github.com/openshift-kni/eco-gotests/tests/system-tests/internal/ptp"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -67,7 +67,7 @@ func SavePTPStatus(apiClient *clients.Settings, outputFile string, timeInterval 
 
 // SavePodsRestartsInNamespace stores the pod restarts of all pods in a namespace in the outputFile.
 func SavePodsRestartsInNamespace(apiClient *clients.Settings, namespace string, outputFile string) error {
-	podList, err := pod.List(apiClient, namespace, v1.ListOptions{})
+	podList, err := pod.List(apiClient, namespace, metav1.ListOptions{})
 	if err != nil {
 		return err
 	}

--- a/tests/system-tests/rdscore/internal/rdscorecommon/ipvlan-validation.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/ipvlan-validation.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/openshift-kni/eco-gotests/tests/system-tests/rdscore/internal/rdscoreinittools"
 	"github.com/openshift-kni/eco-gotests/tests/system-tests/rdscore/internal/rdscoreparams"
 	multus "gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/types"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -321,7 +321,7 @@ func VerifyIPVLANConnectivityOnSameNode() {
 }
 
 func defineIPVlanDeployment(dName, nsName, dLabels, netDefName, volName string,
-	dContainer *v1.Container,
+	dContainer *corev1.Container,
 	nodeSelector map[string]string) *deployment.Builder {
 	By("Defining deployment configuration")
 
@@ -355,12 +355,12 @@ func defineIPVlanDeployment(dName, nsName, dLabels, netDefName, volName string,
 	volMode := new(int32)
 	*volMode = 511
 
-	volDefinition := v1.Volume{
+	volDefinition := corev1.Volume{
 		Name: "configs",
-		VolumeSource: v1.VolumeSource{
-			ConfigMap: &v1.ConfigMapVolumeSource{
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
 				DefaultMode: volMode,
-				LocalObjectReference: v1.LocalObjectReference{
+				LocalObjectReference: corev1.LocalObjectReference{
 					Name: volName,
 				},
 			},

--- a/tests/system-tests/rdscore/internal/rdscorecommon/macvlan-validation.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/macvlan-validation.go
@@ -8,7 +8,7 @@ import (
 	"github.com/golang/glog"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openshift-kni/eco-goinfra/pkg/deployment"
@@ -366,7 +366,7 @@ func VerifyMACVLANConnectivityOnSameNode() {
 }
 
 func defineMacVlanDeployment(dName, nsName, dLabels, netDefName, volName string,
-	dContainer *v1.Container,
+	dContainer *corev1.Container,
 	nodeSelector map[string]string) *deployment.Builder {
 	By("Defining deployment configuration")
 
@@ -400,12 +400,12 @@ func defineMacVlanDeployment(dName, nsName, dLabels, netDefName, volName string,
 	volMode := new(int32)
 	*volMode = 511
 
-	volDefinition := v1.Volume{
+	volDefinition := corev1.Volume{
 		Name: "configs",
-		VolumeSource: v1.VolumeSource{
-			ConfigMap: &v1.ConfigMapVolumeSource{
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
 				DefaultMode: volMode,
-				LocalObjectReference: v1.LocalObjectReference{
+				LocalObjectReference: corev1.LocalObjectReference{
 					Name: volName,
 				},
 			},

--- a/tests/system-tests/spk/internal/spkcommon/setup-workloads.go
+++ b/tests/system-tests/spk/internal/spkcommon/setup-workloads.go
@@ -8,7 +8,7 @@ import (
 	"github.com/golang/glog"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/openshift-kni/eco-goinfra/pkg/configmap"
 	"github.com/openshift-kni/eco-goinfra/pkg/deployment"
@@ -37,7 +37,7 @@ const (
 	// SPKBackendSVCTargetPort service's target port.
 	SPKBackendSVCTargetPort = int32(8080)
 	// SPKBackendSVCProtocol service's protocol.
-	SPKBackendSVCProtocol = v1.Protocol("TCP")
+	SPKBackendSVCProtocol = corev1.Protocol("TCP")
 	// SPKBackendDeployName deployment's name.
 	SPKBackendDeployName = "spk-hello-world"
 	// SPKBackendContainerName container's name.
@@ -52,7 +52,7 @@ const (
 	// SPKBackendUDPSVCTargetPort service's target port.
 	SPKBackendUDPSVCTargetPort = int32(8080)
 	// SPKBackendUDPSVCProtocol service's protocol.
-	SPKBackendUDPSVCProtocol = v1.Protocol("UDP")
+	SPKBackendUDPSVCProtocol = corev1.Protocol("UDP")
 	// SPKBackendUDPDeployName deployment's name.
 	SPKBackendUDPDeployName = "udp-mock-server"
 	// SPKBackendUDPContainerName container's name.
@@ -179,8 +179,8 @@ func createUDPSVC() {
 
 	By("Setting IPFamily")
 
-	ipFamily := []v1.IPFamily{"IPv4", "IPv6"}
-	ipStackFamily := v1.IPFamilyPolicyPreferDualStack
+	ipFamily := []corev1.IPFamily{"IPv4", "IPv6"}
+	ipStackFamily := corev1.IPFamilyPolicyPreferDualStack
 
 	svcDemo = svcDemo.WithIPFamily(ipFamily, ipStackFamily)
 
@@ -288,11 +288,11 @@ func createBackendDeployment() {
 
 	glog.V(spkparams.SPKLogLevel).Infof("Setting SCC")
 
-	deployContainer = deployContainer.WithSecurityContext(&v1.SecurityContext{RunAsGroup: nil, RunAsUser: nil})
+	deployContainer = deployContainer.WithSecurityContext(&corev1.SecurityContext{RunAsGroup: nil, RunAsUser: nil})
 
 	By("Adding VolumeMount to container")
 
-	volMount := v1.VolumeMount{
+	volMount := corev1.VolumeMount{
 		Name:      "web-page",
 		MountPath: "/opt/rh/httpd24/root/var/www/html",
 		ReadOnly:  false,
@@ -335,12 +335,12 @@ func createBackendDeployment() {
 	volMode := new(int32)
 	*volMode = 511
 
-	volDefinition := v1.Volume{
+	volDefinition := corev1.Volume{
 		Name: "web-page",
-		VolumeSource: v1.VolumeSource{
-			ConfigMap: &v1.ConfigMapVolumeSource{
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
 				DefaultMode: volMode,
-				LocalObjectReference: v1.LocalObjectReference{
+				LocalObjectReference: corev1.LocalObjectReference{
 					Name: SPKBackendCMName,
 				},
 			},
@@ -383,7 +383,7 @@ func createBackendUDPDeployment() {
 
 	glog.V(spkparams.SPKLogLevel).Infof("Setting SCC")
 
-	deployContainer = deployContainer.WithSecurityContext(&v1.SecurityContext{RunAsGroup: nil, RunAsUser: nil})
+	deployContainer = deployContainer.WithSecurityContext(&corev1.SecurityContext{RunAsGroup: nil, RunAsUser: nil})
 
 	By("Obtaining container definition")
 

--- a/tests/system-tests/vcore/internal/vcorecommon/post-deployment-config.go
+++ b/tests/system-tests/vcore/internal/vcorecommon/post-deployment-config.go
@@ -21,7 +21,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/nodes"
 	"github.com/openshift-kni/eco-goinfra/pkg/scc"
 	"github.com/openshift-kni/eco-gotests/tests/system-tests/internal/imageregistryconfig"
-	v1 "github.com/openshift/api/operator/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 
 	"github.com/golang/glog"
 	. "github.com/onsi/ginkgo/v2"
@@ -57,7 +57,7 @@ func VerifyPostDeploymentConfig() {
 func VerifyImageRegistryManagementStateEnablement(ctx SpecContext) {
 	glog.V(vcoreparams.VCoreLogLevel).Infof("Enable local imageregistryconfig; change ManagementState to the Managed")
 
-	err := imageregistryconfig.SetManagementState(APIClient, v1.Managed)
+	err := imageregistryconfig.SetManagementState(APIClient, operatorv1.Managed)
 	Expect(err).ToNot(HaveOccurred(),
 		fmt.Sprintf("Failed to change imageRegistry state to the Managed; %v", err))
 


### PR DESCRIPTION
Makes sure that imports are using a more descriptive name than `v1`.

Similar to:
- https://github.com/openshift-kni/eco-goinfra/pull/921
- https://github.com/openshift-kni/eco-goinfra/pull/239
- https://github.com/openshift-kni/eco-goinfra/pull/387
- https://github.com/openshift-kni/eco-goinfra/pull/694
- https://github.com/openshift-kni/eco-goinfra/pull/711