### PR TITLE
system-test: use node that holds IPv6 EgresIP address

### DIFF
--- a/tests/system-tests/rdscore/internal/rdscorecommon/egress-ip.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/egress-ip.go
@@ -659,10 +659,14 @@ func getNodeForReboot(isIPv6 bool) (string, string, error) {
 	egressIPMap, err := getEgressIPMap()
 
 	if err != nil {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to retrieve egressIP map due to %w", err)
+
 		return "", "", fmt.Errorf("failed to retrieve egressIP map due to %w", err)
 	}
 
 	for egressIPNode, egressIPValue := range egressIPMap {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("IP %q is assigned to %q", egressIPValue, egressIPNode)
+
 		myIP, err := netip.ParseAddr(egressIPValue)
 
 		if err != nil {
@@ -672,6 +676,8 @@ func getNodeForReboot(isIPv6 bool) (string, string, error) {
 		}
 
 		if !isIPv6 && myIP.Is4() || isIPv6 && myIP.Is6() {
+			glog.V(100).Infof("Selected node %q with IP %q address", egressIPNode, egressIPValue)
+
 			return egressIPValue, egressIPNode, nil
 		}
 	}
@@ -697,7 +703,7 @@ func verifyEgressIPFailOver(isIPv6 bool) {
 
 	By("Execute graceful node reboot")
 
-	egressIPUnderTest, nodeNameForReboot, err := getNodeForReboot(false)
+	egressIPUnderTest, nodeNameForReboot, err := getNodeForReboot(isIPv6)
 	Expect(err).ToNot(HaveOccurred(),
 		fmt.Sprintf("Failed to find a valid node for reboot: %v", err))
 
@@ -705,7 +711,9 @@ func verifyEgressIPFailOver(isIPv6 bool) {
 	Expect(err).ToNot(HaveOccurred(),
 		fmt.Sprintf("Failed to retrieve egressIP map due to: %v", err))
 
-	glog.V(100).Infof("Retrieve available for EgressIP assignment node")
+	glog.V(100).Infof("Retrieved EgressIP map:\n%v\n", egressIPMap)
+
+	glog.V(100).Infof("Retrieve node available for EgressIP assignment")
 
 	var nodeNameForVerification string
 
@@ -714,9 +722,14 @@ func verifyEgressIPFailOver(isIPv6 bool) {
 		RDSCoreConfig.EgressIPNodeTwo,
 		RDSCoreConfig.EgressIPNodeThree} {
 		_, nodeUsed := egressIPMap[nodeName]
+		glog.V(100).Infof("Processing node: %q", nodeName)
 
 		if !nodeUsed {
+			glog.V(100).Infof("Node %q is not used by EgressIP", nodeName)
+
 			nodeNameForVerification = nodeName
+
+			break
 		}
 	}
 
@@ -727,11 +740,17 @@ func verifyEgressIPFailOver(isIPv6 bool) {
 	Expect(err).ToNot(HaveOccurred(),
 		fmt.Sprintf("Failed to reboot node %s: %v", nodeNameForReboot, err))
 
+	By("Refreshing EgressIP configuration after node reboot")
+
 	egressIPMap, err = getEgressIPMap()
+
 	Expect(err).ToNot(HaveOccurred(),
-		fmt.Sprintf("Failed to retrieve new egressIP map due to: %v", err))
+		fmt.Sprintf("Failed to retrieve new EgressIP map due to: %v", err))
+
+	glog.V(100).Infof("Refreshed EgressIP map:\n%v\n", egressIPMap)
+
 	Expect(egressIPMap[nodeNameForVerification]).To(Equal(egressIPUnderTest),
-		fmt.Sprintf("Released egressIP %s was not assigned to the node %s",
+		fmt.Sprintf("Released EgressIP %s was not assigned to the node %s",
 			egressIPUnderTest, nodeNameForVerification))
 
 	By("Verify egressIP connectivity after egressIP fail-over")


### PR DESCRIPTION
When invoking _verifyEgressIPFailOver_ method pass its _isIPv6_ parameter to the inner call to `getNodeForReboot` method.

So when testing IPv6 failover node that holds IPv6 address of _EgressIP CR_ is used

At the same time added extra logging to make troubleshooting easier.