### PR TITLE
system-test: fix logging issue for failed deployments

### DIFF
--- a/tests/system-tests/rdscore/internal/rdscorecommon/sriov-validation.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/sriov-validation.go
@@ -657,7 +657,10 @@ func VerifySRIOVWorkloadsOnSameNode(ctx SpecContext) {
 
 	deploy, err = deploy.CreateAndWaitUntilReady(5 * time.Minute)
 	Expect(err).ToNot(HaveOccurred(),
-		fmt.Sprintf("Failed to create deployment %s: %v", deploy.Definition.Name, err))
+		fmt.Sprintf("Failed to create deployment %s: %v", sriovDeploy1OneName, err))
+
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Deployment %q created in %q namespace",
+		deploy.Definition.Name, deploy.Definition.Namespace)
 
 	By("Defining 2nd deployment")
 
@@ -677,7 +680,10 @@ func VerifySRIOVWorkloadsOnSameNode(ctx SpecContext) {
 
 	deployTwo, err = deployTwo.CreateAndWaitUntilReady(5 * time.Minute)
 	Expect(err).ToNot(HaveOccurred(),
-		fmt.Sprintf("Failed to create deployment %s: %v", deployTwo.Definition.Name, err))
+		fmt.Sprintf("Failed to create deployment %s: %v", sriovDeploy1TwoName, err))
+
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Deployment %q created in %q namespace",
+		deployTwo.Definition.Name, deployTwo.Definition.Namespace)
 
 	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Verify connectivity between SR-IOV workloads on the same node")
 


### PR DESCRIPTION
_deployment.CreateAndWaitUntilReady_  returns _nil_ and _error_ in case deployment isn't _Ready_ within requested time therefore accessing attributes like _Definition.Name_ panic:
```
[PANICKED] Test Panicked
In [It] at: /usr/local/go/src/runtime/panic.go:262 @ 04/02/25 08:30:11.477

runtime error: invalid memory address or nil pointer dereference

Full Stack Trace
```