### PR TITLE
cnf network: update frr namespace

### DIFF
--- a/tests/cnf/core/network/internal/netconfig/config.go
+++ b/tests/cnf/core/network/internal/netconfig/config.go
@@ -26,6 +26,7 @@ type NetworkConfig struct {
 	CnfNetTestContainer     string `yaml:"cnf_net_test_container" envconfig:"ECO_CNF_CORE_NET_TEST_CONTAINER"`
 	DpdkTestContainer       string `yaml:"dpdk_test_container" envconfig:"ECO_CNF_CORE_NET_DPDK_TEST_CONTAINER"`
 	MlbOperatorNamespace    string `yaml:"metal_lb_operator_namespace" envconfig:"ECO_CNF_CORE_NET_MLB_OPERATOR_NAMESPACE"`
+	Frrk8sNamespace         string `yaml:"frr-k8s_namespace" envconfig:"ECO_CNF_CORE_NET_FRR-K8S_NAMESPACE"`
 	CnfMcpLabel             string `yaml:"cnf_mcp_label" envconfig:"ECO_CNF_CORE_NET_CNF_MCP_LABEL"`
 	MultusNamesapce         string `yaml:"multus_namespace" envconfig:"ECO_CNF_CORE_NET_MULTUS_NAMESPACE"`
 	SwitchUser              string `envconfig:"ECO_CNF_CORE_NET_SWITCH_USER"`

--- a/tests/cnf/core/network/internal/netconfig/default.yaml
+++ b/tests/cnf/core/network/internal/netconfig/default.yaml
@@ -3,6 +3,7 @@
 cnf_net_test_container: quay.io/ocp-edge-qe/eco-gotests-network-client:v4.15.2
 dpdk_test_container: quay.io/ocp-edge-qe/eco-gotests-rootless-dpdk:v4.15.0
 metal_lb_operator_namespace: metallb-system
+frr-k8s_namespace: openshift-frr-k8s
 multus_namespace: openshift-multus
 prometheus_operator_namespace: openshift-monitoring
 frr_image: quay.io/ocp-edge-qe/frr:stable_7.5

--- a/tests/cnf/core/network/internal/netparam/const.go
+++ b/tests/cnf/core/network/internal/netparam/const.go
@@ -19,6 +19,8 @@ const (
 	IPSubnet64 = "64"
 	// IPSubnet32 represents prefix 32 ipv4 subnet.
 	IPSubnet32 = "32"
+	// IPSubnetInt32 represents prefix 32 ipv4 subnet.
+	IPSubnetInt32 = 32
 	// LogLevelDebug represents log level debug.
 	LogLevelDebug = "debug"
 )

--- a/tests/cnf/core/network/metallb/internal/metallbenv/metallbenv.go
+++ b/tests/cnf/core/network/metallb/internal/metallbenv/metallbenv.go
@@ -118,7 +118,7 @@ func CreateNewMetalLbDaemonSetAndWaitUntilItsRunning(timeout time.Duration, node
 	glog.V(90).Infof("Verifying if the FRR webhook server is deployed and ready")
 
 	// Check FRR Webhook Server Readiness **(LAST STEP)**
-	frrk8sWebhookDeployment, err := deployment.Pull(APIClient, tsparams.FrrK8WebHookServer, NetConfig.MlbOperatorNamespace)
+	frrk8sWebhookDeployment, err := deployment.Pull(APIClient, tsparams.FrrK8WebHookServer, NetConfig.Frrk8sNamespace)
 	if err != nil {
 		return fmt.Errorf("failed to pull the frrk8s webhook server: %w", err)
 	}

--- a/tests/cnf/core/network/metallb/internal/prometheus/prometheus.go
+++ b/tests/cnf/core/network/metallb/internal/prometheus/prometheus.go
@@ -26,7 +26,6 @@ type metric struct {
 // PodMetricsPresentInDB returns true if the given metrics are present for the given pod in a prometheus database.
 func PodMetricsPresentInDB(prometheusPod *pod.Builder, podName string, uniqueMetricKeys []string) (bool, error) {
 	for _, metricsKey := range uniqueMetricKeys {
-		metricsKey = strings.Replace(metricsKey, "frrk8s", "metallb", 1)
 		metricFound := false
 		command := []string{
 			"curl",

--- a/tests/cnf/core/network/metallb/internal/tsparams/consts.go
+++ b/tests/cnf/core/network/metallb/internal/tsparams/consts.go
@@ -34,6 +34,8 @@ const (
 	BGPTestPeer = "testpeer"
 	// FrrK8WebHookServer is the web hook server running in namespace metallb-system.
 	FrrK8WebHookServer = "frr-k8s-webhook-server"
+	// MetallbServiceName is the name of the metallb service.
+	MetallbServiceName = "service-1"
 	// BlockBGPBFDPorts adds an input rule blocking TCP & UDP ports for BGP and BFD.
 	// chain custom_chain_INPUT {
 	//    type filter hook input priority 1; policy accept;

--- a/tests/cnf/core/network/metallb/tests/bgp-connect-time-tests.go
+++ b/tests/cnf/core/network/metallb/tests/bgp-connect-time-tests.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openshift-kni/eco-gotests/tests/cnf/core/network/internal/define"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/core/network/internal/frrconfig"
 	. "github.com/openshift-kni/eco-gotests/tests/cnf/core/network/internal/netinittools"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/core/network/internal/netparam"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/core/network/metallb/internal/frr"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/core/network/metallb/internal/metallbenv"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/core/network/metallb/internal/tsparams"
@@ -65,11 +66,9 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelBGPTestCases), ContinueOnFa
 		err := metallbenv.CreateNewMetalLbDaemonSetAndWaitUntilItsRunning(tsparams.DefaultTimeout, workerLabelMap)
 		Expect(err).ToNot(HaveOccurred(), "Failed to recreate metalLb daemonset")
 
-		By("Collecting information before test")
-		frrk8sPods, err = pod.List(APIClient, NetConfig.MlbOperatorNamespace, metav1.ListOptions{
-			LabelSelector: tsparams.FRRK8sDefaultLabel,
-		})
-		Expect(err).ToNot(HaveOccurred(), "Failed to list frr pods")
+		By("Verifying that the frrk8sPod deployment is in Ready state and create a list of the pods on " +
+			"worker nodes.")
+		frrk8sPods = verifyAndCreateFRRk8sPodList()
 	})
 
 	AfterEach(func() {
@@ -101,8 +100,8 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelBGPTestCases), ContinueOnFa
 		reportxml.ID("74414"), func() {
 
 			By("Creating BGP Peers with 10 second retry connect timer")
-			createBGPPeerAndVerifyIfItsReady(tsparams.BGPTestPeer, ipv4metalLbIPList[0], "",
-				64500, false, 10, frrk8sPods)
+			createBGPPeerAndVerifyIfItsReady(tsparams.BgpPeerName1, ipv4metalLbIPList[0], "",
+				tsparams.LocalBGPASN, false, 10, frrk8sPods)
 
 			By("Validate BGP Peers with 10 second retry connect timer")
 			Eventually(func() int {
@@ -123,8 +122,8 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelBGPTestCases), ContinueOnFa
 			frrPod := createAndDeployFRRPod()
 
 			By("Creating BGP Peers with 10 second retry connect timer")
-			createBGPPeerAndVerifyIfItsReady(tsparams.BGPTestPeer, ipv4metalLbIPList[0], "",
-				64500, false, 10, frrk8sPods)
+			createBGPPeerAndVerifyIfItsReady(tsparams.BgpPeerName1, ipv4metalLbIPList[0], "",
+				tsparams.LocalBGPASN, false, 10, frrk8sPods)
 
 			By("Validate BGP Peers with 10 second retry connect timer")
 			Eventually(func() int {
@@ -149,8 +148,8 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelBGPTestCases), ContinueOnFa
 		reportxml.ID("74417"), func() {
 
 			By("Creating BGP Peers")
-			createBGPPeerAndVerifyIfItsReady(tsparams.BGPTestPeer, ipv4metalLbIPList[0], "",
-				64500, false, 0, frrk8sPods)
+			createBGPPeerAndVerifyIfItsReady(tsparams.BgpPeerName1, ipv4metalLbIPList[0], "",
+				tsparams.LocalBGPASN, false, 0, frrk8sPods)
 
 			By("Validate BGP Peers with the default retry connect timer")
 			Eventually(func() int {
@@ -164,7 +163,7 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelBGPTestCases), ContinueOnFa
 				"Failed to fetch BGP connect time")
 
 			By("Update the BGP Peers connect timer to 10 seconds")
-			bgpPeer, err := metallb.PullBGPPeer(APIClient, "testpeer", NetConfig.MlbOperatorNamespace)
+			bgpPeer, err := metallb.PullBGPPeer(APIClient, tsparams.BgpPeerName1, NetConfig.MlbOperatorNamespace)
 			Expect(err).ToNot(HaveOccurred(), "Failed to find bgp peer")
 
 			_, err = bgpPeer.WithConnectTime(metav1.Duration{Duration: 10 * time.Second}).Update(true)
@@ -192,7 +191,8 @@ func createAndDeployFRRPod() *pod.Builder {
 	By("Creating static ip annotation")
 
 	staticIPAnnotation := pod.StaticIPAnnotation(
-		frrconfig.ExternalMacVlanNADName, []string{fmt.Sprintf("%s/%s", ipv4metalLbIPList[0], "24")})
+		frrconfig.ExternalMacVlanNADName, []string{fmt.Sprintf("%s/%s", ipv4metalLbIPList[0],
+			netparam.IPSubnet24)})
 
 	By("Creating MetalLb configMap")
 

--- a/tests/cnf/core/network/metallb/tests/bgp-remote-as-dynamic.go
+++ b/tests/cnf/core/network/metallb/tests/bgp-remote-as-dynamic.go
@@ -135,10 +135,7 @@ var _ = Describe("BGP remote-dynamicAS", Ordered, Label(tsparams.LabelDynamicRem
 
 			AfterEach(func() {
 				By("Removing static routes from the speakers")
-				frrk8sPods, err := pod.List(APIClient, NetConfig.MlbOperatorNamespace, metav1.ListOptions{
-					LabelSelector: tsparams.FRRK8sDefaultLabel,
-				})
-				Expect(err).ToNot(HaveOccurred(), "Failed to list pods")
+				frrk8sPods := verifyAndCreateFRRk8sPodList()
 
 				speakerRoutesMap, err := netenv.BuildRoutesMapWithSpecificRoutes(frrk8sPods, workerNodeList,
 					[]string{ipv4metalLbIPList[0], ipv4metalLbIPList[1], frrNodeSecIntIPv4Addresses[0],
@@ -240,10 +237,7 @@ func setupBGPRemoteASTestCase(hubIPv4ExternalAddresses, externalAdvertisedIPv4Ro
 
 	By("Collect connection information for the Frr Node pods")
 
-	frrk8sPods, err := pod.List(APIClient, NetConfig.MlbOperatorNamespace, metav1.ListOptions{
-		LabelSelector: tsparams.FRRK8sDefaultLabel,
-	})
-	Expect(err).ToNot(HaveOccurred(), "Failed to list frr pods")
+	frrk8sPods := verifyAndCreateFRRk8sPodList()
 
 	By("Collect connection information for the Frr external pod")
 
@@ -266,10 +260,8 @@ func setupBGPRemoteASMultiHopTest(ipv4metalLbIPList, hubIPv4ExternalAddresses, e
 
 	By("Collecting information before test")
 
-	frrk8sPods, err := pod.List(APIClient, NetConfig.MlbOperatorNamespace, metav1.ListOptions{
-		LabelSelector: tsparams.FRRK8sNodeLabel,
-	})
-	Expect(err).ToNot(HaveOccurred(), "Failed to list frrk8 pods")
+	frrk8sPods := verifyAndCreateFRRk8sPodList()
+
 	By("Setting test parameters")
 
 	masterClientPodIP, _, _, nodeAddrList, _, _, err :=
@@ -291,15 +283,15 @@ func setupBGPRemoteASMultiHopTest(ipv4metalLbIPList, hubIPv4ExternalAddresses, e
 
 	hub0BRstaticIPAnnotation := frrconfig.CreateStaticIPAnnotations(frrconfig.ExternalMacVlanNADName,
 		tsparams.HubMacVlanNADName,
-		[]string{fmt.Sprintf("%s/24", ipv4metalLbIPList[0])},
-		[]string{fmt.Sprintf("%s/24", hubIPv4ExternalAddresses[0])})
+		[]string{fmt.Sprintf("%s/%s", ipv4metalLbIPList[0], netparam.IPSubnet24)},
+		[]string{fmt.Sprintf("%s/%s", hubIPv4ExternalAddresses[0], netparam.IPSubnet24)})
 
 	By("Creating static ip annotation for hub1")
 
 	hub1BRstaticIPAnnotation := frrconfig.CreateStaticIPAnnotations(frrconfig.ExternalMacVlanNADName,
 		tsparams.HubMacVlanNADName,
-		[]string{fmt.Sprintf("%s/24", ipv4metalLbIPList[1])},
-		[]string{fmt.Sprintf("%s/24", hubIPv4ExternalAddresses[1])})
+		[]string{fmt.Sprintf("%s/%s", ipv4metalLbIPList[1], netparam.IPSubnet24)},
+		[]string{fmt.Sprintf("%s/%s", hubIPv4ExternalAddresses[1], netparam.IPSubnet24)})
 
 	By("Creating MetalLb Hub pod configMap")
 

--- a/tests/cnf/core/network/metallb/tests/frrk8-tests.go
+++ b/tests/cnf/core/network/metallb/tests/frrk8-tests.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -9,23 +8,24 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/openshift-kni/eco-goinfra/pkg/configmap"
-	"github.com/openshift-kni/eco-goinfra/pkg/daemonset"
 	"github.com/openshift-kni/eco-goinfra/pkg/metallb"
 	"github.com/openshift-kni/eco-goinfra/pkg/nmstate"
 	"github.com/openshift-kni/eco-goinfra/pkg/nodes"
 	"github.com/openshift-kni/eco-goinfra/pkg/pod"
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/core/network/internal/cmd"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/core/network/internal/define"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/core/network/internal/frrconfig"
+	"github.com/openshift-kni/eco-gotests/tests/cnf/core/network/internal/netenv"
 	. "github.com/openshift-kni/eco-gotests/tests/cnf/core/network/internal/netinittools"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/core/network/internal/netnmstate"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/core/network/internal/netparam"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/core/network/metallb/internal/frr"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/core/network/metallb/internal/metallbenv"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/core/network/metallb/internal/tsparams"
-	"gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -40,7 +40,6 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelFRRTestCases), ContinueOnFa
 		hubPodWorker0                = "hub-pod-worker-0"
 		hubPodWorker1                = "hub-pod-worker-1"
 		frrCongigAllowAll            = "frrconfig-allow-all"
-		frrNodeLabel                 = "app=frr-k8s"
 		err                          error
 	)
 
@@ -96,53 +95,12 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelFRRTestCases), ContinueOnFa
 				metallbenv.DefineIterationParams(
 					ipv4metalLbIPList, ipv6metalLbIPList, ipv4NodeAddrList, ipv6NodeAddrList, netparam.IPV4Family)
 			Expect(err).ToNot(HaveOccurred(), "Fail to set iteration parameters")
-
 		})
 
 		AfterEach(func() {
 			By("Clean metallb operator and test namespaces")
 			resetOperatorAndTestNS()
 		})
-
-		It("Verify that prefixes configured with alwaysBlock are not received by the FRR speakers",
-			reportxml.ID("74270"), func() {
-				prefixToBlock := externalAdvertisedIPv4Routes[0]
-
-				By("Creating a new instance of MetalLB Speakers on workers blocking specific incoming prefixes")
-				createNewMetalLbDaemonSetAndWaitUntilItsRunningWithAlwaysBlock(tsparams.DefaultTimeout,
-					workerLabelMap, []string{prefixToBlock})
-
-				By("Creating external FRR pod on master node")
-				frrPod := deployTestPods(addressPool, hubIPv4ExternalAddresses, externalAdvertisedIPv4Routes,
-					externalAdvertisedIPv6Routes)
-
-				By("Creating BGP Peers")
-				createBGPPeerAndVerifyIfItsReady(tsparams.BGPTestPeer, ipv4metalLbIPList[0], "",
-					tsparams.LocalBGPASN, false, 0, frrk8sPods)
-
-				By("Checking that BGP session is established and up")
-				verifyMetalLbBGPSessionsAreUPOnFrrPod(frrPod, removePrefixFromIPList(ipv4NodeAddrList))
-
-				By("Validating BGP route prefix")
-				validatePrefix(frrPod, netparam.IPV4Family, removePrefixFromIPList(nodeAddrList), addressPool)
-
-				By("Create a frrconfiguration allow all")
-				createFrrConfiguration(frrCongigAllowAll, ipv4metalLbIPList[0],
-					tsparams.LocalBGPASN, nil, false, false)
-
-				frrk8sPods, err := pod.List(APIClient, NetConfig.MlbOperatorNamespace, metav1.ListOptions{
-					LabelSelector: frrNodeLabel,
-				})
-				Expect(err).ToNot(HaveOccurred(), "Fail to find Frrk8 pod list")
-
-				By("Verify that the node FRR pods advertises two routes")
-				verifyExternalAdvertisedRoutes(frrPod, ipv4NodeAddrList, externalAdvertisedIPv4Routes)
-
-				By("Validate that only the allowed route was received")
-				verifyReceivedRoutes(frrk8sPods, externalAdvertisedIPv4Routes[1])
-				By("Validate that only the route not allowed was blocked")
-				verifyBlockedRoutes(frrk8sPods, prefixToBlock)
-			})
 
 		It("Verify the FRR node only receives routes that are configured in the allowed prefixes",
 			reportxml.ID("74272"), func() {
@@ -152,29 +110,29 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelFRRTestCases), ContinueOnFa
 				err = metallbenv.CreateNewMetalLbDaemonSetAndWaitUntilItsRunning(tsparams.DefaultTimeout, workerLabelMap)
 				Expect(err).ToNot(HaveOccurred(), "Failed to recreate metalLb daemonset")
 
+				By("Verifying that the frrk8sPod deployment is in Ready state and create a list of the pods on " +
+					"worker nodes.")
+				frrk8sPods = verifyAndCreateFRRk8sPodList()
+
 				frrPod := deployTestPods(addressPool, hubIPv4ExternalAddresses, externalAdvertisedIPv4Routes,
 					externalAdvertisedIPv6Routes)
 
 				By("Creating BGP Peers")
-				createBGPPeerAndVerifyIfItsReady(tsparams.BGPTestPeer, ipv4metalLbIPList[0], "",
+				createBGPPeerAndVerifyIfItsReady(tsparams.BgpPeerName1, ipv4metalLbIPList[0], "",
 					tsparams.LocalBGPASN, false, 0, frrk8sPods)
 
 				By("Checking that BGP session is established and up")
-				verifyMetalLbBGPSessionsAreUPOnFrrPod(frrPod, removePrefixFromIPList(ipv4NodeAddrList))
+				verifyMetalLbBGPSessionsAreUPOnFrrPod(frrPod, cmd.RemovePrefixFromIPList(ipv4NodeAddrList))
 
 				By("Validating BGP route prefix")
-				validatePrefix(frrPod, netparam.IPV4Family, removePrefixFromIPList(nodeAddrList), addressPool)
+				validatePrefix(frrPod, netparam.IPV4Family, netparam.IPSubnetInt32,
+					removePrefixFromIPList(nodeAddrList), addressPool)
 
 				By("Create a frrconfiguration with prefix filter")
 
 				createFrrConfiguration("frrconfig-filtered", ipv4metalLbIPList[0],
 					tsparams.LocalBGPASN, []string{externalAdvertisedIPv4Routes[0], externalAdvertisedIPv6Routes[0]},
 					false, false)
-
-				frrk8sPods, err := pod.List(APIClient, NetConfig.MlbOperatorNamespace, metav1.ListOptions{
-					LabelSelector: frrNodeLabel,
-				})
-				Expect(err).ToNot(HaveOccurred(), "Fail to find Frrk8 pod list")
 
 				By("Verify that the node FRR pods advertises two routes")
 				verifyExternalAdvertisedRoutes(frrPod, ipv4NodeAddrList, externalAdvertisedIPv4Routes)
@@ -192,27 +150,27 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelFRRTestCases), ContinueOnFa
 				err = metallbenv.CreateNewMetalLbDaemonSetAndWaitUntilItsRunning(tsparams.DefaultTimeout, workerLabelMap)
 				Expect(err).ToNot(HaveOccurred(), "Failed to recreate metalLb daemonset")
 
+				By("Verifying that the frrk8sPod deployment is in Ready state and create a list of the pods on " +
+					"worker nodes.")
+				frrk8sPods = verifyAndCreateFRRk8sPodList()
+
 				frrPod := deployTestPods(addressPool, hubIPv4ExternalAddresses, externalAdvertisedIPv4Routes,
 					externalAdvertisedIPv6Routes)
 
 				By("Creating BGP Peers")
-				createBGPPeerAndVerifyIfItsReady(tsparams.BGPTestPeer, ipv4metalLbIPList[0], "",
+				createBGPPeerAndVerifyIfItsReady(tsparams.BgpPeerName1, ipv4metalLbIPList[0], "",
 					tsparams.LocalBGPASN, false, 0, frrk8sPods)
 
 				By("Checking that BGP session is established and up")
-				verifyMetalLbBGPSessionsAreUPOnFrrPod(frrPod, removePrefixFromIPList(ipv4NodeAddrList))
+				verifyMetalLbBGPSessionsAreUPOnFrrPod(frrPod, cmd.RemovePrefixFromIPList(ipv4NodeAddrList))
 
 				By("Validating BGP route prefix")
-				validatePrefix(frrPod, netparam.IPV4Family, removePrefixFromIPList(nodeAddrList), addressPool)
+				validatePrefix(frrPod, netparam.IPV4Family, netparam.IPSubnetInt32,
+					removePrefixFromIPList(nodeAddrList), addressPool)
 
 				By("Create a frrconfiguration allow all")
 				createFrrConfiguration(frrCongigAllowAll, ipv4metalLbIPList[0], tsparams.LocalBGPASN,
 					nil, false, false)
-
-				frrk8sPods, err := pod.List(APIClient, NetConfig.MlbOperatorNamespace, metav1.ListOptions{
-					LabelSelector: frrNodeLabel,
-				})
-				Expect(err).ToNot(HaveOccurred(), "Fail to find Frrk8 pod list")
 
 				By("Verify that the node FRR pods advertises two routes")
 				verifyExternalAdvertisedRoutes(frrPod, ipv4NodeAddrList, externalAdvertisedIPv4Routes)
@@ -229,33 +187,34 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelFRRTestCases), ContinueOnFa
 				err = metallbenv.CreateNewMetalLbDaemonSetAndWaitUntilItsRunning(tsparams.DefaultTimeout, workerLabelMap)
 				Expect(err).ToNot(HaveOccurred(), "Failed to recreate metalLb daemonset")
 
+				By("Verifying that the frrk8sPod deployment is in Ready state and create a list of the pods on " +
+					"worker nodes.")
+				frrk8sPods = verifyAndCreateFRRk8sPodList()
+
 				frrPod := deployTestPods(addressPool, hubIPv4ExternalAddresses, externalAdvertisedIPv4Routes,
 					externalAdvertisedIPv6Routes)
 
 				By("Creating BGP Peers")
-				createBGPPeerAndVerifyIfItsReady(tsparams.BGPTestPeer, ipv4metalLbIPList[0], "",
+				createBGPPeerAndVerifyIfItsReady(tsparams.BgpPeerName1, ipv4metalLbIPList[0], "",
 					tsparams.LocalBGPASN, false, 0, frrk8sPods)
 
 				By("Checking that BGP session is established and up")
-				verifyMetalLbBGPSessionsAreUPOnFrrPod(frrPod, removePrefixFromIPList(ipv4NodeAddrList))
+				verifyMetalLbBGPSessionsAreUPOnFrrPod(frrPod, cmd.RemovePrefixFromIPList(ipv4NodeAddrList))
 
 				By("Validating BGP route prefix")
-				validatePrefix(frrPod, netparam.IPV4Family, removePrefixFromIPList(nodeAddrList), addressPool)
+				validatePrefix(frrPod, netparam.IPV4Family, netparam.IPSubnetInt32,
+					removePrefixFromIPList(nodeAddrList), addressPool)
 
-				By("Create first frrconfiguration that receieves a single route")
+				By("Create first frrconfiguration that receives a single route")
 				createFrrConfiguration(frrConfigFiltered1, ipv4metalLbIPList[0], tsparams.LocalBGPASN,
 					[]string{externalAdvertisedIPv4Routes[0], externalAdvertisedIPv6Routes[0]}, false, false)
-
-				frrk8sPods, err := pod.List(APIClient, NetConfig.MlbOperatorNamespace, metav1.ListOptions{
-					LabelSelector: frrNodeLabel,
-				})
-				Expect(err).ToNot(HaveOccurred(), "Fail to find Frrk8 pod list")
 
 				By("Verify that the node FRR pods advertises two routes")
 				verifyExternalAdvertisedRoutes(frrPod, ipv4NodeAddrList, externalAdvertisedIPv4Routes)
 
 				By("Validate BGP received only the first route")
 				verifyReceivedRoutes(frrk8sPods, externalAdvertisedIPv4Routes[0])
+
 				By("Validate the second BGP route not configured in the frrconfiguration is not received")
 				verifyBlockedRoutes(frrk8sPods, externalAdvertisedIPv4Routes[1])
 
@@ -276,6 +235,9 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelFRRTestCases), ContinueOnFa
 				err = metallbenv.CreateNewMetalLbDaemonSetAndWaitUntilItsRunning(tsparams.DefaultTimeout, workerLabelMap)
 				Expect(err).ToNot(HaveOccurred(), "Failed to recreate metalLb daemonset")
 
+				By("Verifying that the frrk8sWebhookDeployment deployment is in Ready state.")
+				verifyAndCreateFRRk8sPodList()
+
 				By("Create first frrconfiguration that receive a single route")
 				createFrrConfiguration(frrConfigFiltered1, ipv4metalLbIPList[0], tsparams.LocalBGPASN,
 					[]string{externalAdvertisedIPv4Routes[0], externalAdvertisedIPv6Routes[0]}, false,
@@ -293,6 +255,10 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelFRRTestCases), ContinueOnFa
 				By("Creating a new instance of MetalLB Speakers on workers")
 				err = metallbenv.CreateNewMetalLbDaemonSetAndWaitUntilItsRunning(tsparams.DefaultTimeout, workerLabelMap)
 				Expect(err).ToNot(HaveOccurred(), "Failed to recreate metalLb daemonset")
+
+				By("Verifying that the frrk8sPod deployment is in Ready state and create a list of the pods on " +
+					"worker nodes.")
+				verifyAndCreateFRRk8sPodList()
 
 				By("Creating BGP Peers")
 				createBGPPeerAndVerifyIfItsReady(tsparams.BGPTestPeer, ipv4metalLbIPList[0], "",
@@ -354,11 +320,14 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelFRRTestCases), ContinueOnFa
 			err := metallbenv.CreateNewMetalLbDaemonSetAndWaitUntilItsRunning(tsparams.DefaultTimeout, workerLabelMap)
 			Expect(err).ToNot(HaveOccurred(), "Failed to recreate metalLb daemonset")
 
-			By("Collecting information before test")
-			frrk8sPods, err = pod.List(APIClient, NetConfig.MlbOperatorNamespace, metav1.ListOptions{
-				LabelSelector: frrNodeLabel,
-			})
-			Expect(err).ToNot(HaveOccurred(), "Failed to list speaker pods")
+			By("Creating a new instance of MetalLB Speakers on workers")
+			err = metallbenv.CreateNewMetalLbDaemonSetAndWaitUntilItsRunning(tsparams.DefaultTimeout, workerLabelMap)
+			Expect(err).ToNot(HaveOccurred(), "Failed to recreate metalLb daemonset")
+
+			By("Verifying that the frrk8sPod deployment is in Ready state and create a list of the pods on " +
+				"worker nodes.")
+			frrk8sPods = verifyAndCreateFRRk8sPodList()
+
 			By("Setting test iteration parameters")
 			masterClientPodIP, _, _, nodeAddrList, addressPool, _, err =
 				metallbenv.DefineIterationParams(
@@ -366,10 +335,10 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelFRRTestCases), ContinueOnFa
 			Expect(err).ToNot(HaveOccurred(), "Fail to set iteration parameters")
 
 			By("Creating an IPAddressPool and BGPAdvertisement")
-			ipAddressPool := setupBgpAdvertisementAndIPAddressPool(addressPool)
+			ipAddressPool := setupBgpAdvertisementAndIPAddressPool(addressPool, netparam.IPSubnetInt32)
 
 			By("Creating a MetalLB service")
-			setupMetalLbService("service-1", netparam.IPV4Family, ipAddressPool, "Cluster")
+			setupMetalLbService(tsparams.MetallbServiceName, netparam.IPV4Family, ipAddressPool, "Cluster")
 
 			By("Creating nginx test pod on worker node")
 			setupNGNXPod(workerNodeList[0].Definition.Name)
@@ -382,16 +351,14 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelFRRTestCases), ContinueOnFa
 
 		AfterEach(func() {
 			By("Removing static routes from the speakers")
-			frrk8sPods, err := pod.List(APIClient, NetConfig.MlbOperatorNamespace, metav1.ListOptions{
-				LabelSelector: tsparams.FRRK8sDefaultLabel,
-			})
-			Expect(err).ToNot(HaveOccurred(), "Failed to list pods")
-
-			speakerRoutesMap := buildRoutesMapWithSpecificRoutes(frrk8sPods, []string{ipv4metalLbIPList[0],
-				ipv4metalLbIPList[1], frrNodeSecIntIPv4Addresses[0], frrNodeSecIntIPv4Addresses[1]})
+			frrk8sPods = verifyAndCreateFRRk8sPodList()
+			speakerRoutesMap, err := netenv.BuildRoutesMapWithSpecificRoutes(frrk8sPods, workerNodeList,
+				[]string{ipv4metalLbIPList[0], ipv4metalLbIPList[1], frrNodeSecIntIPv4Addresses[0], frrNodeSecIntIPv4Addresses[1]})
+			Expect(err).ToNot(HaveOccurred(), "Failed to create route map with specific routes")
 
 			for _, frrk8sPod := range frrk8sPods {
-				out, err := frr.SetStaticRoute(frrk8sPod, "del", frrExternalMasterIPAddress, speakerRoutesMap)
+				out, err := netenv.SetStaticRoute(frrk8sPod, "del", frrExternalMasterIPAddress,
+					frrconfig.ContainerName, speakerRoutesMap)
 				Expect(err).ToNot(HaveOccurred(), out)
 			}
 
@@ -426,30 +393,35 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelFRRTestCases), ContinueOnFa
 			reportxml.ID("74278"), func() {
 
 				By("Adding static routes to the speakers")
-				speakerRoutesMap := buildRoutesMapWithSpecificRoutes(frrk8sPods, ipv4metalLbIPList)
+				speakerRoutesMap, err := netenv.BuildRoutesMapWithSpecificRoutes(frrk8sPods, workerNodeList,
+					ipv4metalLbIPList)
+				Expect(err).ToNot(HaveOccurred(), "Failed to create route map with specific routes")
 
 				for _, frrk8sPod := range frrk8sPods {
-					out, err := frr.SetStaticRoute(frrk8sPod, "add", masterClientPodIP, speakerRoutesMap)
+					out, err := netenv.SetStaticRoute(frrk8sPod, "add", masterClientPodIP,
+						frrconfig.ContainerName, speakerRoutesMap)
 					Expect(err).ToNot(HaveOccurred(), out)
 				}
 
 				By("Creating External NAD for master FRR pod")
-				createExternalNad(tsparams.ExternalMacVlanNADName)
+				err = define.CreateExternalNad(APIClient, frrconfig.ExternalMacVlanNADName, tsparams.TestNamespaceName)
+				Expect(err).ToNot(HaveOccurred(), "Failed to create a network-attachment-definition")
 
 				By("Creating External NAD for hub FRR pods")
-				createExternalNad(tsparams.HubMacVlanNADName)
+				err = define.CreateExternalNad(APIClient, tsparams.HubMacVlanNADName, tsparams.TestNamespaceName)
+				Expect(err).ToNot(HaveOccurred(), "Failed to create a network-attachment-definition")
 
 				By("Creating static ip annotation for hub0")
-				hub0BRstaticIPAnnotation := createStaticIPAnnotations(tsparams.ExternalMacVlanNADName,
+				hub0BRstaticIPAnnotation := frrconfig.CreateStaticIPAnnotations(frrconfig.ExternalMacVlanNADName,
 					tsparams.HubMacVlanNADName,
-					[]string{fmt.Sprintf("%s/24", ipv4metalLbIPList[0])},
-					[]string{fmt.Sprintf("%s/24", hubIPv4ExternalAddresses[0])})
+					[]string{fmt.Sprintf("%s/%s", ipv4metalLbIPList[0], netparam.IPSubnet24)},
+					[]string{fmt.Sprintf("%s/%s", hubIPv4ExternalAddresses[0], netparam.IPSubnet24)})
 
 				By("Creating static ip annotation for hub1")
-				hub1BRstaticIPAnnotation := createStaticIPAnnotations(tsparams.ExternalMacVlanNADName,
+				hub1BRstaticIPAnnotation := frrconfig.CreateStaticIPAnnotations(frrconfig.ExternalMacVlanNADName,
 					tsparams.HubMacVlanNADName,
-					[]string{fmt.Sprintf("%s/24", ipv4metalLbIPList[1])},
-					[]string{fmt.Sprintf("%s/24", hubIPv4ExternalAddresses[1])})
+					[]string{fmt.Sprintf("%s/%s", ipv4metalLbIPList[1], netparam.IPSubnet24)},
+					[]string{fmt.Sprintf("%s/%s", hubIPv4ExternalAddresses[1], netparam.IPSubnet24)})
 
 				By("Creating MetalLb Hub pod configMap")
 				hubConfigMap := createHubConfigMap("frr-hub-node-config")
@@ -468,14 +440,15 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelFRRTestCases), ContinueOnFa
 					externalAdvertisedIPv6Routes, false)
 
 				By("Creating BGP Peers")
-				createBGPPeerAndVerifyIfItsReady(tsparams.BGPTestPeer, frrExternalMasterIPAddress, "",
+				createBGPPeerAndVerifyIfItsReady(tsparams.BgpPeerName1, frrExternalMasterIPAddress, "",
 					tsparams.LocalBGPASN, false, 0, frrk8sPods)
 
 				By("Checking that BGP session is established and up")
-				verifyMetalLbBGPSessionsAreUPOnFrrPod(frrPod, removePrefixFromIPList(ipv4NodeAddrList))
+				verifyMetalLbBGPSessionsAreUPOnFrrPod(frrPod, cmd.RemovePrefixFromIPList(ipv4NodeAddrList))
 
 				By("Validating BGP route prefix")
-				validatePrefix(frrPod, netparam.IPV4Family, removePrefixFromIPList(nodeAddrList), addressPool)
+				validatePrefix(frrPod, netparam.IPV4Family, netparam.IPSubnetInt32,
+					removePrefixFromIPList(nodeAddrList), addressPool)
 
 				By("Create a frrconfiguration allow all for EBGP multihop")
 				createFrrConfiguration(frrCongigAllowAll, frrExternalMasterIPAddress,
@@ -494,30 +467,35 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelFRRTestCases), ContinueOnFa
 			reportxml.ID("47279"), func() {
 
 				By("Adding static routes to the speakers")
-				speakerRoutesMap := buildRoutesMapWithSpecificRoutes(frrk8sPods, ipv4metalLbIPList)
+				speakerRoutesMap, err := netenv.BuildRoutesMapWithSpecificRoutes(frrk8sPods, workerNodeList,
+					ipv4metalLbIPList)
+				Expect(err).ToNot(HaveOccurred(), "Failed to create route map with specific routes")
 
 				for _, frrk8sPod := range frrk8sPods {
-					out, err := frr.SetStaticRoute(frrk8sPod, "add", masterClientPodIP, speakerRoutesMap)
+					out, err := netenv.SetStaticRoute(frrk8sPod, "add", masterClientPodIP,
+						frrconfig.ContainerName, speakerRoutesMap)
 					Expect(err).ToNot(HaveOccurred(), out)
 				}
 
 				By("Creating External NAD for master FRR pod")
-				createExternalNad(tsparams.ExternalMacVlanNADName)
+				err = define.CreateExternalNad(APIClient, frrconfig.ExternalMacVlanNADName, tsparams.TestNamespaceName)
+				Expect(err).ToNot(HaveOccurred(), "Failed to create a network-attachment-definition")
 
 				By("Creating External NAD for hub FRR pods")
-				createExternalNad(tsparams.HubMacVlanNADName)
+				err = define.CreateExternalNad(APIClient, tsparams.HubMacVlanNADName, tsparams.TestNamespaceName)
+				Expect(err).ToNot(HaveOccurred(), "Failed to create a network-attachment-definition")
 
 				By("Creating static ip annotation for hub0")
-				hub0BRstaticIPAnnotation := createStaticIPAnnotations(tsparams.ExternalMacVlanNADName,
+				hub0BRstaticIPAnnotation := frrconfig.CreateStaticIPAnnotations(frrconfig.ExternalMacVlanNADName,
 					tsparams.HubMacVlanNADName,
-					[]string{fmt.Sprintf("%s/24", ipv4metalLbIPList[0])},
-					[]string{fmt.Sprintf("%s/24", hubIPv4ExternalAddresses[0])})
+					[]string{fmt.Sprintf("%s/%s", ipv4metalLbIPList[0], netparam.IPSubnet24)},
+					[]string{fmt.Sprintf("%s/%s", hubIPv4ExternalAddresses[0], netparam.IPSubnet24)})
 
 				By("Creating static ip annotation for hub1")
-				hub1BRstaticIPAnnotation := createStaticIPAnnotations(tsparams.ExternalMacVlanNADName,
+				hub1BRstaticIPAnnotation := frrconfig.CreateStaticIPAnnotations(frrconfig.ExternalMacVlanNADName,
 					tsparams.HubMacVlanNADName,
-					[]string{fmt.Sprintf("%s/24", ipv4metalLbIPList[1])},
-					[]string{fmt.Sprintf("%s/24", hubIPv4ExternalAddresses[1])})
+					[]string{fmt.Sprintf("%s/%s", ipv4metalLbIPList[1], netparam.IPSubnet24)},
+					[]string{fmt.Sprintf("%s/%s", hubIPv4ExternalAddresses[1], netparam.IPSubnet24)})
 
 				By("Creating MetalLb Hub pod configMap")
 				hubConfigMap := createHubConfigMap("frr-hub-node-config")
@@ -536,14 +514,15 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelFRRTestCases), ContinueOnFa
 					externalAdvertisedIPv6Routes, true)
 
 				By("Creating BGP Peers")
-				createBGPPeerAndVerifyIfItsReady(tsparams.BGPTestPeer, frrExternalMasterIPAddress, "",
+				createBGPPeerAndVerifyIfItsReady(tsparams.BgpPeerName1, frrExternalMasterIPAddress, "",
 					tsparams.RemoteBGPASN, true, 0, frrk8sPods)
 
 				By("Checking that BGP session is established and up")
-				verifyMetalLbBGPSessionsAreUPOnFrrPod(frrPod, removePrefixFromIPList(ipv4NodeAddrList))
+				verifyMetalLbBGPSessionsAreUPOnFrrPod(frrPod, cmd.RemovePrefixFromIPList(ipv4NodeAddrList))
 
 				By("Validating BGP route prefix")
-				validatePrefix(frrPod, netparam.IPV4Family, removePrefixFromIPList(nodeAddrList), addressPool)
+				validatePrefix(frrPod, netparam.IPV4Family, netparam.IPSubnetInt32,
+					removePrefixFromIPList(nodeAddrList), addressPool)
 
 				By("Create a frrconfiguration allow all for EBGP multihop")
 				createFrrConfiguration(frrCongigAllowAll, frrExternalMasterIPAddress, tsparams.RemoteBGPASN,
@@ -575,14 +554,14 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelFRRTestCases), ContinueOnFa
 					srIovInterfacesUnderTest[0], frrNodeSecIntIPv4Addresses[1], "2001:100::253", vlanID)
 
 				By("Adding static routes to the speakers")
-				speakerRoutesMap := buildRoutesMapWithSpecificRoutes(frrk8sPods, hubSecIntIPv4Addresses)
+				speakerRoutesMap, err := netenv.BuildRoutesMapWithSpecificRoutes(frrk8sPods, workerNodeList,
+					hubSecIntIPv4Addresses)
+				Expect(err).ToNot(HaveOccurred(), "Failed to create route map with specific routes")
 
 				for _, frrk8sPod := range frrk8sPods {
-					// Wait until the interface is created before adding the static route
 					Eventually(func() error {
-						// Here you can add logic to check if the interface exists
-						out, err := frr.SetStaticRoute(frrk8sPod, "add", fmt.Sprintf("%s/32",
-							frrExternalMasterIPAddress), speakerRoutesMap)
+						out, err := netenv.SetStaticRoute(frrk8sPod, "add", fmt.Sprintf("%s/32",
+							frrExternalMasterIPAddress), frrconfig.ContainerName, speakerRoutesMap)
 						if err != nil {
 							return fmt.Errorf("error adding static route: %s", out)
 						}
@@ -598,25 +577,27 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelFRRTestCases), ContinueOnFa
 				createExternalNadWithMasterInterface(tsparams.HubMacVlanNADSecIntName, interfaceNameWithVlan)
 
 				By("Creating External NAD for master FRR pod")
-				createExternalNad(tsparams.ExternalMacVlanNADName)
+				err = define.CreateExternalNad(APIClient, frrconfig.ExternalMacVlanNADName, tsparams.TestNamespaceName)
+				Expect(err).ToNot(HaveOccurred(), "Failed to create a network-attachment-definition")
 
 				By("Creating External NAD for hub FRR pods")
-				createExternalNad(tsparams.HubMacVlanNADName)
+				err = define.CreateExternalNad(APIClient, tsparams.HubMacVlanNADName, tsparams.TestNamespaceName)
+				Expect(err).ToNot(HaveOccurred(), "Failed to create a network-attachment-definition")
 
 				By("Creating MetalLb Hub pod configMap")
 				createHubConfigMapSecInt := createHubConfigMap("frr-hub-node-config")
 
 				By("Creating static ip annotation for hub0")
-				hub0BRStaticSecIntIPAnnotation := createStaticIPAnnotations(tsparams.HubMacVlanNADSecIntName,
+				hub0BRStaticSecIntIPAnnotation := frrconfig.CreateStaticIPAnnotations(tsparams.HubMacVlanNADSecIntName,
 					tsparams.HubMacVlanNADName,
-					[]string{fmt.Sprintf("%s/24", hubSecIntIPv4Addresses[0])},
-					[]string{fmt.Sprintf("%s/24", hubIPv4ExternalAddresses[0])})
+					[]string{fmt.Sprintf("%s/%s", hubSecIntIPv4Addresses[0], netparam.IPSubnet24)},
+					[]string{fmt.Sprintf("%s/%s", hubIPv4ExternalAddresses[0], netparam.IPSubnet24)})
 
 				By("Creating static ip annotation for hub1")
-				hub1SecIntIPAnnotation := createStaticIPAnnotations(tsparams.HubMacVlanNADSecIntName,
+				hub1SecIntIPAnnotation := frrconfig.CreateStaticIPAnnotations(tsparams.HubMacVlanNADSecIntName,
 					tsparams.HubMacVlanNADName,
-					[]string{fmt.Sprintf("%s/24", hubSecIntIPv4Addresses[1])},
-					[]string{fmt.Sprintf("%s/24", hubIPv4ExternalAddresses[1])})
+					[]string{fmt.Sprintf("%s/%s", hubSecIntIPv4Addresses[1], netparam.IPSubnet24)},
+					[]string{fmt.Sprintf("%s/%s", hubIPv4ExternalAddresses[1], netparam.IPSubnet24)})
 
 				By("Creating FRR Hub pod on worker node 0")
 				_ = createFrrHubPod(hubPodWorker0,
@@ -634,13 +615,14 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelFRRTestCases), ContinueOnFa
 					externalAdvertisedIPv6Routes, false)
 
 				By("Creating BGP Peers")
-				createBGPPeerAndVerifyIfItsReady(tsparams.BGPTestPeer, frrExternalMasterIPAddress, "",
+				createBGPPeerAndVerifyIfItsReady(tsparams.BgpPeerName1, frrExternalMasterIPAddress, "",
 					tsparams.LocalBGPASN, false, 0, frrk8sPods)
 
 				By("Checking that BGP session is established and up")
 				verifyMetalLbBGPSessionsAreUPOnFrrPod(frrPod, frrNodeSecIntIPv4Addresses)
 				By("Validating BGP route prefix")
-				validatePrefix(frrPod, netparam.IPV4Family, frrNodeSecIntIPv4Addresses, addressPool)
+				validatePrefix(frrPod, netparam.IPV4Family, netparam.IPSubnetInt32, frrNodeSecIntIPv4Addresses,
+					addressPool)
 
 				By("Create a frrconfiguration allow all for IBGP multihop")
 				createFrrConfiguration(frrCongigAllowAll, frrExternalMasterIPAddress,
@@ -655,74 +637,27 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelFRRTestCases), ContinueOnFa
 
 })
 
-func createNewMetalLbDaemonSetAndWaitUntilItsRunningWithAlwaysBlock(timeout time.Duration,
-	nodeLabel map[string]string, prefixes []string) {
-	By("Verifying if metalLb daemonset is running")
-
-	metalLbIo, err := metallb.Pull(APIClient, tsparams.MetalLbIo, NetConfig.MlbOperatorNamespace)
-
-	if err == nil {
-		By("MetalLb daemonset is running. Removing daemonset.")
-
-		_, err = metalLbIo.Delete()
-		Expect(err).ToNot(HaveOccurred(), "Failed to delete MetalLb daemonset")
-	}
-
-	By("Create new metalLb speaker's daemonSet.")
-
-	metalLbIo = metallb.NewBuilder(APIClient, tsparams.MetalLbIo, NetConfig.MlbOperatorNamespace, nodeLabel)
-	metalLbIo.WithFRRConfigAlwaysBlock(prefixes)
-
-	_, err = metalLbIo.Create()
-	Expect(err).ToNot(HaveOccurred(), "Failed to create new MetalLb daemonset")
-
-	var metalLbDs *daemonset.Builder
-
-	err = wait.PollUntilContextTimeout(
-		context.TODO(), 3*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
-			metalLbDs, err = daemonset.Pull(APIClient, tsparams.MetalLbDsName, NetConfig.MlbOperatorNamespace)
-			if err != nil {
-				By(fmt.Sprintf("Error pulling speakers in %s namespace %s, retry",
-					tsparams.MetalLbDsName, NetConfig.MlbOperatorNamespace))
-
-				return false, nil
-			}
-
-			metalLbDs, err = daemonset.Pull(APIClient, tsparams.FrrDsName, NetConfig.MlbOperatorNamespace)
-			if err != nil {
-				By(fmt.Sprintf("Error pulling frrk8s in %s namespace %s, retry",
-					tsparams.FRRK8sDefaultLabel, NetConfig.MlbOperatorNamespace))
-
-				return false, nil
-			}
-
-			return true, nil
-		})
-	Expect(err).ToNot(HaveOccurred(), "Failed to wait for MetalLb daemonset readiness")
-
-	By("Waiting until the new metalLb daemonset is in Ready state.")
-	Expect(metalLbDs.IsReady(timeout)).To(BeTrue(), "MetalLb daemonset is not ready")
-}
-
 func deployTestPods(addressPool, hubIPAddresses, externalAdvertisedIPv4Routes,
 	externalAdvertisedIPv6Routes []string) *pod.Builder {
 	By("Creating an IPAddressPool and BGPAdvertisement")
 
-	ipAddressPool := setupBgpAdvertisementAndIPAddressPool(addressPool)
+	ipAddressPool := setupBgpAdvertisementAndIPAddressPool(addressPool, netparam.IPSubnetInt32)
 
 	By("Creating a MetalLB service")
-	setupMetalLbService("service-1", netparam.IPV4Family, ipAddressPool, "Cluster")
+	setupMetalLbService(tsparams.MetallbServiceName, netparam.IPV4Family, ipAddressPool, "Cluster")
 
 	By("Creating nginx test pod on worker node")
 	setupNGNXPod(workerNodeList[0].Definition.Name)
 
 	By("Creating External NAD")
-	createExternalNad(tsparams.ExternalMacVlanNADName)
+
+	err := define.CreateExternalNad(APIClient, frrconfig.ExternalMacVlanNADName, tsparams.TestNamespaceName)
+	Expect(err).ToNot(HaveOccurred(), "Failed to create a network-attachment-definition")
 
 	By("Creating static ip annotation")
 
 	staticIPAnnotation := pod.StaticIPAnnotation(
-		tsparams.ExternalMacVlanNADName, []string{fmt.Sprintf("%s/%s", ipv4metalLbIPList[0], "24")})
+		frrconfig.ExternalMacVlanNADName, []string{fmt.Sprintf("%s/%s", ipv4metalLbIPList[0], netparam.IPSubnet24)})
 
 	By("Creating MetalLb configMap")
 
@@ -739,7 +674,7 @@ func deployTestPods(addressPool, hubIPAddresses, externalAdvertisedIPv4Routes,
 
 func createFrrConfiguration(name, bgpPeerIP string, remoteAS uint32, filteredIP []string, ebgp, expectToFail bool) {
 	frrConfig := metallb.NewFrrConfigurationBuilder(APIClient, name,
-		NetConfig.MlbOperatorNamespace).
+		NetConfig.Frrk8sNamespace).
 		WithBGPRouter(tsparams.LocalBGPASN).
 		WithBGPNeighbor(bgpPeerIP, remoteAS, 0)
 
@@ -762,6 +697,7 @@ func createFrrConfiguration(name, bgpPeerIP string, remoteAS uint32, filteredIP 
 
 	if expectToFail {
 		_, err := frrConfig.Create()
+
 		Expect(err).To(HaveOccurred(), "Failed expected to not create a FRR configuration for %s", name)
 	} else {
 		_, err := frrConfig.Create()
@@ -778,7 +714,7 @@ func createMasterFrrPod(localAS int, frrExternalMasterIPAddress string, ipv4Node
 	By("Creating static ip annotation for master FRR pod")
 
 	masterStaticIPAnnotation := pod.StaticIPAnnotation(
-		tsparams.HubMacVlanNADName, []string{fmt.Sprintf("%s/24", frrExternalMasterIPAddress)})
+		tsparams.HubMacVlanNADName, []string{fmt.Sprintf("%s/%s", frrExternalMasterIPAddress, netparam.IPSubnet24)})
 
 	By("Creating FRR Master Pod")
 
@@ -793,8 +729,8 @@ func createConfigMapWithStaticRoutes(
 	enableMultiHop, enableBFD bool) *configmap.Builder {
 	frrBFDConfig := frr.DefineBGPConfigWithStaticRouteAndNetwork(
 		bgpAsn, tsparams.LocalBGPASN, hubIPAddresses, externalAdvertisedIPv4Routes,
-		externalAdvertisedIPv6Routes, removePrefixFromIPList(nodeAddrList), enableMultiHop, enableBFD)
-	configMapData := frr.DefineBaseConfig(tsparams.DaemonsFile, frrBFDConfig, "")
+		externalAdvertisedIPv6Routes, cmd.RemovePrefixFromIPList(nodeAddrList), enableMultiHop, enableBFD)
+	configMapData := frrconfig.DefineBaseConfig(frrconfig.DaemonsFile, frrBFDConfig, "")
 	masterConfigMap, err := configmap.NewBuilder(APIClient, "frr-master-node-config", tsparams.TestNamespaceName).
 		WithData(configMapData).Create()
 	Expect(err).ToNot(HaveOccurred(), "Failed to create config map")
@@ -804,7 +740,7 @@ func createConfigMapWithStaticRoutes(
 
 func verifyExternalAdvertisedRoutes(frrPod *pod.Builder, ipv4NodeAddrList, externalExpectedRoutes []string) {
 	// Get advertised routes from FRR pod, now returned as a map of node IPs to their advertised routes
-	advertisedRoutesMap, err := frr.GetBGPAdvertisedRoutes(frrPod, removePrefixFromIPList(ipv4NodeAddrList))
+	advertisedRoutesMap, err := frr.GetBGPAdvertisedRoutes(frrPod, cmd.RemovePrefixFromIPList(ipv4NodeAddrList))
 	Expect(err).ToNot(HaveOccurred(), "Failed to find advertised routes")
 
 	// Iterate through each node in the advertised routes map
@@ -822,26 +758,6 @@ func verifyExternalAdvertisedRoutes(frrPod *pod.Builder, ipv4NodeAddrList, exter
 	}
 }
 
-func buildRoutesMapWithSpecificRoutes(podList []*pod.Builder, nextHopList []string) map[string]string {
-	Expect(len(podList)).ToNot(BeZero(), "Pod list is empty")
-	Expect(len(nextHopList)).ToNot(BeZero(), "Nexthop IP addresses list is empty")
-	Expect(len(nextHopList)).To(BeNumerically(">=", len(podList)),
-		fmt.Sprintf("Number of speaker IP addresses[%d] is less than the number of pods[%d]",
-			len(nextHopList), len(podList)))
-
-	routesMap := make(map[string]string)
-
-	for _, frrPod := range podList {
-		if frrPod.Definition.Spec.NodeName == workerNodeList[0].Definition.Name {
-			routesMap[frrPod.Definition.Spec.NodeName] = nextHopList[1]
-		} else {
-			routesMap[frrPod.Definition.Spec.NodeName] = nextHopList[0]
-		}
-	}
-
-	return routesMap
-}
-
 func createSecondaryInterfaceOnNode(policyName, nodeName, interfaceName, ipv4Address, ipv6Address string,
 	vlanID uint16) {
 	secondaryInterface := nmstate.NewPolicyBuilder(APIClient, policyName, map[string]string{
@@ -853,15 +769,6 @@ func createSecondaryInterfaceOnNode(policyName, nodeName, interfaceName, ipv4Add
 	_, err := secondaryInterface.Create()
 	Expect(err).ToNot(HaveOccurred(),
 		"fail to create secondary interface: %s.+%d", interfaceName, vlanID)
-}
-
-func createStaticIPAnnotations(internalNADName, externalNADName string, internalIPAddresses,
-	externalIPAddresses []string) []*types.NetworkSelectionElement {
-	ipAnnotation := pod.StaticIPAnnotation(internalNADName, internalIPAddresses)
-	ipAnnotation = append(ipAnnotation,
-		pod.StaticIPAnnotation(externalNADName, externalIPAddresses)...)
-
-	return ipAnnotation
 }
 
 func verifyReceivedRoutes(frrk8sPods []*pod.Builder, allowedPrefixes string) {

--- a/tests/cnf/core/network/metallb/tests/layer2-test.go
+++ b/tests/cnf/core/network/metallb/tests/layer2-test.go
@@ -78,7 +78,7 @@ var _ = Describe("Layer2", Ordered, Label(tsparams.LabelLayer2TestCases), Contin
 		ipAddressPool := setupL2Advertisement(ipv4metalLbIPList)
 
 		By("Creating a MetalLB service")
-		setupMetalLbService("service-1", netparam.IPV4Family, ipAddressPool, "Cluster")
+		setupMetalLbService(tsparams.MetallbServiceName, netparam.IPV4Family, ipAddressPool, "Cluster")
 
 		By("Creating external Network Attachment Definition")
 		err = define.CreateExternalNad(APIClient, frrconfig.ExternalMacVlanNADName, tsparams.TestNamespaceName)
@@ -90,7 +90,7 @@ var _ = Describe("Layer2", Ordered, Label(tsparams.LabelLayer2TestCases), Contin
 			DefineOnNode(masterNodeList[0].Object.Name).
 			WithTolerationToMaster().
 			WithSecondaryNetwork(pod.StaticIPAnnotation(frrconfig.ExternalMacVlanNADName,
-				[]string{fmt.Sprintf("%s/24", ipv4metalLbIPList[1])})).
+				[]string{fmt.Sprintf("%s/%s", ipv4metalLbIPList[1], netparam.IPSubnet24)})).
 			WithPrivilegedFlag().CreateAndWaitUntilRunning(time.Minute)
 		Expect(err).ToNot(HaveOccurred(), "Failed to create client test pod")
 	})
@@ -138,6 +138,7 @@ var _ = Describe("Layer2", Ordered, Label(tsparams.LabelLayer2TestCases), Contin
 		Expect(err).ToNot(HaveOccurred(), "Failed to update metallb object with the new MetalLb label")
 
 		By("Adding test label to compute nodes")
+
 		addNodeLabel(workerNodeList, tsparams.TestLabel)
 
 		By("Validating all metalLb speaker daemonset are running")

--- a/tests/cnf/core/network/metallb/tests/metallb-nodeSelector.go
+++ b/tests/cnf/core/network/metallb/tests/metallb-nodeSelector.go
@@ -221,12 +221,14 @@ func setupTestCase(ipAddressPool1, ipAddressPool2 *metallb.IPAddressPoolBuilder,
 	By("Creating static ip annotation for FRR master 0")
 
 	staticIPAnnotation0 := pod.StaticIPAnnotation(
-		tsparams.ExternalMacVlanNADName, []string{fmt.Sprintf("%s/%s", ipv4metalLbIPList[0], netparam.IPSubnet24)})
+		tsparams.ExternalMacVlanNADName, []string{fmt.Sprintf("%s/%s", ipv4metalLbIPList[0],
+			netparam.IPSubnet24)})
 
 	By("Creating static ip annotation for FRR master 1")
 
 	staticIPAnnotation1 := pod.StaticIPAnnotation(
-		tsparams.ExternalMacVlanNADName, []string{fmt.Sprintf("%s/%s", ipv4metalLbIPList[1], netparam.IPSubnet24)})
+		tsparams.ExternalMacVlanNADName, []string{fmt.Sprintf("%s/%s", ipv4metalLbIPList[1],
+			netparam.IPSubnet24)})
 
 	By("Creating MetalLb configMap for FRR master pods")
 
@@ -243,13 +245,11 @@ func setupTestCase(ipAddressPool1, ipAddressPool2 *metallb.IPAddressPoolBuilder,
 		masterNodeList[1].Object.Name, masterConfigMap.Definition.Name, []string{}, staticIPAnnotation1, "frr-master1")
 
 	By("Create two BGPPeers")
-	createBGPPeerAndVerifyIfItsReady(tsparams.BgpPeerName1, ipv4metalLbIPList[0], "",
-		tsparams.LocalBGPASN, false,
-		0, frrk8sPods)
+	createBGPPeerAndVerifyIfItsReady(tsparams.BgpPeerName1, ipv4metalLbIPList[0], "", tsparams.LocalBGPASN,
+		false, 0, frrk8sPods)
 
-	createBGPPeerAndVerifyIfItsReady(tsparams.BgpPeerName2, ipv4metalLbIPList[1], "",
-		tsparams.LocalBGPASN, false,
-		0, frrk8sPods)
+	createBGPPeerAndVerifyIfItsReady(tsparams.BgpPeerName2, ipv4metalLbIPList[1], "", tsparams.LocalBGPASN,
+		false, 0, frrk8sPods)
 
 	return frrPod0, frrPod1
 }
@@ -263,8 +263,10 @@ func verifyBGPConnectivityAndPrefixes(frrPod0, frrPod1 *pod.Builder, nodeAddrLis
 	verifyMetalLbBGPSessionsAreUPOnFrrPod(frrPod1, removePrefixFromIPList(ipv4NodeAddrList))
 
 	By("Validating BGP route prefix on Frr Master 0")
-	validatePrefix(frrPod0, netparam.IPV4Family, removePrefixFromIPList(nodeAddrList), addressPool1)
+	validatePrefix(frrPod0, netparam.IPV4Family, netparam.IPSubnetInt32,
+		removePrefixFromIPList(nodeAddrList), addressPool1)
 
 	By("Validating BGP route prefix on Frr Master 1")
-	validatePrefix(frrPod1, netparam.IPV4Family, removePrefixFromIPList(nodeAddrList), addressPool2)
+	validatePrefix(frrPod1, netparam.IPV4Family, netparam.IPSubnetInt32,
+		removePrefixFromIPList(nodeAddrList), addressPool2)
 }


### PR DESCRIPTION
Changes are being implemented to metallb/frr in OCP 4.19. All frr components are being moved to a separate namespace. This PR updates existing test cases in eco-gotest to run with the new frr namespace. 