### PR TITLE
hw-accel: add "default" namespace and Events in KMM reporter

### DIFF
--- a/tests/hw-accel/kmm/internal/kmmparams/const.go
+++ b/tests/hw-accel/kmm/internal/kmmparams/const.go
@@ -217,6 +217,8 @@ const (
 	VersionModuleTestNamespace = "modver"
 	// TolerationModuleTestNamespace represents test case namespace name.
 	TolerationModuleTestNamespace = "79205-tol"
+	// DefaultNodesNamespace represents namespace of the nodes events.
+	DefaultNodesNamespace = "default"
 	// PreflightTemplateImage represents image against which preflightvalidationocp will build against.
 	PreflightTemplateImage = "quay.io/openshift-release-dev/ocp-release:4.16.15-%s"
 	// PreflightName represents preflightvalidation ocp object name.

--- a/tests/hw-accel/kmm/modules/internal/tsparams/kmm-vars.go
+++ b/tests/hw-accel/kmm/modules/internal/tsparams/kmm-vars.go
@@ -4,6 +4,7 @@ import (
 	moduleV1Beta1 "github.com/openshift-kni/eco-goinfra/pkg/schemes/kmm/v1beta1"
 	"github.com/openshift-kni/eco-gotests/tests/hw-accel/kmm/internal/kmmparams"
 	"github.com/openshift-kni/k8sreporter"
+	corev1 "k8s.io/api/core/v1"
 )
 
 var (
@@ -29,10 +30,12 @@ var (
 		kmmparams.VersionModuleTestNamespace:      "module",
 		kmmparams.ScannerTestNamespace:            "module",
 		kmmparams.TolerationModuleTestNamespace:   "module",
+		kmmparams.DefaultNodesNamespace:           "nodes",
 	}
 
 	// ReporterCRDsToDump tells to the reporter what CRs to dump.
 	ReporterCRDsToDump = []k8sreporter.CRData{
 		{Cr: &moduleV1Beta1.ModuleList{}},
+		{Cr: &corev1.EventList{}},
 	}
 )


### PR DESCRIPTION
- Include `default` namespace in the reporter
- Include events in the reporter