### PR TITLE
System Test: remove custom metallb ffr namespace from the 4.18 branch

### DIFF
--- a/tests/system-tests/rdscore/internal/rdscorecommon/frr-bgp.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/frr-bgp.go
@@ -26,9 +26,9 @@ func ReachURLviaFRRroute(ctx SpecContext) {
 	By("Finding MetalLB-FRR pods")
 
 	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Searching for pods in %q namespace with %q label",
-		RDSCoreConfig.MetalLBFRRNamespace, rdscoreparams.MetalLBFRRPodSelector)
+		rdscoreparams.MetalLBOperatorNamespace, rdscoreparams.MetalLBFRRPodSelector)
 
-	frrPodList := findPodWithSelector(RDSCoreConfig.MetalLBFRRNamespace,
+	frrPodList := findPodWithSelector(rdscoreparams.MetalLBOperatorNamespace,
 		rdscoreparams.MetalLBFRRPodSelector)
 
 	Expect(len(frrPodList)).ToNot(Equal(0), "No MetalLB FRR pods found")

--- a/tests/system-tests/rdscore/internal/rdscorecommon/metallb-graceful-restart.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/metallb-graceful-restart.go
@@ -477,7 +477,7 @@ func restartMetallbFRRPod(node string, metallbFRRRestartFailed *bool, start, fin
 
 		err = wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute, true,
 			func(context.Context) (bool, error) {
-				mPodList, err = pod.List(APIClient, RDSCoreConfig.MetalLBFRRNamespace,
+				mPodList, err = pod.List(APIClient, rdscoreparams.MetalLBOperatorNamespace,
 					metav1.ListOptions{LabelSelector: rdscoreparams.MetalLBFRRPodSelector})
 
 				if err != nil {
@@ -545,7 +545,7 @@ func restartMetallbFRRPod(node string, metallbFRRRestartFailed *bool, start, fin
 
 		err = wait.PollUntilContextTimeout(context.TODO(), 3*time.Second, 90*time.Second, true,
 			func(context.Context) (bool, error) {
-				mPodList, err = pod.List(APIClient, RDSCoreConfig.MetalLBFRRNamespace,
+				mPodList, err = pod.List(APIClient, rdscoreparams.MetalLBOperatorNamespace,
 					metav1.ListOptions{LabelSelector: "app=frr-k8s"})
 
 				if err != nil {

--- a/tests/system-tests/rdscore/internal/rdscorecommon/metallb-traffic-segregation.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/metallb-traffic-segregation.go
@@ -71,7 +71,7 @@ func VerifyMetallbEgressTrafficSegregation(ctx SpecContext) {
 
 	By("Randomly choosing node for the traceroute deployment")
 
-	segregationTestNode, err := getNodeForTest(RDSCoreConfig.MetalLBFRRNamespace,
+	segregationTestNode, err := getNodeForTest(rdscoreparams.MetalLBOperatorNamespace,
 		rdscoreparams.MetalLBFRRPodSelector)
 	Expect(err).ToNot(HaveOccurred(),
 		fmt.Sprintf("Failed to retrieve testing node name: %v", err))

--- a/tests/system-tests/rdscore/internal/rdscoreconfig/config.go
+++ b/tests/system-tests/rdscore/internal/rdscoreconfig/config.go
@@ -191,7 +191,6 @@ type CoreConfig struct {
 	NROPSchedulerName       string      `yaml:"rdscore_nrop_scheduler_name" envconfig:"ECO_RDSCORE_NROP_SCHEDULER_NAME"`
 	//nolint:lll
 	MetalLBFRRTestURLIPv4 string `yaml:"rdscore_metallb_frr_test_url_ipv4" envconfig:"ECO_RDSCORE_METALLB_FRR_TEST_URL_IPV4"`
-	MetalLBFRRNamespace   string `yaml:"rdscore_frr_namespace" envconfig:"ECO_RDSCORE_METALLB_FRR_NAMESPACE"`
 	MetalLBFRROneIPv4     string `yaml:"rdscore_metallb_frr_one_ipv4" envconfig:"ECO_RDSCORE_METALLB_FRR_ONE_IPV4"`
 	MetalLBFRROneIPv6     string `yaml:"rdscore_metallb_frr_one_ipv6" envconfig:"ECO_RDSCORE_METALLB_FRR_ONEIPV6"`
 	MetalLBFRRTwoIPv4     string `yaml:"rdscore_metallb_frr_two_ipv4" envconfig:"ECO_RDSCORE_METALLB_FRR_TWO_IPV4"`

--- a/tests/system-tests/rdscore/internal/rdscoreconfig/default.yaml
+++ b/tests/system-tests/rdscore/internal/rdscoreconfig/default.yaml
@@ -123,7 +123,6 @@ rdscore_kdump_worker_node_label: 'node-role.kubernetes.io/standard='
 rdscore_kdump_cnf_node_label: 'node-role.kubernetes.io/customcnf='
 rdscore_metallb_frr_test_url_ipv4: ''
 rdscore_metallb_frr_test_url_ipv6: ''
-rdscore_frr_namespace: 'metallb-system'
 # Egress Service
 rdscore_egress_service_ns: rds-egress-ns
 rdscore_egress_service_remote_ip: ''


### PR DESCRIPTION
there is some issue with the retrieving the default value, so the field left empty