### PR TITLE
cnf network: fix/improve metallb tests

### DIFF
--- a/tests/cnf/core/network/metallb/internal/metallbenv/metallbenv.go
+++ b/tests/cnf/core/network/metallb/internal/metallbenv/metallbenv.go
@@ -118,7 +118,20 @@ func CreateNewMetalLbDaemonSetAndWaitUntilItsRunning(timeout time.Duration, node
 	glog.V(90).Infof("Verifying if the FRR webhook server is deployed and ready")
 
 	// Check FRR Webhook Server Readiness **(LAST STEP)**
-	frrk8sWebhookDeployment, err := deployment.Pull(APIClient, tsparams.FrrK8WebHookServer, NetConfig.Frrk8sNamespace)
+	var frrk8sWebhookDeployment *deployment.Builder
+
+	err = wait.PollUntilContextTimeout(
+		context.TODO(), 3*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+			frrk8sWebhookDeployment, err = deployment.Pull(APIClient, tsparams.FrrK8WebHookServer, NetConfig.Frrk8sNamespace)
+			if err != nil {
+				glog.V(90).Infof("Error pulling frrk8s webhook %s in namespace %s, retrying...",
+					tsparams.FrrK8WebHookServer, NetConfig.Frrk8sNamespace)
+
+				return false, nil
+			}
+
+			return true, nil
+		})
 	if err != nil {
 		return fmt.Errorf("failed to pull the frrk8s webhook server: %w", err)
 	}

--- a/tests/cnf/core/network/metallb/tests/common.go
+++ b/tests/cnf/core/network/metallb/tests/common.go
@@ -118,6 +118,7 @@ func updateNodeLabel(workerNodeList []*nodes.Builder, nodeLabel map[string]strin
 		if removeLabel {
 			worker.RemoveLabel(netenv.MapFirstKeyValue(nodeLabel))
 		} else {
+			worker.RemoveLabel(netenv.MapFirstKeyValue(nodeLabel))
 			worker.WithNewLabel(netenv.MapFirstKeyValue(nodeLabel))
 		}
 
@@ -502,7 +503,7 @@ func verifyAndCreateFRRk8sPodList() []*pod.Builder {
 
 	frrk8sPods := []*pod.Builder{}
 
-	for _, node := range cnfWorkerNodeList {
+	for _, node := range workerNodeList {
 		var frrk8sPodList []*pod.Builder
 
 		Eventually(func() error {

--- a/tests/cnf/core/network/metallb/tests/frrk8-tests.go
+++ b/tests/cnf/core/network/metallb/tests/frrk8-tests.go
@@ -293,10 +293,6 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelFRRTestCases), ContinueOnFa
 			err := metallbenv.CreateNewMetalLbDaemonSetAndWaitUntilItsRunning(tsparams.DefaultTimeout, workerLabelMap)
 			Expect(err).ToNot(HaveOccurred(), "Failed to recreate metalLb daemonset")
 
-			By("Creating a new instance of MetalLB Speakers on workers")
-			err = metallbenv.CreateNewMetalLbDaemonSetAndWaitUntilItsRunning(tsparams.DefaultTimeout, workerLabelMap)
-			Expect(err).ToNot(HaveOccurred(), "Failed to recreate metalLb daemonset")
-
 			By("Verifying that the frrk8sPod deployment is in Ready state and create a list of the pods on " +
 				"worker nodes.")
 			frrk8sPods = verifyAndCreateFRRk8sPodList()

--- a/tests/cnf/core/network/metallb/tests/metallb-crds.go
+++ b/tests/cnf/core/network/metallb/tests/metallb-crds.go
@@ -81,7 +81,7 @@ var _ = Describe("MetalLb New CRDs", Ordered, Label("newcrds"), ContinueOnFailur
 		sriovInterfacesUnderTest, err = NetConfig.GetSriovInterfaces(1)
 		Expect(err).ToNot(HaveOccurred(), "Failed to retrieve SR-IOV interfaces for testing")
 
-		addOrDeleteNodeSecIPAddViaFRRK8S("add", cnfWorkerNodeList[0].Object.Name,
+		addOrDeleteNodeSecIPAddViaFRRK8S("add", workerNodeList[0].Object.Name,
 			ipSecondaryInterface1, sriovInterfacesUnderTest[0])
 
 		By("Creating an IPAddressPool and BGPAdvertisement")
@@ -99,7 +99,7 @@ var _ = Describe("MetalLb New CRDs", Ordered, Label("newcrds"), ContinueOnFailur
 
 	AfterAll(func() {
 		By("Removing IP to a secondary interface from the worker 0")
-		addOrDeleteNodeSecIPAddViaFRRK8S("del", cnfWorkerNodeList[0].Object.Name,
+		addOrDeleteNodeSecIPAddViaFRRK8S("del", workerNodeList[0].Object.Name,
 			ipSecondaryInterface1, sriovInterfacesUnderTest[0])
 
 		By("Removing MetalLB CRs and cleaning the test ns")
@@ -125,7 +125,7 @@ var _ = Describe("MetalLb New CRDs", Ordered, Label("newcrds"), ContinueOnFailur
 		staticIPAnnotation := pod.StaticIPAnnotation("l2nad", []string{ipSecondaryInterface2})
 
 		l2ClientPod, err := pod.NewBuilder(APIClient, "l2client", tsparams.TestNamespaceName, NetConfig.CnfNetTestContainer).
-			DefineOnNode(cnfWorkerNodeList[1].Object.Name).
+			DefineOnNode(workerNodeList[1].Object.Name).
 			WithSecondaryNetwork(staticIPAnnotation).
 			CreateAndWaitUntilRunning(5 * time.Minute)
 		Expect(err).ToNot(HaveOccurred(), "Failed to create l2 client pod")


### PR DESCRIPTION
- frrk8s webhook server starts after deploying metallb instance for the first on the cluster. 1st test will fail if eco-gotests is ran right after cluster deployment. Hence, adding wait time.
- ReportIfFailed does not have correct test namespace and relevant CR/Objects to be fetched
- frrk8s test creates metallb instance twice
- use workerNodeList var instead cnfWorkerNodeList while fetching frrk8s pods. Tests fail on 3 worker node setup with this.
- remove using  cnfWorkerNodeList var everywhere else in metallb tests and use workerNodeList var only
- addlabel to the node will attempt to remove it first. This is to avoid test failures when we are trying to add a label to the node which already has the same label.