### PR TITLE
Update Go to v1.24.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi9/ubi:latest
 
-ARG GO_VER=go1.24.1
+ARG GO_VER=go1.24.2
 ARG GINKGO_VER=ginkgo@v2.22.2
 ARG CONTAINERUSER=testuser
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift-kni/eco-gotests
 
-go 1.24.1
+go 1.24.2
 
 require (
 	github.com/BurntSushi/toml v1.4.0


### PR DESCRIPTION
Related to: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2899