### PR TITLE
assisted ztp: get hub API client through ZTPConfig

### DIFF
--- a/tests/assisted/ztp/internal/ztpinittools/ztpinittools.go
+++ b/tests/assisted/ztp/internal/ztpinittools/ztpinittools.go
@@ -3,7 +3,6 @@ package ztpinittools
 import (
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-gotests/tests/assisted/ztp/internal/ztpconfig"
-	"github.com/openshift-kni/eco-gotests/tests/internal/inittools"
 )
 
 var (
@@ -16,7 +15,7 @@ var (
 )
 
 func init() {
-	HubAPIClient = inittools.APIClient
 	ZTPConfig = ztpconfig.NewZTPConfig()
+	HubAPIClient = ZTPConfig.HubAPIClient
 	SpokeAPIClient = ZTPConfig.SpokeAPIClient
 }


### PR DESCRIPTION
- Updates ztpinittools to collect hub API client from ZTPConfig rather than through inittools directly
- Helps in recovering from errors during hub environment initialization