### PR TITLE
cnf ran: fix edge case that causes nil prBuilder

### DIFF
--- a/tests/cnf/ran/oran/tests/oran-post-provision.go
+++ b/tests/cnf/ran/oran/tests/oran-post-provision.go
@@ -47,6 +47,10 @@ var _ = Describe("ORAN Post-provision Tests", Label(tsparams.LabelPostProvision)
 		powerState, err := BMCClient.SystemPowerState()
 		Expect(err).ToNot(HaveOccurred(), "Failed to get system power state from spoke 1 BMC")
 
+		By("pulling the ProvisioningRequest again to ensure it is valid")
+		prBuilder, err = oran.PullPR(HubAPIClient, tsparams.TestPRName)
+		Expect(err).ToNot(HaveOccurred(), "Failed to pull the ProvisioningRequest again")
+
 		By("restoring the original ProvisioningRequest spec")
 		prBuilder.Definition.Spec = *originalPRSpec
 		prBuilder = updatePRUntilNoConflict(prBuilder)


### PR DESCRIPTION
In certain tests, the prBuilder is set then used again in AfterEach without being pulled again. When the test fails calling a function that sets prBuilder, this can lead to prBuilder being set to nil with no way to clean up after the tests. This PR addresses the issue by always pulling prBuilder in the AfterEach block.