### PR TITLE
hw-accel: fixing kmm test and some typos

### DIFF
--- a/tests/hw-accel/kmm/internal/await/await.go
+++ b/tests/hw-accel/kmm/internal/await/await.go
@@ -126,11 +126,11 @@ func ModuleObjectDeleted(apiClient *clients.Settings, moduleName, nsName string,
 }
 
 // PreflightStageDone awaits preflightvalidationocp to be in stage Done.
-func PreflightStageDone(apiClinet *clients.Settings, preflight, module, nsname string,
+func PreflightStageDone(apiClient *clients.Settings, preflight, module, nsname string,
 	timeout time.Duration) error {
 	return wait.PollUntilContextTimeout(
 		context.TODO(), 5*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
-			pre, err := kmm.PullPreflightValidationOCP(apiClinet, preflight,
+			pre, err := kmm.PullPreflightValidationOCP(apiClient, preflight,
 				nsname)
 
 			if err != nil {

--- a/tests/hw-accel/kmm/modules/tests/external-registry-test.go
+++ b/tests/hw-accel/kmm/modules/tests/external-registry-test.go
@@ -153,12 +153,14 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSani
 
 			By("Check labels are removed on all nodes")
 			_, err = check.NodeLabel(APIClient, kmodName, localNsName, GeneralConfig.WorkerLabelMap)
-			log.Printf("error is: %v", err)
 			Expect(err).To(HaveOccurred(), "error while checking the module is loaded")
 
 		})
 
 		It("should generate events on nodes when module is loaded", reportxml.ID("68106"), func() {
+			By("Waiting events to be flushed")
+			time.Sleep(30 * time.Second)
+
 			By("Getting events from 'default' namespace")
 			eventList, err := events.List(APIClient, "default")
 			Expect(err).ToNot(HaveOccurred(), "Fail to collect events")
@@ -177,8 +179,8 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSani
 					foundModuleUnloadedEvents++
 				}
 			}
-			Expect(totalNodes).To(Equal(foundModuleLoadedEvents), "ModuleLoaded events do not match")
-			Expect(totalNodes).To(Equal(foundModuleUnloadedEvents), "ModuleUnloaded events do not match")
+			Expect(foundModuleLoadedEvents).To(Equal(totalNodes), "ModuleLoaded events do not match")
+			Expect(foundModuleUnloadedEvents).To(Equal(totalNodes), "ModuleUnloaded events do not match")
 		})
 
 		It("should deploy prebuild image", reportxml.ID("53395"), func() {

--- a/tests/hw-accel/kmm/modules/tests/webhook-test.go
+++ b/tests/hw-accel/kmm/modules/tests/webhook-test.go
@@ -130,7 +130,7 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSani
 
 		Context("Modprobe", Label("webhook"), func() {
 
-			It("should fail if there are duplications in modulesLoaindOrder", reportxml.ID("62742"), func() {
+			It("should fail if there are duplications in modulesLoadingOrder", reportxml.ID("62742"), func() {
 
 				By("Create KernelMapping")
 				image := fmt.Sprintf("%s/%s/%s:$KERNEL_FULL_VERSION",


### PR DESCRIPTION
- Awaiting few seconds for the events to be published in the events tests. If still does not work, some redesign is needed
- Fixing some misspelled words in some vars