### PR TITLE
Remove GO111MODULE flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,6 @@
 BASE_IMG ?= eco-gotests
 BASE_TAG ?= latest
 
-# Export GO111MODULE=on to enable project to be built from within GOPATH/src
-export GO111MODULE=on
 GO_PACKAGES=$(shell go list ./... | grep -v vendor)
 .PHONY: lint \
         deps-update \


### PR DESCRIPTION
`GO111MODULE` is no longer needed and was deprecated in Go 1.16 and the flag is completely ignored in Go 1.17.

https://go.dev/blog/go116-module-changes