### PR TITLE
report: add rest of report program

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,6 +58,7 @@ linters-settings:
         - "gopkg.in/yaml.v3"
         - "gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/types"
         - "golang.org/x/crypto/ssh"
+        - "github.com/klauspost/compress/zstd"
   wsl:
     strict-append: false
   gofmt:

--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 	open-cluster-management.io/config-policy-controller v0.15.0
 	open-cluster-management.io/governance-policy-propagator v0.15.0
 	open-cluster-management.io/multicloud-operators-subscription v0.15.0
+	github.com/klauspost/compress v1.17.11
 	sigs.k8s.io/controller-runtime v0.19.5
 )
 
@@ -143,7 +144,6 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kdomanski/iso9660 v0.2.1 // indirect
-	github.com/klauspost/compress v1.17.11 // indirect
 	github.com/kube-object-storage/lib-bucket-provisioner v0.0.0-20221122204822-d1a8c34382f1 // indirect
 	github.com/lib/pq v1.10.9 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect

--- a/internal/report/cache.go
+++ b/internal/report/cache.go
@@ -1,0 +1,460 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/golang/glog"
+	"github.com/klauspost/compress/zstd"
+)
+
+const (
+	cacheDir  = "eco-gotests"
+	remoteURL = "https://github.com/openshift-kni/eco-gotests.git"
+)
+
+var (
+	errCacheMiss = fmt.Errorf("cache miss")
+)
+
+// IsMiss returns true if the given error is a cache miss error and false otherwise.
+func IsMiss(err error) bool {
+	return errors.Is(err, errCacheMiss)
+}
+
+// CacheKey holds the information necessary to index the cached trees. Using both the branch and revision allows for
+// easily verifying if the tree cached for a given branch is current.
+type CacheKey struct {
+	Branch   string
+	Revision string
+}
+
+// Cache represents the format of the cache file. It will be saved as JSON according to the XDG base directory
+// specification.
+type Cache struct {
+	Trees     map[CacheKey]*SuiteTree
+	directory string
+	ctx       context.Context
+}
+
+// NewCacheContext creates a new cache instance. It will attempt to load the cache from the cache file. If the file does
+// not exist, a new cache will be created but not saved until Save is called.
+func NewCacheContext(ctx context.Context) (*Cache, error) {
+	glog.V(100).Info("Instantiating new Cache and attempting to load")
+
+	cache := &Cache{
+		Trees: make(map[CacheKey]*SuiteTree),
+		ctx:   ctx,
+	}
+
+	err := cache.Load()
+	if err != nil {
+		return nil, err
+	}
+
+	return cache, nil
+}
+
+// CleanCache cleans the existing cache on disk by removing the entire eco-gotests cache directory.
+func CleanCache() error {
+	cache := &Cache{ctx: context.TODO()}
+
+	cachePath, err := cache.getDirectory()
+	if err != nil {
+		return err
+	}
+
+	glog.V(100).Infof("Deleting cache directory at %s", cachePath)
+
+	err = os.RemoveAll(cachePath)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Load will attempt to load all regular files from the cache directory then update the cache if necessary. It tries to
+// ignore files that may cause an error. It will return early on errors, leaving the cache in an invalid state until
+// Update is called.
+func (cache *Cache) Load() error {
+	cachePath, err := cache.getDirectory()
+	if err != nil {
+		return err
+	}
+
+	glog.V(100).Infof("Loading cache from %s", cachePath)
+
+	if sourceCodeSum == "" {
+		glog.V(100).Info("Unable to retrieve source code sum. Cache entries cannot be verified and will not be loaded.")
+
+		return nil
+	}
+
+	cacheDirEntries, err := os.ReadDir(cachePath)
+	if err != nil {
+		glog.V(100).Info("Unable to access cache directory. Cache entries will not be loaded.")
+
+		return nil
+	}
+
+	for _, dirEntry := range cacheDirEntries {
+		glog.V(100).Infof("Considering loading cache from %s", dirEntry.Name())
+
+		// We only ever create regular files, so all other files should be ignored.
+		if !dirEntry.Type().IsRegular() {
+			glog.V(100).Infof("Not going to load cache from %s because it is not a regular file", dirEntry.Name())
+
+			continue
+		}
+
+		key, sum := parseCacheFileName(dirEntry.Name())
+		if sum != sourceCodeSum {
+			continue
+		}
+
+		tree, err := loadCacheFile(filepath.Join(cachePath, dirEntry.Name()))
+		if err != nil {
+			return err
+		}
+
+		cache.Trees[key] = tree
+	}
+
+	return cache.Update()
+}
+
+// Save saves the cache to the cache directory, returning early on any errors.
+func (cache *Cache) Save() error {
+	if sourceCodeSum == "" {
+		glog.V(100).Info("Unable to retrieve source code sum. Cache entries will not be saved.")
+
+		return nil
+	}
+
+	cachePath, err := cache.getDirectory()
+	if err != nil {
+		return err
+	}
+
+	glog.V(100).Infof("Saving cache with %d trees to %s", len(cache.Trees), cachePath)
+
+	err = os.MkdirAll(cachePath, 0755)
+	if err != nil {
+		return err
+	}
+
+	err = cache.deleteExpiredFiles()
+	if err != nil {
+		return err
+	}
+
+	for key, tree := range cache.Trees {
+		err := saveCacheFile(filepath.Join(cachePath, generateCacheFileName(key)), tree)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// GetRemotePatterns fetches the branches from the remote repository that match patterns. For each match, the branch and
+// revision are concatenated and used as the key in the returned map. If the match was present in the cache, then its
+// value is the cached SuiteTree. If the match was not present in the cache, its value is nil. All matches will appear
+// in the returned map.
+func (cache *Cache) GetRemotePatterns(patterns []string) (map[CacheKey]*SuiteTree, error) {
+	glog.V(100).Infof("Checking if branches matching patterns %v are in cache", patterns)
+
+	if sourceCodeSum == "" {
+		glog.V(100).Info("Unable to retrieve source code sum. All cache lookups will miss.")
+
+		return nil, errCacheMiss
+	}
+
+	revisions, err := GetRemoteRevisions(cache.ctx, remoteURL, slices.Values(patterns))
+	if err != nil {
+		return nil, err
+	}
+
+	cachedTrees := make(map[CacheKey]*SuiteTree)
+
+	for branch, revision := range revisions {
+		key := CacheKey{Branch: branch, Revision: revision}
+
+		tree, ok := cache.Trees[key]
+		if !ok {
+			cachedTrees[key] = nil
+		} else {
+			cachedTrees[key] = tree
+		}
+	}
+
+	return cachedTrees, nil
+}
+
+// Get returns the suite tree for the given repo path from the cache. It returns a cache miss error if the repo has
+// uncommitted changes or if the cache does not contain the repo.
+func (cache *Cache) Get(repoPath string) (*SuiteTree, error) {
+	glog.V(100).Infof("Getting cache for repo %s", repoPath)
+
+	if sourceCodeSum == "" {
+		glog.V(100).Info("Unable to retrieve source code sum. All cache lookups will miss.")
+
+		return nil, errCacheMiss
+	}
+
+	key, err := cache.GetKeyFromPath(repoPath)
+	if err != nil {
+		return nil, err
+	}
+
+	tree, ok := cache.Trees[key]
+	if !ok {
+		return nil, errCacheMiss
+	}
+
+	return tree, nil
+}
+
+// GetOrCreate returns the suite tree for the given repo path from the cache. It first calls Get and if there is a cache
+// miss, it calls the given create function and adds the result to the cache. Note that if the repo has local changes,
+// the create function will always be called, but the result will not be added to the cache.
+func (cache *Cache) GetOrCreate(repoPath string) (*SuiteTree, error) {
+	glog.V(100).Infof("Getting or creating cache for repo %s", repoPath)
+
+	tree, err := cache.Get(repoPath)
+	if err == nil {
+		return tree, nil
+	}
+
+	if !IsMiss(err) {
+		return nil, err
+	}
+
+	glog.V(100).Infof("Cache miss for repo %s, dry running on repo", repoPath)
+
+	reportPath, err := DryRun(cache.ctx, repoPath)
+	if err != nil {
+		glog.V(100).Infof("Failed to run eco-gotests dry-run: %v", err)
+
+		return nil, err
+	}
+
+	tree, err = NewFromFile(reportPath)
+	if err != nil {
+		glog.V(100).Infof("Failed to create SuiteTree from report.json: %v", err)
+
+		return nil, err
+	}
+
+	_ = os.Remove(reportPath)
+
+	key, err := cache.GetKeyFromPath(repoPath)
+	if err == nil {
+		cache.Trees[key] = tree
+	} else {
+		glog.V(100).Infof("Failed to get cache key for repo %s, created tree not saved", repoPath)
+	}
+
+	return tree, nil
+}
+
+// Update iterates through all the cached trees and deletes any that are out of date. Entries are considered out of
+// date when the branch name and hash do not match the remote repo or when the checksum does not match this module's
+// checksum.
+func (cache *Cache) Update() error {
+	glog.V(100).Info("Updating cache and removing out of date entries")
+
+	if sourceCodeSum == "" {
+		glog.V(100).Info(
+			"Unable to retrieve source code sum. All cache entries will be removed as their validity cannot be verified.")
+
+		cache.Trees = make(map[CacheKey]*SuiteTree)
+
+		return nil
+	}
+
+	cachedRevisions := make(map[string]string)
+
+	for key := range cache.Trees {
+		cachedRevisions[key.Branch] = key.Revision
+	}
+
+	remoteRevisions, err := GetRemoteRevisions(cache.ctx, remoteURL, maps.Keys(cachedRevisions))
+	if err != nil {
+		return err
+	}
+
+	for cachedBranch, cachedRevision := range cachedRevisions {
+		remoteRevision, ok := remoteRevisions[cachedBranch]
+		if ok && cachedRevision == remoteRevision {
+			continue
+		}
+
+		delete(cache.Trees, CacheKey{Branch: cachedBranch, Revision: cachedRevision})
+	}
+
+	return nil
+}
+
+// GetKeyFromPath returns the cache file name that corresponds to the repo at repoPath. It returns a cache miss error if
+// the repo has uncommitted changes and a different error if no source code sum is available.
+func (cache *Cache) GetKeyFromPath(repoPath string) (CacheKey, error) {
+	glog.V(100).Infof("Getting cache key for repo %s", repoPath)
+
+	changes, err := HasLocalChanges(cache.ctx, repoPath)
+	if err != nil {
+		return CacheKey{}, err
+	}
+
+	if changes {
+		glog.V(100).Infof("Repo %s has uncommitted changes, cache will always miss", repoPath)
+
+		return CacheKey{}, errCacheMiss
+	}
+
+	branch, err := GetRepoBranch(cache.ctx, repoPath)
+	if err != nil {
+		return CacheKey{}, err
+	}
+
+	revision, err := GetRepoRevision(cache.ctx, repoPath)
+	if err != nil {
+		return CacheKey{}, err
+	}
+
+	return CacheKey{Branch: branch, Revision: revision}, nil
+}
+
+// getDirectory returns the stored directory for this cache if it exists, otherwise it uses a subdirectory of the
+// OS-specific user cache directory. If the user cache directory does not exist, it returns an error.
+func (cache *Cache) getDirectory() (string, error) {
+	if cache.directory != "" {
+		return cache.directory, nil
+	}
+
+	userCache, err := os.UserCacheDir()
+	if err != nil {
+		return "", err
+	}
+
+	cachePath := filepath.Join(userCache, cacheDir)
+
+	return cachePath, nil
+}
+
+// deleteExpiredFiles will delete all regular files in the cache directory that are not included in the current cache.
+// It returns early on any error deleting files.
+func (cache *Cache) deleteExpiredFiles() error {
+	cachePath, err := cache.getDirectory()
+	if err != nil {
+		return err
+	}
+
+	glog.V(100).Infof("Deleting expired cache files from %s", cachePath)
+
+	cacheDirEntries, err := os.ReadDir(cachePath)
+	if err != nil {
+		return err
+	}
+
+	for _, dirEntry := range cacheDirEntries {
+		// We only create regular files so avoid deleting anything not created by us.
+		if !dirEntry.Type().IsRegular() {
+			continue
+		}
+
+		key, sum := parseCacheFileName(dirEntry.Name())
+
+		_, keyFound := cache.Trees[key]
+		if keyFound && sum == sourceCodeSum {
+			continue
+		}
+
+		err := os.RemoveAll(dirEntry.Name())
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// saveCacheFile saves the tree at the path provided by cacheFileName, truncating if the file already exists.
+func saveCacheFile(cacheFileName string, tree *SuiteTree) error {
+	glog.V(100).Infof("Saving cached tree to %s", cacheFileName)
+
+	file, err := os.Create(cacheFileName)
+	if err != nil {
+		return err
+	}
+
+	defer file.Close()
+
+	compressor, err := zstd.NewWriter(file)
+	if err != nil {
+		return err
+	}
+
+	defer compressor.Close()
+
+	err = json.NewEncoder(compressor).Encode(tree)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// loadCacheFile attempts to load a SuiteTree from cacheFileName.
+func loadCacheFile(cacheFileName string) (*SuiteTree, error) {
+	glog.V(100).Infof("Loading cached tree from %s", cacheFileName)
+
+	file, err := os.Open(cacheFileName)
+	if err != nil {
+		return nil, err
+	}
+
+	defer file.Close()
+
+	decompressor, err := zstd.NewReader(file)
+	if err != nil {
+		return nil, err
+	}
+
+	tree := &SuiteTree{}
+	err = json.NewDecoder(decompressor).Decode(tree)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tree, nil
+}
+
+// generateCacheFileName takes the parameters and generates the corresponding cache file name. It guarantees that the
+// name consists of branch, revision, and sum joined by spaces. The extension should be considered opaque.
+func generateCacheFileName(key CacheKey) string {
+	return fmt.Sprintf("%s %s %s.json.zstd", key.Branch, key.Revision, sourceCodeSum)
+}
+
+// parseCacheFileName takes the cacheFileName and extracts the branch, revision, and sum. It is guaranteed to be the
+// inverse of generateCacheFileName. For an invalid cacheFileName, all returns will be empty.
+func parseCacheFileName(cacheFileName string) (key CacheKey, sum string) {
+	withoutExtension, _ := strings.CutSuffix(cacheFileName, ".json.zstd")
+	fields := strings.Fields(withoutExtension)
+
+	if len(fields) != 3 {
+		return CacheKey{}, ""
+	}
+
+	return CacheKey{Branch: fields[0], Revision: fields[1]}, fields[2]
+}

--- a/internal/report/main.go
+++ b/internal/report/main.go
@@ -1,0 +1,283 @@
+/*
+Report is a tool to generate a report of the test suites in a Ginkgo test suite. It will print a tree of the test suites
+and the number of specs in each suite. If an output directory is provided, a static site for visualizing the test suites
+will be generated.
+
+Upon successful generation of the report the exit code is 0. If any error occurs it will be logged to stderr and the
+exit code will be 1.
+
+Usage:
+
+	report [flags]
+
+The flags are:
+
+	-h, -help
+		Print this help message
+
+	-a, -action-url string
+		URL to the action generating this report. Only necessary with -o. Uses "/" if left blank
+
+	-b, -branch string
+		Space-separated list of globs to match branches. Leave blank to use the local directory
+
+	-c, -clean
+		Delete the test suite cache and exit without running
+
+	-o, -output string
+		Directory to output static site to. Will not be generated if left blank
+
+	-v int
+		Log level verbosity for glog. Use 100 for logging all messages or leave blank for none
+*/
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"html/template"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+)
+
+var (
+	help      bool
+	actionURL string
+	branch    string
+	clean     bool
+	output    string
+)
+
+//nolint:gochecknoinits // This is a main package so init is fine.
+func init() {
+	const (
+		helpUsage      = "Print this help message"
+		actionURLUsage = "URL to the action generating this report. Only necessary with -o. Uses \"/\" if left blank"
+		branchUsage    = "Space-separated list of globs to match branches. Leave blank to use the local directory"
+		cleanUsage     = "Delete the test suite cache and exit without running"
+		outputUsage    = "Directory to output static site to. Will not be generated if left blank"
+
+		defaultHelp      = false
+		defaultActionURL = "/"
+		defaultBranch    = ""
+		defaultClean     = false
+		defaultOutput    = ""
+
+		shorthand = " (shorthand)"
+	)
+
+	flag.BoolVar(&help, "help", defaultHelp, helpUsage)
+	flag.BoolVar(&help, "h", defaultHelp, helpUsage+shorthand)
+
+	flag.StringVar(&actionURL, "action-url", defaultActionURL, actionURLUsage)
+	flag.StringVar(&actionURL, "a", defaultActionURL, actionURLUsage+shorthand)
+
+	flag.StringVar(&branch, "branch", defaultBranch, branchUsage)
+	flag.StringVar(&branch, "b", defaultBranch, branchUsage+shorthand)
+
+	flag.BoolVar(&clean, "clean", defaultClean, cleanUsage)
+	flag.BoolVar(&clean, "c", defaultClean, cleanUsage+shorthand)
+
+	flag.StringVar(&output, "output", defaultOutput, outputUsage)
+	flag.StringVar(&output, "o", defaultOutput, outputUsage+shorthand)
+}
+
+func main() {
+	// Also send glog messages to stderr
+	_ = flag.Lookup("logtostderr").Value.Set("true")
+
+	flag.Parse()
+
+	if help {
+		flag.Usage()
+
+		return
+	}
+
+	if clean {
+		err := CleanCache()
+		if err != nil {
+			glog.Errorf("Failed to clean cache: %v", err)
+
+			os.Exit(1)
+		}
+
+		return
+	}
+
+	treeMap, err := getTrees(branch)
+	if err != nil {
+		glog.Errorf("Failed to get suite trees when branch=\"%s\": %v", branch, err)
+
+		os.Exit(1)
+	}
+
+	printTreeMap(treeMap)
+
+	if output != "" {
+		err := templateTreeMap(treeMap, output)
+		if err != nil {
+			glog.Errorf("Failed to template tree map and save to %s: %v", output, err)
+
+			os.Exit(1)
+		}
+	}
+}
+
+func getTrees(branch string) (map[CacheKey]*SuiteTree, error) {
+	ctx, cancel := signal.NotifyContext(context.TODO(), os.Interrupt, os.Kill)
+	defer cancel()
+
+	cache, err := NewCacheContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var treeMap map[CacheKey]*SuiteTree
+
+	if branch != "" {
+		patterns := strings.Fields(branch)
+		treeMap, err = getFromCacheOrClone(ctx, cache, patterns)
+	} else {
+		treeMap, err = getLocalTreeMap(cache, ".")
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = cache.Save()
+	if err != nil {
+		return nil, err
+	}
+
+	for key, tree := range treeMap {
+		treeMap[key] = tree.TrimRoot()
+		treeMap[key].Sort(true)
+	}
+
+	return treeMap, nil
+}
+
+func printTreeMap(treeMap map[CacheKey]*SuiteTree) {
+	for key, tree := range treeMap {
+		fmt.Println("---")
+		fmt.Printf("Branch %s (%s)\n", key.Branch, key.Revision[:7])
+		fmt.Print(tree)
+	}
+}
+
+func templateTreeMap(treeMap map[CacheKey]*SuiteTree, output string) error {
+	err := os.MkdirAll(output, 0755)
+	if err != nil {
+		return err
+	}
+
+	var branchReports []BranchReportConfig
+
+	for key, tree := range treeMap {
+		config := TreeTemplateConfig{
+			Tree:       tree,
+			Generated:  time.Now(),
+			Branch:     key.Branch,
+			ActionURL:  template.URL(actionURL),
+			RepoURL:    "https://github.com/openshift-kni/eco-gotests",
+			TimeFormat: time.RFC3339,
+		}
+		outputFileName := fmt.Sprintf("report_%s.html", key.Branch)
+		outputFilePath := filepath.Join(output, outputFileName)
+
+		err := TemplateTree(config, outputFilePath)
+		if err != nil {
+			return err
+		}
+
+		branchReport := BranchReportConfig{
+			Name:          key.Branch,
+			ReportFile:    outputFileName,
+			Revision:      key.Revision,
+			ShortRevision: key.Revision[:7],
+		}
+		branchReports = append(branchReports, branchReport)
+	}
+
+	config := ReportTemplateConfig{
+		BranchReports: branchReports,
+		Generated:     time.Now(),
+		ActionURL:     template.URL(actionURL),
+		RepoURL:       "https://github.com/openshift-kni/eco-gotests",
+		TimeFormat:    time.RFC3339,
+	}
+	outputFilePath := filepath.Join(output, "report.html")
+
+	err = TemplateReport(config, outputFilePath)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getLocalTreeMap(cache *Cache, repoPath string) (map[CacheKey]*SuiteTree, error) {
+	tree, err := cache.GetOrCreate(repoPath)
+	if err != nil {
+		glog.Errorf("Failed to get or create SuiteTree from cache: %v", err)
+
+		return nil, err
+	}
+
+	key, err := cache.GetKeyFromPath(repoPath)
+	if IsMiss(err) {
+		treeMap := map[CacheKey]*SuiteTree{{Branch: "local", Revision: "local"}: tree}
+
+		return treeMap, nil
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	treeMap := map[CacheKey]*SuiteTree{key: tree}
+
+	return treeMap, nil
+}
+
+func getFromCacheOrClone(ctx context.Context, cache *Cache, patterns []string) (map[CacheKey]*SuiteTree, error) {
+	treeMap, err := cache.GetRemotePatterns(patterns)
+	if err != nil {
+		return nil, err
+	}
+
+	tempDir := os.TempDir()
+	if _, err = os.Stat(tempDir); err != nil {
+		return nil, fmt.Errorf("unable to access temp dir to clone repo: %w", err)
+	}
+
+	for key, tree := range treeMap {
+		if tree != nil {
+			continue
+		}
+
+		repoPath, err := CloneRepo(ctx, tempDir, remoteURL, key.Branch)
+		if err != nil {
+			return nil, err
+		}
+
+		tree, err := cache.GetOrCreate(repoPath)
+		if err != nil {
+			glog.Errorf("Failed to get or create SuiteTree from cache: %v", err)
+
+			return nil, err
+		}
+
+		treeMap[key] = tree
+	}
+
+	return treeMap, nil
+}

--- a/internal/report/sum.go
+++ b/internal/report/sum.go
@@ -1,4 +1,3 @@
-//nolint:unused // Until the next PR merges, this file is unused.
 package main
 
 import (


### PR DESCRIPTION
Depends-on: #446

This PR contains the rest of the report program. It includes the last two files not part of the last PR:

* `cache.go`: Caches the trees generated from each branch and revision combination. Since a dry-run may take many minutes, caching allows the program to remain performant and responsive to changes in the templates without having to redo a dry-run.
* `main.go`: Handles the command line flags and actual running of the program. It handles retrieving values from the cache or cloning and dry running as necessary.

There are some small changes to the lint config and go.mod to allow the cache to be compressed. It uses a package already vendored so does not include additional dependencies. Compression is beneficial since the cache for the main branch alone may be over a megabyte in size but only ~40 KB when compressed.

Excluded from this PR is the GitHub workflow to actually generate the report along with some high-level documentation.

---

This is PR 3/4. An example report can be seen on [my GitHub pages](https://klaskosk.github.io/eco-gotests/report.html).