### PR TITLE
hw-accel: remove csv checks for certain features in kmm tests

### DIFF
--- a/tests/hw-accel/kmm/internal/get/get.go
+++ b/tests/hw-accel/kmm/internal/get/get.go
@@ -200,5 +200,5 @@ func operatorVersion(apiClient *clients.Settings, namePattern, namespace string)
 		return csvVersion, nil
 	}
 
-	return nil, err
+	return nil, fmt.Errorf("no matching CSV were found")
 }

--- a/tests/hw-accel/kmm/modules/tests/external-registry-test.go
+++ b/tests/hw-accel/kmm/modules/tests/external-registry-test.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"time"
 
-	"github.com/hashicorp/go-version"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/openshift-kni/eco-goinfra/pkg/configmap"
@@ -160,14 +159,6 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSani
 		})
 
 		It("should generate events on nodes when module is loaded", reportxml.ID("68106"), func() {
-			By("Checking if version is greater than 2.0.0")
-			currentVersion, err := get.KmmOperatorVersion(APIClient)
-			Expect(err).ToNot(HaveOccurred(), "failed to get current KMM version")
-			featureFromVersion, _ := version.NewVersion("2.0.0")
-			if currentVersion.LessThan(featureFromVersion) {
-				Skip("Test not supported for versions lower than 2.0.0")
-			}
-
 			By("Getting events from 'default' namespace")
 			eventList, err := events.List(APIClient, "default")
 			Expect(err).ToNot(HaveOccurred(), "Fail to collect events")

--- a/tests/hw-accel/kmm/modules/tests/olm-install-test.go
+++ b/tests/hw-accel/kmm/modules/tests/olm-install-test.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
-	"github.com/hashicorp/go-version"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -12,7 +11,6 @@ import (
 	"github.com/openshift-kni/eco-goinfra/pkg/namespace"
 	"github.com/openshift-kni/eco-goinfra/pkg/olm"
 	"github.com/openshift-kni/eco-goinfra/pkg/reportxml"
-	"github.com/openshift-kni/eco-gotests/tests/hw-accel/kmm/internal/get"
 	. "github.com/openshift-kni/eco-gotests/tests/hw-accel/kmm/internal/kmminittools"
 	"github.com/openshift-kni/eco-gotests/tests/hw-accel/kmm/internal/kmmparams"
 	. "github.com/openshift-kni/eco-gotests/tests/internal/inittools"
@@ -50,14 +48,6 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSani
 		})
 
 		It("Webhook server should be properly installed", reportxml.ID("72719"), func() {
-			By("Checking if version is greater than 2.1.0")
-			currentVersion, err := get.KmmOperatorVersion(APIClient)
-			Expect(err).ToNot(HaveOccurred(), "failed to get current KMM version")
-			featureFromVersion, _ := version.NewVersion("2.1.0")
-			if currentVersion.LessThan(featureFromVersion) {
-				Skip("Test not supported for versions lower than 2.1.0")
-			}
-
 			By("Listing deployments in operator namespace")
 			deploymentList, err := deployment.List(APIClient, kmmparams.KmmOperatorNamespace)
 			Expect(err).NotTo(HaveOccurred(), "error getting deployment list")

--- a/tests/hw-accel/kmm/modules/tests/signing-test.go
+++ b/tests/hw-accel/kmm/modules/tests/signing-test.go
@@ -6,8 +6,6 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/hashicorp/go-version"
-
 	"github.com/openshift-kni/eco-goinfra/pkg/configmap"
 	"github.com/openshift-kni/eco-goinfra/pkg/events"
 	"github.com/openshift-kni/eco-goinfra/pkg/kmm"
@@ -136,7 +134,7 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSani
 			Expect(err).ToNot(HaveOccurred(), "error while building module")
 
 			By("Await driver container deployment")
-			err = await.ModuleDeployment(APIClient, moduleName, kmmparams.ModuleBuildAndSignNamespace, time.Minute,
+			err = await.ModuleDeployment(APIClient, moduleName, kmmparams.ModuleBuildAndSignNamespace, 5*time.Minute,
 				GeneralConfig.WorkerLabelMap)
 			Expect(err).ToNot(HaveOccurred(), "error while waiting on driver deployment")
 
@@ -156,14 +154,6 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSani
 		})
 
 		It("should generate event about build being created and completed", reportxml.ID("68110"), func() {
-			By("Checking if version is greater than 2.0.0")
-			currentVersion, err := get.KmmOperatorVersion(APIClient)
-			Expect(err).ToNot(HaveOccurred(), "failed to get current KMM version")
-			featureFromVersion, _ := version.NewVersion("2.0.0")
-			if currentVersion.LessThan(featureFromVersion) {
-				Skip("Test not supported for versions lower than 2.0.0")
-			}
-
 			By("Getting events from module's namespace")
 			eventList, err := events.List(APIClient, kmmparams.ModuleBuildAndSignNamespace)
 			Expect(err).ToNot(HaveOccurred(), "Fail to collect events")
@@ -185,14 +175,6 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSani
 		})
 
 		It("should generate event about sign being created and completed", reportxml.ID("68108"), func() {
-			By("Checking if version is greater than 2.0.0")
-			currentVersion, err := get.KmmOperatorVersion(APIClient)
-			Expect(err).ToNot(HaveOccurred(), "failed to get current KMM version")
-			featureFromVersion, _ := version.NewVersion("2.0.0")
-			if currentVersion.LessThan(featureFromVersion) {
-				Skip("Test not supported for versions lower than 2.0.0")
-			}
-
 			By("Getting events from module's namespace")
 			eventList, err := events.List(APIClient, kmmparams.ModuleBuildAndSignNamespace)
 			Expect(err).ToNot(HaveOccurred(), "Fail to collect events")

--- a/tests/hw-accel/kmm/modules/tests/version-test.go
+++ b/tests/hw-accel/kmm/modules/tests/version-test.go
@@ -152,7 +152,7 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSani
 			Expect(err).ToNot(HaveOccurred(), "error setting node label")
 
 			By("Check that the module is deployed on just one node")
-			err = await.ModuleDeployment(APIClient, moduleName, kmmparams.VersionModuleTestNamespace, time.Minute,
+			err = await.ModuleDeployment(APIClient, moduleName, kmmparams.VersionModuleTestNamespace, 5*time.Minute,
 				firstNode.Object.Labels)
 			Expect(err).ToNot(HaveOccurred(), "error while checking module is deployed")
 		})

--- a/tests/hw-accel/kmm/modules/tests/webhook-test.go
+++ b/tests/hw-accel/kmm/modules/tests/webhook-test.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 
 	"github.com/golang/glog"
-	"github.com/hashicorp/go-version"
 	"github.com/openshift-kni/eco-goinfra/pkg/schemes/kmm/v1beta1"
-	"github.com/openshift-kni/eco-gotests/tests/hw-accel/kmm/internal/get"
 	"github.com/openshift-kni/eco-gotests/tests/hw-accel/kmm/internal/kmmparams"
 	"github.com/openshift-kni/eco-gotests/tests/hw-accel/kmm/modules/internal/tsparams"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -235,14 +233,6 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSani
 		})
 
 		It("should require image tag or digest for container image", reportxml.ID("75990"), func() {
-			By("Checking if version is greater than 2.2.0")
-			currentVersion, err := get.KmmOperatorVersion(APIClient)
-			Expect(err).ToNot(HaveOccurred(), "failed to get current KMM version")
-			featureFromVersion, _ := version.NewVersion("2.2.0")
-			if currentVersion.LessThan(featureFromVersion) {
-				Skip("Test not supported for versions lower than 2.2.0")
-			}
-
 			By("Preparing module")
 			module := &v1beta1.Module{
 				ObjectMeta: metav1.ObjectMeta{
@@ -257,7 +247,7 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSani
 			module.Spec.ModuleLoader.Container.KernelMappings = mappings
 
 			By("Create Module")
-			err = APIClient.Create(context.TODO(), module)
+			err := APIClient.Create(context.TODO(), module)
 			Expect(err).To(HaveOccurred(), "error creating module")
 			glog.V(kmmparams.KmmLogLevel).Infof("err is: %s", err)
 			Expect(err.Error()).To(ContainSubstring("container image must explicitely set a tag or digest")) //nolint:misspell


### PR DESCRIPTION
Removed the checks on operator version
Updated some timeouts
Properly return an error while looking for KMM CSVs