### PR TITLE
cnf network: fix metallb test failure [4.18]

### DIFF
--- a/tests/cnf/core/network/metallb/tests/bgp-connect-time-tests.go
+++ b/tests/cnf/core/network/metallb/tests/bgp-connect-time-tests.go
@@ -97,6 +97,13 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelBGPTestCases), ContinueOnFa
 		Expect(err).ToNot(HaveOccurred(), "Failed to clean test namespace")
 	})
 
+	AfterAll(func() {
+		By("Removing test label from worker nodes")
+		if len(cnfWorkerNodeList) > 2 {
+			removeNodeLabel(workerNodeList, metalLbTestsLabel)
+		}
+	})
+
 	It("Verify configuration of a FRR node router peer with the connectTime less than the default of 120 seconds",
 		reportxml.ID("74414"), func() {
 


### PR DESCRIPTION
backport https://github.com/openshift-kni/eco-gotests/pull/517
