### PR TITLE
IBU: Refactored ValidateNoImagesPulled test

### DIFF
--- a/tests/lca/imagebasedupgrade/cnf/internal/validations/post_ibu_validations.go
+++ b/tests/lca/imagebasedupgrade/cnf/internal/validations/post_ibu_validations.go
@@ -336,12 +336,9 @@ func ValidateNoImagesPulled() {
 			catSrc, err := olm.ListCatalogSources(TargetSNOAPIClient, "openshift-marketplace")
 			Expect(err).ToNot(HaveOccurred(), "Failed to list catalog sources")
 
-			excludeImages := "| grep -v "
-			for i, catalogSource := range catSrc {
-				excludeImages += catalogSource.Definition.Spec.Image
-				if i < len(catSrc)-1 {
-					excludeImages += " | grep -v "
-				}
+			excludeImages := ""
+			for _, catalogSource := range catSrc {
+				excludeImages += fmt.Sprintf("|grep -v %s", catalogSource.Definition.Spec.Image)
 			}
 
 			logCmd := "journalctl -l --system | grep Pulling | grep image:"


### PR DESCRIPTION
This change prevents the test from failing when  $excludeImages var is empty. 

Before this change, the test will fail with the error:

```
 [FAILED] Images are being pulled after upgrade: Usage: grep [OPTION]... PATTERNS [FILE]...
  Try 'grep --help' for more information.

  Expected
      <int>: 83
  not to be >
      <int>: 1
  In [It] at: /home/testuser/tests/lca/imagebasedupgrade/cnf/internal/validations/post_ibu_validations.go:352
```

Because when  $excludeImages var is empty, the grep command fails and isses an an error with character count=83 