### PR TITLE
ci: run lint and dry-run/tests in parallel

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -13,21 +13,34 @@ on:
       - 'release-\d.\d\d'
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     env:
       SHELL: /bin/bash
 
     steps:
-      - name: Set up Go 1.22
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.6
-
-      - uses: actions/checkout@v4
+          go-version-file: go.mod
 
       - name: Run lint
         run: make lint
+
+  test:
+    runs-on: ubuntu-latest
+    env:
+      SHELL: /bin/bash
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
 
       - name: Install
         run: make install-ginkgo


### PR DESCRIPTION
Similar to openshift-kni/eco-goinfra#743, this PR splits out the linting from the rest of the makefile CI. This should cut the time in half.

Also switches over to using go.mod to get the go version, that way we do not introduce another place where the version needs to be updated.