### PR TITLE
cnf ran: remove old oran tests

### DIFF
--- a/tests/cnf/ran/oran/internal/tsparams/consts.go
+++ b/tests/cnf/ran/oran/internal/tsparams/consts.go
@@ -38,24 +38,11 @@ const (
 
 	// ImmutableMessage is the message to expect in a Policy's history when an immutable field cannot be updated.
 	ImmutableMessage = "cannot be updated, likely due to immutable fields not matching"
-	// CTMissingSchemaMessage is the ClusterTemplate condition message for when required schema is missing.
-	CTMissingSchemaMessage = "Error validating the clusterInstanceParameters schema"
-	// CTMissingLabelMessage is the ClusterTemplate condition message for when the default ConfigMap is missing an
-	// interface label.
-	CTMissingLabelMessage = "failed to validate the default ConfigMap: 'label' is missing for interface"
 )
 
 const (
 	// TemplateValid is the valid ClusterTemplate used for the provision tests.
 	TemplateValid = "v1"
-	// TemplateNonexistentProfile is the ClusterTemplate version for the nonexistent hardware profile test.
-	TemplateNonexistentProfile = "v2"
-	// TemplateNoHardware is the ClusterTemplate version for the no hardware available test.
-	TemplateNoHardware = "v3"
-	// TemplateMissingLabels is the ClusterTemplate version for the missing interface labels test.
-	TemplateMissingLabels = "v4"
-	// TemplateIncorrectLabel is the ClusterTemplate version for the incorrect boot interface label test.
-	TemplateIncorrectLabel = "v5"
 	// TemplateUpdateProfile is the ClusterTemplate version for the hardware profile update test.
 	TemplateUpdateProfile = "v6"
 	// TemplateInvalid is the ClusterTemplate version for the invalid ClusterTemplate test.

--- a/tests/cnf/ran/oran/internal/tsparams/oranvars.go
+++ b/tests/cnf/ran/oran/internal/tsparams/oranvars.go
@@ -43,21 +43,6 @@ var (
 )
 
 var (
-	// HwmgrFailedAuthCondition is the condition to match for when the HardwareManager fails to authenticate with
-	// the DTIAS.
-	HwmgrFailedAuthCondition = metav1.Condition{
-		Type:    string(pluginv1alpha1.ConditionTypes.Validation),
-		Reason:  string(pluginv1alpha1.ConditionReasons.Failed),
-		Status:  metav1.ConditionFalse,
-		Message: "401",
-	}
-
-	// PRHardwareProvisionFailedCondition is the ProvisioningRequest condition where hardware provisioning failed.
-	PRHardwareProvisionFailedCondition = metav1.Condition{
-		Type:   string(provisioningv1alpha1.PRconditionTypes.HardwareProvisioned),
-		Reason: string(provisioningv1alpha1.CRconditionReasons.Failed),
-		Status: metav1.ConditionFalse,
-	}
 	// PRValidationFailedCondition is the ProvisioningRequest condition where ProvisioningRequest validation failed.
 	PRValidationFailedCondition = metav1.Condition{
 		Type:   string(provisioningv1alpha1.PRconditionTypes.Validated),
@@ -70,13 +55,6 @@ var (
 		Type:   string(provisioningv1alpha1.PRconditionTypes.Validated),
 		Reason: string(provisioningv1alpha1.CRconditionReasons.Completed),
 		Status: metav1.ConditionTrue,
-	}
-	// PRNodeConfigFailedCondition is the ProvisioningRequest condition where applying the node configuration
-	// failed.
-	PRNodeConfigFailedCondition = metav1.Condition{
-		Type:   string(provisioningv1alpha1.PRconditionTypes.HardwareNodeConfigApplied),
-		Reason: string(provisioningv1alpha1.CRconditionReasons.NotApplied),
-		Status: metav1.ConditionFalse,
 	}
 	// PRConfigurationAppliedCondition is the ProvisioningRequest condition where applying day2 configuration
 	// succeeds.
@@ -93,10 +71,11 @@ var (
 		Status: metav1.ConditionTrue,
 	}
 
-	// CTValidationFailedCondition is the ClusterTemplate condition where the validation failed.
-	CTValidationFailedCondition = metav1.Condition{
-		Type:   string(provisioningv1alpha1.CTconditionTypes.Validated),
-		Reason: string(provisioningv1alpha1.CTconditionReasons.Failed),
-		Status: metav1.ConditionFalse,
+	// CTInvalidSchemaCondition is the ClusterTemplate condition where the validation failed due to invalid schema.
+	CTInvalidSchemaCondition = metav1.Condition{
+		Type:    string(provisioningv1alpha1.CTconditionTypes.Validated),
+		Reason:  string(provisioningv1alpha1.CTconditionReasons.Failed),
+		Status:  metav1.ConditionFalse,
+		Message: "Error validating the clusterInstanceParameters schema",
 	}
 )

--- a/tests/cnf/ran/oran/tests/oran-pre-provision.go
+++ b/tests/cnf/ran/oran/tests/oran-pre-provision.go
@@ -8,57 +8,12 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/openshift-kni/eco-goinfra/pkg/oran"
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
-	"github.com/openshift-kni/eco-goinfra/pkg/secret"
 	. "github.com/openshift-kni/eco-gotests/tests/cnf/ran/internal/raninittools"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/oran/internal/helper"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran/oran/internal/tsparams"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Some test cases are marked as pending from the code. This is used for tests that cannot be used with the loopback
-// adaptor and are guaranteed to fail until the production-ready DTIAS is available.
-
 var _ = Describe("ORAN Pre-provision Tests", Label(tsparams.LabelPreProvision), func() {
-	// 77386 - Failed authentication with hardware manager
-	PIt("fails to authenticate with hardware manager using invalid credentials", reportxml.ID("77386"), func() {
-		By("getting a valid Dell HardwareManager")
-		hwmgr, err := helper.GetValidDellHwmgr(HubAPIClient)
-		Expect(err).ToNot(HaveOccurred(), "Failed to get a valid Dell HardwareManager")
-
-		By("getting the Dell AuthSecret")
-		authSecret, err := secret.Pull(
-			HubAPIClient, hwmgr.Definition.Spec.DellData.AuthSecret, tsparams.HardwareManagerNamespace)
-		Expect(err).ToNot(HaveOccurred(), "Failed to get the HardwareManager AuthSecret")
-		Expect(authSecret.Definition.Data).ToNot(BeNil(), "HardwareManager AuthSecret must have data")
-
-		By("copying the secret and updating the password")
-		authSecret.Definition.Name += "-test"
-		authSecret.Definition.Data["password"] = []byte(tsparams.TestBase64Credential) // wrongpassword
-
-		authSecret, err = authSecret.Create()
-		Expect(err).ToNot(HaveOccurred(), "Failed to create the new AuthSecret")
-
-		By("copying the HardwareManager and updating the AuthSecret")
-		hwmgr.Definition.Name += "-test"
-		hwmgr.Definition.Spec.DellData.AuthSecret = authSecret.Definition.Name
-
-		By("creating the copied HardwareManager")
-		hwmgr, err = hwmgr.Create()
-		Expect(err).ToNot(HaveOccurred(), "Failed to create the new HardwareManager")
-
-		By("waiting for the authentication to fail")
-		hwmgr, err = hwmgr.WaitForCondition(tsparams.HwmgrFailedAuthCondition, time.Minute)
-		Expect(err).ToNot(HaveOccurred(), "Failed to wait for the HardwareManager to fail authentication")
-
-		By("deleting the invalid HardwareManager")
-		err = hwmgr.Delete()
-		Expect(err).ToNot(HaveOccurred(), "Failed to delete the invalid HardwareManager")
-
-		By("deleting the invalid AuthSecret")
-		err = authSecret.Delete()
-		Expect(err).ToNot(HaveOccurred(), "Failed to delete the invalid AuthSecret")
-	})
-
 	// 77392 - Apply a ProvisioningRequest referencing an invalid ClusterTemplate
 	It("fails to create ProvisioningRequest with invalid ClusterTemplate", reportxml.ID("77392"), func() {
 		By("attempting to create a ProvisioningRequest")
@@ -67,28 +22,19 @@ var _ = Describe("ORAN Pre-provision Tests", Label(tsparams.LabelPreProvision), 
 		Expect(err).To(HaveOccurred(), "Creating a ProvisioningRequest with an invalid ClusterTemplate should fail")
 	})
 
-	DescribeTable("ClusterTemplate failed validations",
-		func(templateVersion, message string) {
-			By("verifying the ClusterTemplate validation failed with proper message")
-			clusterTemplateName := fmt.Sprintf("%s.%s-%s",
-				tsparams.ClusterTemplateName, RANConfig.ClusterTemplateAffix, templateVersion)
-			clusterTemplateNamespace := tsparams.ClusterTemplateName + "-" + RANConfig.ClusterTemplateAffix
-			clusterTemplate, err := oran.PullClusterTemplate(HubAPIClient, clusterTemplateName, clusterTemplateNamespace)
-			Expect(err).ToNot(HaveOccurred(), "Failed to pull ClusterTemplate with version %s", templateVersion)
+	// 78245 - Missing schema while provisioning without hardware template
+	It("fails to provision without a HardwareTemplate when required schema is missing", reportxml.ID("78245"), func() {
+		By("verifying the ClusterTemplate validation failed with invalid schema message")
+		clusterTemplateName := fmt.Sprintf("%s.%s-%s",
+			tsparams.ClusterTemplateName, RANConfig.ClusterTemplateAffix, tsparams.TemplateMissingSchema)
+		clusterTemplateNamespace := tsparams.ClusterTemplateName + "-" + RANConfig.ClusterTemplateAffix
 
-			condition := tsparams.CTValidationFailedCondition
-			condition.Message = message
+		clusterTemplate, err := oran.PullClusterTemplate(HubAPIClient, clusterTemplateName, clusterTemplateNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Failed to pull ClusterTemplate with missing schema")
 
-			_, err = clusterTemplate.WaitForCondition(condition, time.Minute)
-			Expect(err).ToNot(HaveOccurred(), "Failed to verify the ClusterTemplate validation failed with message %s", message)
-		},
-		// 77389 - Failed provisioning with missing interface labels
-		Entry("fails to provision with missing interface labels",
-			reportxml.ID("77389"), tsparams.TemplateMissingLabels, tsparams.CTMissingLabelMessage),
-		// 78245 - Missing schema while provisioning without hardware template
-		Entry("fails to provision without a HardwareTemplate when required schema is missing",
-			reportxml.ID("78245"), tsparams.TemplateMissingSchema, tsparams.CTMissingSchemaMessage),
-	)
+		_, err = clusterTemplate.WaitForCondition(tsparams.CTInvalidSchemaCondition, time.Minute)
+		Expect(err).ToNot(HaveOccurred(), "Failed to verify the ClusterTemplate validation failed due to invalid schema")
+	})
 
 	When("a ProvisioningRequest is created", func() {
 		AfterEach(func() {
@@ -99,28 +45,6 @@ var _ = Describe("ORAN Pre-provision Tests", Label(tsparams.LabelPreProvision), 
 				Expect(err).ToNot(HaveOccurred(), "Failed to delete the ProvisioningRequest")
 			}
 		})
-
-		DescribeTable("ProvisionRequest pre-provision validations",
-			func(templateVersion string, condition metav1.Condition) {
-				By("creating a ProvisioningRequest")
-				prBuilder := helper.NewProvisioningRequest(HubAPIClient, templateVersion)
-				prBuilder, err := prBuilder.Create()
-				Expect(err).ToNot(HaveOccurred(), "Failed to create a ProvisioningRequest")
-
-				By("verifying the ProvisioningRequest has the expected condition")
-				_, err = prBuilder.WaitForCondition(condition, time.Minute)
-				Expect(err).ToNot(HaveOccurred(), "Failed to verify the ProvisioningRequest status")
-			},
-			// 77387 - Failed provisioning with nonexistent hardware profile
-			PEntry("fails to provision with nonexistent hardware profile",
-				reportxml.ID("77387"), tsparams.TemplateNonexistentProfile, tsparams.PRHardwareProvisionFailedCondition),
-			// 77388 - Failed provisioning with no hardware available
-			Entry("fails to provision with no hardware available",
-				reportxml.ID("77388"), tsparams.TemplateNoHardware, tsparams.PRHardwareProvisionFailedCondition),
-			// 77390 - Failed provisioning with incorrect boot interface label
-			Entry("fails to provision with incorrect boot interface label",
-				reportxml.ID("77390"), tsparams.TemplateIncorrectLabel, tsparams.PRNodeConfigFailedCondition),
-		)
 
 		// 78246 - Successful provisioning without hardware template
 		It("successfully generates ClusterInstance provisioning without HardwareTemplate", reportxml.ID("78246"), func() {


### PR DESCRIPTION
In preparation for the changes to automation for 4.19+, this PR removes all the ORAN test cases that are no longer necessary.