### PR TITLE
cnf-network: Enhance `setupNGNXPod` to support dynamic pod naming.

### DIFF
--- a/tests/cnf/core/network/metallb/internal/cmd/cmd.go
+++ b/tests/cnf/core/network/metallb/internal/cmd/cmd.go
@@ -8,11 +8,6 @@ import (
 	"github.com/openshift-kni/eco-gotests/tests/cnf/core/network/internal/netparam"
 )
 
-// DefineNGNXAndSleep runs NGNX server.
-func DefineNGNXAndSleep() []string {
-	return []string{"/bin/bash", "-c", "nginx && sleep INF"}
-}
-
 // DefineRouteAndSleep creates route and appends sleep CMD.
 func DefineRouteAndSleep(dstNet, nextHop string) []string {
 	cmd := DefineRoute(dstNet, nextHop)

--- a/tests/cnf/core/network/metallb/internal/tsparams/consts.go
+++ b/tests/cnf/core/network/metallb/internal/tsparams/consts.go
@@ -44,6 +44,8 @@ const (
 	LabelValue1 = "nginx1"
 	// LabelValue2 is the value name for the label2.
 	LabelValue2 = "nginx2"
+	// MLBNginxPodName represents the pod name used for the MetalLB NGINX configuration.
+	MLBNginxPodName = "mlbnginxtpod"
 	// FRRBaseConfig represents FRR daemon minimal configuration.
 	FRRBaseConfig = `!
 frr defaults traditional

--- a/tests/cnf/core/network/metallb/tests/bfd-test.go
+++ b/tests/cnf/core/network/metallb/tests/bfd-test.go
@@ -213,7 +213,9 @@ var _ = Describe("BFD", Ordered, Label(tsparams.LabelBFDTestCases), ContinueOnFa
 					tsparams.MetallbServiceName, ipStack, tsparams.LabelValue1, ipAddressPool, externalTrafficPolicy)
 
 				By("Creating nginx test pod on worker node")
-				setupNGNXPod(workerNodeList[0].Definition.Name, tsparams.LabelValue1)
+				setupNGNXPod(tsparams.MLBNginxPodName+workerNodeList[0].Definition.Name,
+					workerNodeList[0].Definition.Name,
+					tsparams.LabelValue1)
 
 				By("Creating internal NAD")
 				masterBridgePlugin, err := nad.NewMasterBridgePlugin("internalnad", "br0").

--- a/tests/cnf/core/network/metallb/tests/bgp-multiservice.go
+++ b/tests/cnf/core/network/metallb/tests/bgp-multiservice.go
@@ -81,8 +81,12 @@ var _ = Describe("MetalLB BGP", Ordered, Label(tsparams.LabelBGPTestCases), Cont
 			ipAddressPool1,
 			corev1.ServiceExternalTrafficPolicyTypeCluster)
 
-		setupNGNXPod(workerNodeList[0].Definition.Name, tsparams.LabelValue1)
-		setupNGNXPod(workerNodeList[1].Definition.Name, tsparams.LabelValue1)
+		setupNGNXPod("mlbnginxtpod1"+workerNodeList[0].Definition.Name,
+			workerNodeList[0].Definition.Name,
+			tsparams.LabelValue1)
+		setupNGNXPod("mlbnginxtpod1"+workerNodeList[1].Definition.Name,
+			workerNodeList[1].Definition.Name,
+			tsparams.LabelValue1)
 
 		By("Creating service 2 with 2 backend pods")
 		setupMetalLbService(
@@ -92,8 +96,12 @@ var _ = Describe("MetalLB BGP", Ordered, Label(tsparams.LabelBGPTestCases), Cont
 			ipAddressPool2,
 			corev1.ServiceExternalTrafficPolicyTypeCluster)
 
-		setupNGNXPod(workerNodeList[0].Definition.Name, tsparams.LabelValue2)
-		setupNGNXPod(workerNodeList[1].Definition.Name, tsparams.LabelValue2)
+		setupNGNXPod("mlbnginxtpod2"+workerNodeList[0].Definition.Name,
+			workerNodeList[0].Definition.Name,
+			tsparams.LabelValue2)
+		setupNGNXPod("mlbnginxtpod2"+workerNodeList[1].Definition.Name,
+			workerNodeList[1].Definition.Name,
+			tsparams.LabelValue2)
 
 		By("Creating an IBGP BGP Peer")
 		frrk8sPods := verifyAndCreateFRRk8sPodList()

--- a/tests/cnf/core/network/metallb/tests/bgp-tests.go
+++ b/tests/cnf/core/network/metallb/tests/bgp-tests.go
@@ -112,7 +112,9 @@ var _ = Describe("BGP", Ordered, Label(tsparams.LabelBGPTestCases), ContinueOnFa
 					corev1.ServiceExternalTrafficPolicyTypeCluster)
 
 				By("Creating nginx test pod on worker node")
-				setupNGNXPod(workerNodeList[0].Definition.Name, tsparams.LabelValue1)
+				setupNGNXPod(tsparams.MLBNginxPodName+workerNodeList[0].Definition.Name,
+					workerNodeList[0].Definition.Name,
+					tsparams.LabelValue1)
 
 				By("Checking that BGP session is established and up")
 				verifyMetalLbBGPSessionsAreUPOnFrrPod(frrPod, netcmd.RemovePrefixFromIPList(nodeAddrList))

--- a/tests/cnf/core/network/metallb/tests/common.go
+++ b/tests/cnf/core/network/metallb/tests/common.go
@@ -25,7 +25,6 @@ import (
 	"github.com/openshift-kni/eco-gotests/tests/cnf/core/network/internal/ipaddr"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/core/network/internal/netenv"
 	. "github.com/openshift-kni/eco-gotests/tests/cnf/core/network/internal/netinittools"
-	mlbcmd "github.com/openshift-kni/eco-gotests/tests/cnf/core/network/metallb/internal/cmd"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/core/network/metallb/internal/frr"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/core/network/metallb/internal/metallbenv"
 	"github.com/openshift-kni/eco-gotests/tests/cnf/core/network/metallb/internal/prometheus"
@@ -364,12 +363,12 @@ func setupMetalLbService(
 	Expect(err).ToNot(HaveOccurred(), "Failed to create MetalLB Service")
 }
 
-func setupNGNXPod(nodeName, labelValue string) {
+func setupNGNXPod(podName, nodeName, labelValue string) {
 	_, err := pod.NewBuilder(
-		APIClient, "mlbnginxtpod"+nodeName, tsparams.TestNamespaceName, NetConfig.CnfNetTestContainer).
+		APIClient, podName, tsparams.TestNamespaceName, NetConfig.CnfNetTestContainer).
 		DefineOnNode(nodeName).
 		WithLabel("app", labelValue).
-		RedefineDefaultCMD(mlbcmd.DefineNGNXAndSleep()).
+		RedefineDefaultCMD([]string{"/bin/bash", "-c", "nginx && sleep INF"}).
 		WithPrivilegedFlag().CreateAndWaitUntilRunning(tsparams.DefaultTimeout)
 	Expect(err).ToNot(HaveOccurred(), "Failed to create nginx test pod")
 }

--- a/tests/cnf/core/network/metallb/tests/frrk8-tests.go
+++ b/tests/cnf/core/network/metallb/tests/frrk8-tests.go
@@ -316,7 +316,9 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelFRRTestCases), ContinueOnFa
 				corev1.ServiceExternalTrafficPolicyTypeCluster)
 
 			By("Creating nginx test pod on worker node")
-			setupNGNXPod(workerNodeList[0].Definition.Name, tsparams.LabelValue1)
+			setupNGNXPod(tsparams.MLBNginxPodName+workerNodeList[0].Definition.Name,
+				workerNodeList[0].Definition.Name,
+				tsparams.LabelValue1)
 		})
 
 		AfterAll(func() {
@@ -628,7 +630,9 @@ func deployTestPods(addressPool, hubIPAddresses, externalAdvertisedIPv4Routes,
 		corev1.ServiceExternalTrafficPolicyTypeCluster)
 
 	By("Creating nginx test pod on worker node")
-	setupNGNXPod(workerNodeList[0].Definition.Name, tsparams.LabelValue1)
+	setupNGNXPod(tsparams.MLBNginxPodName+workerNodeList[0].Definition.Name,
+		workerNodeList[0].Definition.Name,
+		tsparams.LabelValue1)
 
 	By("Creating External NAD")
 

--- a/tests/cnf/core/network/metallb/tests/layer2-test.go
+++ b/tests/cnf/core/network/metallb/tests/layer2-test.go
@@ -101,7 +101,9 @@ var _ = Describe("Layer2", Ordered, Label(tsparams.LabelLayer2TestCases), Contin
 
 	It("Validate MetalLB Layer 2 functionality", reportxml.ID("42936"), func() {
 		By("Creating nginx test pod on worker node")
-		setupNGNXPod(workerNodeList[0].Definition.Name, tsparams.LabelValue1)
+		setupNGNXPod(tsparams.MLBNginxPodName+workerNodeList[0].Definition.Name,
+			workerNodeList[0].Definition.Name,
+			tsparams.LabelValue1)
 
 		By("Getting announcing node name")
 		announcingNodeName := getLBServiceAnnouncingNodeName()
@@ -126,8 +128,12 @@ var _ = Describe("Layer2", Ordered, Label(tsparams.LabelLayer2TestCases), Contin
 			BeEquivalentTo(len(workerNodeList)), "Failed to run metalLb speakers on top of nodes with test label")
 
 		By("Creating nginx test pod on worker nodes")
-		setupNGNXPod(workerNodeList[0].Definition.Name, tsparams.LabelValue1)
-		setupNGNXPod(workerNodeList[1].Definition.Name, tsparams.LabelValue1)
+		setupNGNXPod(tsparams.MLBNginxPodName+workerNodeList[0].Definition.Name,
+			workerNodeList[0].Definition.Name,
+			tsparams.LabelValue1)
+		setupNGNXPod(tsparams.MLBNginxPodName+workerNodeList[1].Definition.Name,
+			workerNodeList[1].Definition.Name,
+			tsparams.LabelValue1)
 
 		By("Getting announcing node name")
 		announcingNodeName := getLBServiceAnnouncingNodeName()

--- a/tests/cnf/core/network/metallb/tests/metallb-crds.go
+++ b/tests/cnf/core/network/metallb/tests/metallb-crds.go
@@ -45,7 +45,9 @@ var _ = Describe("MetalLb New CRDs", Ordered, Label("newcrds"), ContinueOnFailur
 		Expect(err).ToNot(HaveOccurred(), "Failed create MetalLB CR")
 
 		By("Creating nginx test pod")
-		setupNGNXPod(workerNodeList[0].Definition.Name, tsparams.LabelValue1)
+		setupNGNXPod(tsparams.MLBNginxPodName+workerNodeList[0].Definition.Name,
+			workerNodeList[0].Definition.Name,
+			tsparams.LabelValue1)
 
 		By("Generating ConfigMap configuration for the external FRR pod")
 		masterConfigMap := createConfigMap(tsparams.LocalBGPASN, ipv4NodeAddrList, false, true)

--- a/tests/cnf/core/network/metallb/tests/metallb-nodeSelector.go
+++ b/tests/cnf/core/network/metallb/tests/metallb-nodeSelector.go
@@ -195,10 +195,14 @@ func setupTestCase(ipAddressPool1, ipAddressPool2 *metallb.IPAddressPoolBuilder,
 		corev1.ServiceExternalTrafficPolicyTypeCluster)
 
 	By("Creating nginx test pod on worker node 0")
-	setupNGNXPod(workerNodeList[0].Definition.Name, tsparams.LabelValue1)
+	setupNGNXPod(tsparams.MLBNginxPodName+workerNodeList[0].Definition.Name,
+		workerNodeList[0].Definition.Name,
+		tsparams.LabelValue1)
 
 	By("Creating nginx test pod on worker node 1")
-	setupNGNXPod(workerNodeList[1].Definition.Name, tsparams.LabelValue1)
+	setupNGNXPod(tsparams.MLBNginxPodName+workerNodeList[1].Definition.Name,
+		workerNodeList[1].Definition.Name,
+		tsparams.LabelValue1)
 
 	By("Creating External NAD for master FRR pods")
 	createExternalNad(tsparams.ExternalMacVlanNADName)


### PR DESCRIPTION
Refactored `setupNGNXPod` to accept a pod name parameter, enabling dynamic naming for MetalLB NGINX test pods. Updated all calls to include the new naming convention, improving consistency and configurability across tests. Added a constant for the base pod name to streamline usage.