### PR TITLE
fix metallb func validateprefix

### DIFF
--- a/tests/cnf/core/network/metallb/tests/common.go
+++ b/tests/cnf/core/network/metallb/tests/common.go
@@ -439,7 +439,7 @@ func validatePrefix(
 		}
 	}
 
-	Expect(workerNodesAddresses).To(ContainElements(nextHopAddresses),
+	Expect(nextHopAddresses).To(ContainElements(workerNodesAddresses),
 		"Failed next hop address in not in node addresses list")
 }
 

--- a/tests/cnf/core/network/metallb/tests/metallb-nodeSelector.go
+++ b/tests/cnf/core/network/metallb/tests/metallb-nodeSelector.go
@@ -275,9 +275,9 @@ func verifyBGPConnectivityAndPrefixes(frrPod0, frrPod1 *pod.Builder, nodeAddrLis
 
 	By("Validating BGP route prefix on Frr Master 0")
 	validatePrefix(frrPod0, netparam.IPV4Family, netparam.IPSubnetInt32,
-		removePrefixFromIPList(nodeAddrList), addressPool1)
+		removePrefixFromIPList([]string{nodeAddrList[0]}), addressPool1)
 
 	By("Validating BGP route prefix on Frr Master 1")
 	validatePrefix(frrPod1, netparam.IPV4Family, netparam.IPSubnetInt32,
-		removePrefixFromIPList(nodeAddrList), addressPool2)
+		removePrefixFromIPList([]string{nodeAddrList[1]}), addressPool2)
 }


### PR DESCRIPTION
In func validatePrefix the comparsion of [] was reversed.
	Expect(nextHopAddresses).To(ContainElements(workerNodesAddresses),
		"Failed next hop address in not in node addresses list")
When correct this error the two nodeselector test cases failed because they passed in the incorrect number of workerNodesAddresses. 