### PR TITLE
ci: run eco-goinfra bump for all branches

### DIFF
--- a/.github/workflows/bump-all-branches.yml
+++ b/.github/workflows/bump-all-branches.yml
@@ -1,0 +1,51 @@
+name: Bump eco-goinfra on all branches
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+permissions:
+  contents: read
+    
+jobs:
+  branches:
+    outputs:
+      branches: ${{ steps.intersect-branches.outputs.branches }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: List eco-gotests branches
+        id: gotests-branches
+        run: echo "branches=$(gh api repos/openshift-kni/eco-gotests/branches -q '[.[].name] | map(select(test("main|release-.*"))) | @json')" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: List eco-goinfra branches
+        id: goinfra-branches
+        run: echo "branches=$(gh api repos/openshift-kni/eco-goinfra/branches -q '[.[].name] | map(select(test("main|release-.*"))) | @json')" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Intersect eco-gotests and eco-goinfra branches
+        id: intersect-branches
+        run: echo "branches=$(echo $GOTESTS_BRANCHES $GOINFRA_BRANCHES | jq -sc '.[0] - (.[0] - .[1])')" >> $GITHUB_OUTPUT
+        env:
+          GOTESTS_BRANCHES: ${{ steps.gotests-branches.outputs.branches }}
+          GOINFRA_BRANCHES: ${{ steps.goinfra-branches.outputs.branches }}
+
+  bump:
+    needs: [branches]
+
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ${{ fromJson(needs.branches.outputs.branches) }}
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    uses: ./.github/workflows/eco-goinfra-bump.yml
+    with:
+      branch: ${{ matrix.branch }}

--- a/.github/workflows/eco-goinfra-bump.yml
+++ b/.github/workflows/eco-goinfra-bump.yml
@@ -1,13 +1,24 @@
 name: 'Eco-GoInfra Module Bump'
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 0 * * *"
+    inputs:
+      branch:
+        description: Branch to bump eco-goinfra on
+        required: true
+        default: main
+        type: string
+  workflow_call:
+    inputs:
+      branch:
+        description: Branch to bump eco-goinfra on
+        required: true
+        default: main
+        type: string
 permissions:
   contents: read
 jobs:
   main:
-    name: Eco-goinfra module bump
+    name: Eco-goinfra module bump on ${{ inputs.branch }}
 
     permissions:
       contents: write  # for peter-evans/create-pull-request to create branch
@@ -22,6 +33,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
 
       - name: Set up Go 1.23
         uses: actions/setup-go@v5
@@ -29,7 +42,10 @@ jobs:
           go-version: 1.23.6
 
       - name: Run sync script
-        run: make sync-eco-goinfra
+        run: |
+          go get github.com/openshift-kni/eco-goinfra@${{ inputs.branch }} &&
+          go mod tidy &&
+          go mod vendor
 
       - name: Create PR
         id: create-pr
@@ -39,18 +55,27 @@ jobs:
         with:
           commit-message: "deps: bump github.com/openshift-kni/eco-goinfra"
           author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
-          title: Bump eco-goinfra dependency
+          title: Bump eco-goinfra dependency on ${{ inputs.branch }}
+          base: ${{ inputs.branch }}
           branch: eco-goinfra-bump
           delete-branch: true
           reviewers: achuzhoy,cdvultur,klaskosk,kononovn,trewest
 
   ci:
-    needs: main
+    needs: [main]
+    # Only run the CI if the action created a PR to save time when the version
+    # is already up-to-date.
+    if: ${{ needs.main.result == 'success' && needs.main.outputs.pr-url }}
+    
     uses: ./.github/workflows/makefile.yml
+    with:
+      branch: ${{ inputs.branch }}
 
   label:
     needs: [main, ci]
-    if: ${{ needs.main.result == 'success' && needs.main.outputs.pr-url }}
+    # Only label the PR if the CI actually ran. This also handles the case when
+    # a PR is not created.
+    if: ${{ contains(fromJson('["success", "failure"]'), needs.ci.result) }}
 
     name: Label created PR
 
@@ -61,6 +86,7 @@ jobs:
 
     steps:
       - name: Label PR based on CI result
-        run: gh pr edit ${{ needs.main.outputs.pr-url }} --add-label ci/${{ needs.ci.result }}
+        run: gh pr edit ${{ needs.main.outputs.pr-url }} --add-label ci/$CI_RESULT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CI_RESULT: ${{ needs.ci.result == 'success' && 'success' || 'failure' }}

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -2,6 +2,12 @@ name: Makefile CI
 
 on:
   workflow_call:
+    inputs:
+      branch:
+        description: Branch to run Makefile CI against
+        required: true
+        default: main
+        type: string
 
   workflow_dispatch:
 
@@ -25,6 +31,8 @@ jobs:
           go-version: 1.23.6
 
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_call' && inputs.branch || github.sha }}
 
       - name: Run lint
         run: make lint


### PR DESCRIPTION
This PR updates the existing eco-goinfra-bump to take a branch input and remove the schedule. Instead, a new workflow has been added on a schedule that gets all branches on both eco-gotests and eco-goinfra and runs the bump against branches that exist on both. Since the setup-go action caches automatically, runs against branches with no need to bump will be fast (<30 seconds).

[Example run](https://github.com/klaskosk/eco-gotests/actions/runs/13467685849/job/37636771757), the failure is just because all the reviewers aren't members of my fork