### PR TITLE
[release-4.18]cnf-network: Refactor BFD test logic and enhance error handling

### DIFF
--- a/tests/cnf/core/network/internal/netenv/netenv.go
+++ b/tests/cnf/core/network/internal/netenv/netenv.go
@@ -93,20 +93,25 @@ func BFDHasStatus(frrPod *pod.Builder, bfdPeer string, status string) error {
 		return err
 	}
 
-	var result []netparam.BFDDescription
+	var peers []netparam.BFDDescription
 
-	err = json.Unmarshal(bfdStatusOut.Bytes(), &result)
+	err = json.Unmarshal(bfdStatusOut.Bytes(), &peers)
 	if err != nil {
 		return err
 	}
 
-	for _, peer := range result {
-		if peer.BFDPeer == bfdPeer && peer.BFDStatus != status {
-			return fmt.Errorf("%s bfd status is %s (expected %s)", peer.BFDPeer, peer.BFDStatus, status)
+	for _, peer := range peers {
+		if peer.BFDPeer == bfdPeer {
+			if peer.BFDStatus != status {
+				return fmt.Errorf("BFD peer %s on pod %s has status %s (expected %s)",
+					bfdPeer, frrPod.Object.Name, peer.BFDStatus, status)
+			}
+
+			return nil
 		}
 	}
 
-	return nil
+	return fmt.Errorf("BFD peer %s not found on pod %s", bfdPeer, frrPod.Object.Name)
 }
 
 // MapFirstKeyValue returns the first key-value pair found in the input map.

--- a/tests/cnf/core/network/metallb/tests/bfd-test.go
+++ b/tests/cnf/core/network/metallb/tests/bfd-test.go
@@ -502,7 +502,7 @@ func setLocalGWMode(status bool) {
 func verifyMetalLbBFDAndBGPSessionsAreUPOnFrrPod(frrPod *pod.Builder, peerAddrList []string) {
 	for _, peerAddress := range netcmd.RemovePrefixFromIPList(peerAddrList) {
 		Eventually(frr.BGPNeighborshipHasState,
-			time.Minute*3, tsparams.DefaultRetryInterval).
+			time.Minute*4, tsparams.DefaultRetryInterval).
 			WithArguments(frrPod, peerAddress, "Established").Should(
 			BeTrue(), "Failed to receive BGP status UP")
 		Eventually(netenv.BFDHasStatus,


### PR DESCRIPTION
Updated variable names and error messages for better clarity in BFD tests. Adjusted worker node selection logic, introduced proper resource cleanup in AfterAll and AfterEach blocks, and modified timeout durations to improve test reliability. Changes ensure improved readability, maintainability, and robustness of the test suite.