### PR TITLE
ci: backport eco-goinfra's fix to prevent forks from running nightly crons

### DIFF
--- a/.github/workflows/docker-image-ci.yml
+++ b/.github/workflows/docker-image-ci.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   build:
     name: Build and push docker image
+    if: github.repository_owner == 'openshift-kni'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/docker-image-manual.yml
+++ b/.github/workflows/docker-image-manual.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   build:
     name: Build and push docker image
+    if: github.repository_owner == 'openshift-kni'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/eco-goinfra-bump.yml
+++ b/.github/workflows/eco-goinfra-bump.yml
@@ -8,6 +8,7 @@ permissions:
 jobs:
   main:
     name: Eco-goinfra module bump
+    if: github.repository_owner == 'openshift-kni'
 
     permissions:
       contents: write  # for peter-evans/create-pull-request to create branch


### PR DESCRIPTION
Applied same fix for from: https://github.com/openshift-kni/eco-goinfra/pull/961 

This will prevent running the actions that will surely fail. 


