### PR TITLE
lint,cnf ran: enable ginkgo linter for cnf/ran

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -91,6 +91,12 @@ linters-settings:
     checks:
       - all
       - ST1001
+  ginkgolinter:
+    forbid-focus-container: true
+    force-expect-to: true
+    validate-async-intervals: true
+    forbid-spec-pollution: true
+    force-succeed: true
 
 linters:
   disable:
@@ -106,6 +112,7 @@ linters:
     - exhaustive
     - forcetypeassert
     - funlen
+    - ginkgolinter
     - gochecknoinits
     - gocognit
     - goconst
@@ -159,7 +166,9 @@ issues:
     - EXC0014  # EXC0014 revive: Annoying issue about not having a comment. The rare codebase has such comments
   exclude-rules:
     #- # Exclude some linters from running on tests files.
-
+    - path-except: tests/cnf/ran
+      linters:
+        - ginkgolinter
     - path: 'tests/internal/inittools'
       linters:
         - gochecknoinits

--- a/tests/cnf/ran/containernshide/tests/containernshide.go
+++ b/tests/cnf/ran/containernshide/tests/containernshide.go
@@ -32,9 +32,9 @@ var _ = Describe("Container Namespace Hiding", Label(tsparams.LabelContainerNSHi
 			ranparam.RetryInterval, "readlink /proc/$(pidof crio)/ns/mnt")
 		Expect(err).ToNot(HaveOccurred(), "Failed to check crio inodes")
 
-		Expect(len(systemdInodes)).To(Equal(len(kubeletInodes)),
+		Expect(systemdInodes).To(HaveLen(len(kubeletInodes)),
 			"Collected systemd inodes from different number of nodes than kubelet inodes")
-		Expect(len(systemdInodes)).To(Equal(len(crioInodes)),
+		Expect(systemdInodes).To(HaveLen(len(crioInodes)),
 			"Collected systemd inodes from different number of nodes than crio inodes")
 
 		for host, systemdInode := range systemdInodes {

--- a/tests/cnf/ran/gitopsztp/tests/ztp-argocd-node-delete.go
+++ b/tests/cnf/ran/gitopsztp/tests/ztp-argocd-node-delete.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/gomega"
 	"github.com/openshift-kni/eco-goinfra/pkg/bmh"
 	"github.com/openshift-kni/eco-goinfra/pkg/mco"
@@ -18,9 +19,8 @@ import (
 
 var _ = Describe("ZTP Argo CD Node Deletion Tests", Label(tsparams.LabelArgoCdNodeDeletionTestCases), func() {
 	var (
-		plusOneNodeName   string
-		bmhNamespace      string
-		earlyReturnNonSNO = true
+		plusOneNodeName string
+		bmhNamespace    string
 	)
 
 	BeforeEach(func() {
@@ -40,8 +40,6 @@ var _ = Describe("ZTP Argo CD Node Deletion Tests", Label(tsparams.LabelArgoCdNo
 			Skip("Cluster does not contain a single control plane and a single worker node")
 		}
 
-		earlyReturnNonSNO = false
-
 		By("checking that the 'worker' mcp is ready")
 		mcp, err := mco.Pull(Spoke1APIClient, "worker")
 		Expect(err).ToNot(HaveOccurred(), "Failed to pull 'worker' MCP")
@@ -56,7 +54,7 @@ var _ = Describe("ZTP Argo CD Node Deletion Tests", Label(tsparams.LabelArgoCdNo
 	})
 
 	AfterEach(func() {
-		if earlyReturnNonSNO {
+		if CurrentSpecReport().State.Is(types.SpecStateSkipped) {
 			return
 		}
 

--- a/tests/cnf/ran/gitopsztp/tests/ztp-cluster-instance-delete.go
+++ b/tests/cnf/ran/gitopsztp/tests/ztp-cluster-instance-delete.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/gomega"
 
 	"github.com/openshift-kni/eco-goinfra/pkg/assisted"
@@ -27,8 +28,6 @@ import (
 
 var _ = Describe("ZTP Siteconfig Operator's Cluster Instance Delete Tests",
 	Label(tsparams.LabelClusterInstanceDeleteTestCases), func() {
-		var earlyReturnSkip = true
-
 		// These tests use the hub and spoke architecture.
 		BeforeEach(func() {
 			By("verifying that ZTP meets the minimum version")
@@ -41,7 +40,7 @@ var _ = Describe("ZTP Siteconfig Operator's Cluster Instance Delete Tests",
 		})
 
 		AfterEach(func() {
-			if earlyReturnSkip {
+			if CurrentSpecReport().State.Is(types.SpecStateSkipped) {
 				return
 			}
 
@@ -88,8 +87,6 @@ var _ = Describe("ZTP Siteconfig Operator's Cluster Instance Delete Tests",
 			if spokeClusterType == ranparam.SNOCluster {
 				Skip("This test only applies to standard or multi-node openshift spoke cluster")
 			}
-
-			earlyReturnSkip = false
 
 			// Test step 1-Delete default assisted installer template reference ConfigMap CRs after spoke cluster installed.
 			By("deleting default assisted installer template reference ConfigMap custom resources")
@@ -193,7 +190,6 @@ var _ = Describe("ZTP Siteconfig Operator's Cluster Instance Delete Tests",
 				Skip(err.Error())
 			}
 
-			earlyReturnSkip = false
 			Expect(err).ToNot(HaveOccurred(), "Failed to update Argo CD clusters app with new git path")
 
 			// Test step 1 expected results validation.

--- a/tests/cnf/ran/gitopsztp/tests/ztp-siteconfig-day-two.go
+++ b/tests/cnf/ran/gitopsztp/tests/ztp-siteconfig-day-two.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/gomega"
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/gitopsztp/internal/gitdetails"
@@ -15,8 +16,6 @@ import (
 
 var _ = Describe("ZTP Siteconfig Operator's Day 2 configuration Test",
 	Label(tsparams.LabelSiteconfigDayTwoConfigTestCase), func() {
-		var earlyReturnSkip = true
-
 		// These tests use the hub and spoke architecture.
 		BeforeEach(func() {
 			By("verifying that ZTP meets the minimum version")
@@ -26,11 +25,10 @@ var _ = Describe("ZTP Siteconfig Operator's Day 2 configuration Test",
 			if !versionInRange {
 				Skip("ZTP Siteconfig operator tests require ZTP 4.17 or later")
 			}
-
 		})
 
 		AfterEach(func() {
-			if earlyReturnSkip {
+			if CurrentSpecReport().State.Is(types.SpecStateSkipped) {
 				return
 			}
 
@@ -79,7 +77,6 @@ var _ = Describe("ZTP Siteconfig Operator's Day 2 configuration Test",
 					Skip(err.Error())
 				}
 
-				earlyReturnSkip = false
 				Expect(err).ToNot(HaveOccurred(), "Failed to update Argo CD clusters app with new git path")
 
 				// Make sure the ClusterInstance CR on hub cluster updated with newly added cluster label.

--- a/tests/cnf/ran/powermanagement/internal/tsparams/consts.go
+++ b/tests/cnf/ran/powermanagement/internal/tsparams/consts.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	performancev2 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v2"
 )
 
 const (
@@ -17,6 +18,11 @@ const (
 	PowerSaveTimeout = 10 * time.Minute
 	// TestingNamespace is the tests namespace.
 	TestingNamespace = "ran-test"
+
+	// DesiredReservedCoreFreq is the frequency to set the reserved cores to.
+	DesiredReservedCoreFreq = performancev2.CPUfrequency(2500002)
+	// DesiredIsolatedCoreFreq is the frequency to set the isolated cores to.
+	DesiredIsolatedCoreFreq = performancev2.CPUfrequency(2200002)
 
 	// PowerSavingMode is the name of the power saving power state.
 	PowerSavingMode = "powersaving"

--- a/tests/cnf/ran/powermanagement/tests/cpufreq.go
+++ b/tests/cnf/ran/powermanagement/tests/cpufreq.go
@@ -19,14 +19,13 @@ import (
 	performancev2 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v2"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/cpuset"
+	"k8s.io/utils/ptr"
 )
 
 var _ = Describe("CPU frequency tuning tests change the core frequencies of isolated and reserved cores",
 	Label(tsparams.LabelCPUFrequency), func() {
 		var (
 			perfProfile             *nto.Builder
-			desiredReservedCoreFreq = performancev2.CPUfrequency(2500002)
-			desiredIsolatedCoreFreq = performancev2.CPUfrequency(2200002)
 			originalIsolatedCPUFreq performancev2.CPUfrequency
 			originalReservedCPUFreq performancev2.CPUfrequency
 			err                     error
@@ -71,7 +70,8 @@ var _ = Describe("CPU frequency tuning tests change the core frequencies of isol
 					Skip("OCP 4.16 or higher required for this test")
 				}
 
-				err = helper.SetCPUFreq(perfProfile, &desiredIsolatedCoreFreq, &desiredReservedCoreFreq)
+				err = helper.SetCPUFreq(
+					perfProfile, ptr.To(tsparams.DesiredIsolatedCoreFreq), ptr.To(tsparams.DesiredReservedCoreFreq))
 				Expect(err).ToNot(HaveOccurred(), "Failed to set CPU Freq")
 
 			})

--- a/tests/cnf/ran/powermanagement/tests/powersave.go
+++ b/tests/cnf/ran/powermanagement/tests/powersave.go
@@ -40,7 +40,10 @@ var _ = Describe("Per-core runtime power states tuning", Label(tsparams.LabelPow
 	BeforeAll(func() {
 		nodeList, err = nodes.List(Spoke1APIClient)
 		Expect(err).ToNot(HaveOccurred(), "Failed to get nodes")
-		Expect(len(nodeList)).To(Equal(1), "Currently only SNO clusters are supported")
+
+		if len(nodeList) != 1 {
+			Skip("Power save tests require a SNO cluster")
+		}
 
 		nodeName = nodeList[0].Object.Name
 		perfProfile, err = helper.GetPerformanceProfileWithCPUSet()

--- a/tests/cnf/ran/talm/tests/talm-precache.go
+++ b/tests/cnf/ran/talm/tests/talm-precache.go
@@ -388,10 +388,6 @@ var _ = Describe("TALM precache", Label(tsparams.LabelPreCacheTestCases), func()
 	})
 
 	When("there are multiple spokes and one turns off", Ordered, ContinueOnFailure, func() {
-		var (
-			talmCompleteLabel = "talmcomplete"
-		)
-
 		BeforeAll(func() {
 			clusters := []*clients.Settings{HubAPIClient, Spoke1APIClient, Spoke2APIClient}
 			for index, cluster := range clusters {
@@ -477,7 +473,7 @@ var _ = Describe("TALM precache", Label(tsparams.LabelPreCacheTestCases), func()
 				By("updating CGU to add afterCompletion action")
 				cguBuilder.Definition.Spec.Actions = v1alpha1.Actions{
 					AfterCompletion: &v1alpha1.AfterCompletion{
-						AddClusterLabels: map[string]string{talmCompleteLabel: ""},
+						AddClusterLabels: map[string]string{tsparams.TalmCompleteLabel: ""},
 					},
 				}
 
@@ -495,7 +491,7 @@ var _ = Describe("TALM precache", Label(tsparams.LabelPreCacheTestCases), func()
 				Expect(errorList).To(BeEmpty(), "Failed to clean up test resources on hub")
 
 				By("deleting label from managed cluster")
-				err := helper.DeleteClusterLabel(HubAPIClient, RANConfig.Spoke2Name, talmCompleteLabel)
+				err := helper.DeleteClusterLabel(HubAPIClient, RANConfig.Spoke2Name, tsparams.TalmCompleteLabel)
 				Expect(err).ToNot(HaveOccurred(), "Failed to delete label from managed cluster")
 			})
 
@@ -514,12 +510,12 @@ var _ = Describe("TALM precache", Label(tsparams.LabelPreCacheTestCases), func()
 			// 59946 - Post completion action on a per cluster basis
 			It("verifies CGU afterCompletion action executes on spoke2 when spoke1 is offline", reportxml.ID("59946"), func() {
 				By("checking spoke 2 for post-action label present")
-				labelPresent, err := helper.DoesClusterLabelExist(HubAPIClient, RANConfig.Spoke2Name, talmCompleteLabel)
+				labelPresent, err := helper.DoesClusterLabelExist(HubAPIClient, RANConfig.Spoke2Name, tsparams.TalmCompleteLabel)
 				Expect(err).ToNot(HaveOccurred(), "Failed to check if spoke 2 has post-action label")
 				Expect(labelPresent).To(BeTrue(), "Cluster post-action label was not present on spoke 2")
 
 				By("checking spoke 1 for post-action label not present")
-				labelPresent, err = helper.DoesClusterLabelExist(HubAPIClient, RANConfig.Spoke1Name, talmCompleteLabel)
+				labelPresent, err = helper.DoesClusterLabelExist(HubAPIClient, RANConfig.Spoke1Name, tsparams.TalmCompleteLabel)
 				Expect(err).ToNot(HaveOccurred(), "Failed to check if cluster post-action label exists on spoke 1")
 				Expect(labelPresent).To(BeFalse(), "Cluster post-action label was present on spoke 1")
 			})


### PR DESCRIPTION
This PR enables the ginkgo linter from golangci-lint but restricts it to the cnf/ran subdirectory. Since this linter covers many conventions that have been mostly enforced through code review in cnf/ran it is useful to have it enabled. However, it can be fairly strict so it has been left to teams to opt-in to using it.