### PR TITLE
metallb: use service.GetGVR()

### DIFF
--- a/tests/cnf/core/network/metallb/tests/bgp-connect-time-tests.go
+++ b/tests/cnf/core/network/metallb/tests/bgp-connect-time-tests.go
@@ -91,7 +91,7 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelBGPTestCases), ContinueOnFa
 		err = namespace.NewBuilder(APIClient, tsparams.TestNamespaceName).CleanObjects(
 			tsparams.DefaultTimeout,
 			pod.GetGVR(),
-			service.GetServiceGVR(),
+			service.GetGVR(),
 			configmap.GetGVR(),
 			nad.GetGVR())
 		Expect(err).ToNot(HaveOccurred(), "Failed to clean test namespace")

--- a/tests/cnf/core/network/metallb/tests/common.go
+++ b/tests/cnf/core/network/metallb/tests/common.go
@@ -382,7 +382,7 @@ func resetOperatorAndTestNS() {
 	err = namespace.NewBuilder(APIClient, tsparams.TestNamespaceName).CleanObjects(
 		tsparams.DefaultTimeout,
 		pod.GetGVR(),
-		service.GetServiceGVR(),
+		service.GetGVR(),
 		configmap.GetGVR(),
 		nad.GetGVR())
 	Expect(err).ToNot(HaveOccurred(), "Failed to clean test namespace")


### PR DESCRIPTION
Follow up to #209 

#209 was created way before these tests referenced the old deprecated func.