### PR TITLE
yaml: Address mismatch of v2/v3 imports

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -54,7 +54,6 @@ linters-settings:
         - "github.com/stmcginnis/gofish"
         - "github.com/BurntSushi/toml"
         - "github.com/containers/image/v5/pkg/sysregistriesv2"
-        - "gopkg.in/yaml.v2"
         - "gopkg.in/yaml.v3"
         - "gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/types"
         - "golang.org/x/crypto/ssh"

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/wk8/go-ordered-map/v2 v2.1.8
 	golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8
 	gopkg.in/k8snetworkplumbingwg/multus-cni.v4 v4.1.4
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.31.5
 	k8s.io/apimachinery v0.31.5
 	k8s.io/client-go v12.0.0+incompatible
@@ -247,7 +247,7 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-require gopkg.in/yaml.v3 v3.0.1
+require gopkg.in/yaml.v2 v2.4.0 // indirect
 
 replace (
 	github.com/imdario/mergo => github.com/imdario/mergo v0.3.16

--- a/tests/accel/internal/accelconfig/config.go
+++ b/tests/accel/internal/accelconfig/config.go
@@ -10,7 +10,7 @@ import (
 	"github.com/kelseyhightower/envconfig"
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-gotests/tests/internal/config"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 const (

--- a/tests/assisted/ztp/internal/installconfig/installconfig.go
+++ b/tests/assisted/ztp/internal/installconfig/installconfig.go
@@ -2,7 +2,7 @@ package installconfig
 
 import (
 	installerTypes "github.com/openshift/installer/pkg/types"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // NewInstallConfigFromString returns an unmarshalled install-config from provided string.

--- a/tests/cnf/core/internal/coreconfig/config.go
+++ b/tests/cnf/core/internal/coreconfig/config.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/internal/cnfconfig"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 const (

--- a/tests/cnf/core/network/internal/netconfig/config.go
+++ b/tests/cnf/core/network/internal/netconfig/config.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/core/internal/coreconfig"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 const (

--- a/tests/cnf/core/network/internal/netnmstate/netnmstate.go
+++ b/tests/cnf/core/network/internal/netnmstate/netnmstate.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/golang/glog"
 	nmstateShared "github.com/nmstate/kubernetes-nmstate/api/shared"

--- a/tests/cnf/internal/cnfconfig/cnfconfig.go
+++ b/tests/cnf/internal/cnfconfig/cnfconfig.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/openshift-kni/eco-gotests/tests/internal/config"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 const (

--- a/tests/cnf/ran/gitopsztp/tests/ztp-generator.go
+++ b/tests/cnf/ran/gitopsztp/tests/ztp-generator.go
@@ -14,7 +14,7 @@ import (
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/ranhelper"
 	. "github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/raninittools"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/ranparam"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 var _ = Describe("ZTP Generator Tests", Label(tsparams.LabelGeneratorTestCases, ranparam.LabelNoContainer), func() {

--- a/tests/cnf/ran/internal/ranconfig/config.go
+++ b/tests/cnf/ran/internal/ranconfig/config.go
@@ -14,7 +14,7 @@ import (
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/ranparam"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/version"
 	"github.com/openshift-kni/eco-gotests/tests/internal/inittools"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 const (

--- a/tests/hw-accel/nfd/internal/set/featurelist.go
+++ b/tests/hw-accel/nfd/internal/set/featurelist.go
@@ -3,7 +3,7 @@ package set
 import (
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
 	"github.com/openshift-kni/eco-gotests/tests/hw-accel/internal/deploy"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // Config worker-config.

--- a/tests/internal/config/config.go
+++ b/tests/internal/config/config.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/kelseyhightower/envconfig"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 const (

--- a/tests/lca/imagebasedinstall/mgmt/internal/mgmtconfig/config.go
+++ b/tests/lca/imagebasedinstall/mgmt/internal/mgmtconfig/config.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openshift-kni/eco-gotests/tests/lca/imagebasedinstall/mgmt/internal/mgmtparams"
 	"github.com/openshift-kni/eco-gotests/tests/lca/internal/seedimage"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // Cluster contains resources information that make up the cluster to be installed.

--- a/tests/lca/imagebasedupgrade/cnf/internal/cnfconfig/config.go
+++ b/tests/lca/imagebasedupgrade/cnf/internal/cnfconfig/config.go
@@ -9,7 +9,7 @@ import (
 	"github.com/kelseyhightower/envconfig"
 	"github.com/openshift-kni/eco-gotests/tests/lca/imagebasedupgrade/cnf/internal/cnfparams"
 	"github.com/openshift-kni/eco-gotests/tests/lca/imagebasedupgrade/internal/ibuconfig"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 const (

--- a/tests/rhwa/internal/rhwaconfig/rhwaconfig.go
+++ b/tests/rhwa/internal/rhwaconfig/rhwaconfig.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/openshift-kni/eco-gotests/tests/internal/config"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 const (

--- a/tests/system-tests/diskencryption/internal/config/config.go
+++ b/tests/system-tests/diskencryption/internal/config/config.go
@@ -12,7 +12,7 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/bmc"
 	"github.com/openshift-kni/eco-gotests/tests/system-tests/diskencryption/tsparams"
 	"github.com/openshift-kni/eco-gotests/tests/system-tests/internal/systemtestsconfig"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 const (

--- a/tests/system-tests/internal/systemtestsconfig/systemtestsconfig.go
+++ b/tests/system-tests/internal/systemtestsconfig/systemtestsconfig.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/openshift-kni/eco-gotests/tests/internal/config"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 const (

--- a/tests/system-tests/ipsec/internal/ipsecconfig/config.go
+++ b/tests/system-tests/ipsec/internal/ipsecconfig/config.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/openshift-kni/eco-gotests/tests/system-tests/internal/systemtestsconfig"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 const (

--- a/tests/system-tests/ran-du/internal/randuconfig/config.go
+++ b/tests/system-tests/ran-du/internal/randuconfig/config.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/openshift-kni/eco-gotests/tests/system-tests/internal/systemtestsconfig"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 const (

--- a/tests/system-tests/rdscore/internal/rdscoreconfig/config.go
+++ b/tests/system-tests/rdscore/internal/rdscoreconfig/config.go
@@ -15,7 +15,7 @@ import (
 	"github.com/kelseyhightower/envconfig"
 	"github.com/openshift-kni/eco-gotests/tests/internal/config"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 const (

--- a/tests/system-tests/spk/internal/spkconfig/config.go
+++ b/tests/system-tests/spk/internal/spkconfig/config.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/openshift-kni/eco-gotests/tests/system-tests/internal/systemtestsconfig"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 const (

--- a/tests/system-tests/vcore/internal/vcoreconfig/config.go
+++ b/tests/system-tests/vcore/internal/vcoreconfig/config.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/openshift-kni/eco-gotests/tests/system-tests/internal/systemtestsconfig"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 const (


### PR DESCRIPTION
Switch totally over to using `yaml.v3`.