### PR TITLE
system-test: Filter FRR nodes per node

### DIFF
--- a/tests/system-tests/rdscore/internal/rdscorecommon/frr-bgp.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/frr-bgp.go
@@ -2,6 +2,7 @@ package rdscorecommon
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -41,6 +42,18 @@ func ReachURLviaFRRroute(ctx SpecContext) {
 				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Empty URL continue")
 
 				continue
+			}
+
+			if len(RDSCoreConfig.FRRExpectedNodes) != 0 {
+				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("User specified list of FRR nodes present: %q",
+					RDSCoreConfig.FRRExpectedNodes)
+
+				if !slices.Contains(RDSCoreConfig.FRRExpectedNodes, _pod.Definition.Spec.NodeName) {
+					glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Pod %q(%q) runs on not user expected node %q. Skipping",
+						_pod.Definition.Name, _pod.Definition.Namespace, _pod.Definition.Spec.NodeName)
+
+					continue
+				}
 			}
 
 			cmd := fmt.Sprintf("curl -Ls --max-time 5 -o /dev/null -w '%%{http_code}' %s", testURL)

--- a/tests/system-tests/rdscore/internal/rdscoreconfig/config.go
+++ b/tests/system-tests/rdscore/internal/rdscoreconfig/config.go
@@ -473,6 +473,7 @@ type CoreConfig struct {
 	//nolint:lll,nolintlint
 	EgressIPTcpPort       string `yaml:"rdscore_egressip_tcp_port_number" envconfig:"ECO_RDSCORE_EGRESSIP_TCP_PORT_NUMBER"`
 	WorkerLabelListOption metav1.ListOptions
+	FRRExpectedNodes      EnvSliceString `yaml:"rdscore_frr_expected_nodes" envconfig:"ECO_RDSCORE_FRR_EXPECTED_NODES"`
 }
 
 // NewCoreConfig returns instance of CoreConfig config type.

--- a/tests/system-tests/rdscore/internal/rdscoreconfig/default.yaml
+++ b/tests/system-tests/rdscore/internal/rdscoreconfig/default.yaml
@@ -162,3 +162,4 @@ rdscore_egressip_ns_two: 'rds-egressip-ns-two'
 rdscore_egressip_ns_label: 'env=sys-qa'
 rdscore_egressip_pod_label: 'app=web'
 rdscore_egressip_tcp_port_number: '9090'
+rdscore_frr_expected_nodes: []


### PR DESCRIPTION
FRR pods now run on all the nodes so we need an option to filter them by node