### PR TITLE
system-test: increase timeout while executing command

### DIFF
--- a/tests/system-tests/rdscore/internal/rdscorecommon/egress-ip.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/egress-ip.go
@@ -333,8 +333,8 @@ func sendTrafficCheckIP(clientPods []*pod.Builder, isIPv6 bool, expectedIPs []st
 
 		err = wait.PollUntilContextTimeout(
 			context.TODO(),
-			time.Second,
 			time.Second*5,
+			time.Minute*1,
 			true,
 			func(ctx context.Context) (bool, error) {
 				result, err := clientPod.ExecCommand(cmdToRun, clientPod.Object.Spec.Containers[0].Name)


### PR DESCRIPTION
Invoked command has a timeout of 5 seconds, `--connect-timeout 5`, therefor extending timeout of the retry block to 1 minute