### PR TITLE
global: update WaitForRecover to use new method

### DIFF
--- a/tests/cnf/ran/talm/internal/setup/setup.go
+++ b/tests/cnf/ran/talm/internal/setup/setup.go
@@ -2,7 +2,6 @@ package setup
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/openshift-kni/eco-goinfra/pkg/namespace"
 	"github.com/openshift-kni/eco-goinfra/pkg/pod"
@@ -56,8 +55,7 @@ func VerifyTalmIsInstalled() error {
 
 	// Check each pod for the talm container
 	for _, talmPod := range talmPods {
-		err := talmPod.WaitUntilHealthy(0*time.Second, true, false, true)
-		if err != nil {
+		if !talmPod.IsHealthy() {
 			return fmt.Errorf("talm pod %s is not healthy", talmPod.Definition.Name)
 		}
 

--- a/tests/internal/cluster/cluster.go
+++ b/tests/internal/cluster/cluster.go
@@ -277,8 +277,7 @@ func WaitForRecover(client *clients.Settings, namespaces []string, timeout time.
 		return err
 	}
 
-	err = pod.WaitForAllPodsInNamespacesHealthy(client, namespaces, timeout,
-		true, false, true, []string{GeneralConfig.LoggingOperatorNamespace})
+	err = pod.WaitForPodsInNamespacesHealthy(client, namespaces, timeout)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This is part 1 of a 3 part effort to replace pod.WaitForAllPodsInNamespacesHealthy.

1. (openshift-kni/eco-goinfra#928) Add new helpers to eco-goinfra that simplify waiting for pods healthy and list on every iteration.
2. (This PR) Change the cluster.WaitForRecover function to use the new eco-goinfra helpers. Also a small change in cnf/ran/talm.
3. Remove the old helpers from eco-goinfra.

Motivation:

The old WaitForRecover function would list the pods each iteration, ensuring that pods started after calling the function will be checked as well as ignoring pods that later end up deleted. A workaround for the latter of these issues was merged in openshift-kni/eco-goinfra#808.

Additionally, the current pod.WaitForAllPodsInNamespacesHealthy has too many parameters and is hard to test properly. The current unit tests for it do not adequately cover all scenarios. This function only gets used in one place in eco-gotests, the aforementioned cluster.WaitForRecover, where many parameters will always be the same.