### PR TITLE
infra: add actions dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+# dependabot config
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This PR just copies the dependabot config Brandon added in openshift-kni/eco-goinfra#240 to keep our actions up to date.