### PR TITLE
system-test: cleanup pods affected by KDump tests

### DIFF
--- a/tests/system-tests/rdscore/internal/rdscorecommon/kernel-crash-kdump.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/kernel-crash-kdump.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openshift-kni/eco-goinfra/pkg/nodes"
+	"github.com/openshift-kni/eco-goinfra/pkg/pod"
 	"github.com/openshift-kni/eco-gotests/tests/system-tests/internal/reboot"
 	"github.com/openshift-kni/eco-gotests/tests/system-tests/internal/remote"
 
@@ -128,4 +129,104 @@ func VerifyKDumpOnWorkerMCP(ctx SpecContext) {
 // VerifyKDumpOnCNFMCP check KDump service on nodes in "CNF" MCP.
 func VerifyKDumpOnCNFMCP(ctx SpecContext) {
 	crashNodeKDump(RDSCoreConfig.KDumpCNFMCPNodeLabel)
+}
+
+// CleanupUnexpectedAdmissionPodsCP cleans up pods with UnexpectedAdmissionError status
+// on the Control Plane nodes.
+func CleanupUnexpectedAdmissionPodsCP(ctx SpecContext) {
+	cleanupUnexpectedPods(RDSCoreConfig.KDumpCPNodeLabel)
+}
+
+// CleanupUnexpectedAdmissionPodsWorker cleans up pods with UnexpectedAdmissionError status
+// on the Worker nodes.
+func CleanupUnexpectedAdmissionPodsWorker(ctx SpecContext) {
+	cleanupUnexpectedPods(RDSCoreConfig.KDumpWorkerMCPNodeLabel)
+}
+
+// CleanupUnexpectedAdmissionPodsCNF cleans up pods with UnexpectedAdmissionError status
+// on the CNF nodes.
+func CleanupUnexpectedAdmissionPodsCNF(ctx SpecContext) {
+	cleanupUnexpectedPods(RDSCoreConfig.KDumpCNFMCPNodeLabel)
+}
+
+func cleanupUnexpectedPods(nodeLabel string) {
+	listOptions := metav1.ListOptions{
+		FieldSelector: "status.phase=Failed",
+	}
+
+	var (
+		nodeList []*nodes.Builder
+		podsList []*pod.Builder
+		err      error
+		ctx      SpecContext
+	)
+
+	By("Searching for pods with UnexpectedAdmissionError status")
+
+	Eventually(func() bool {
+		podsList, err = pod.ListInAllNamespaces(APIClient, listOptions)
+		if err != nil {
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to list pods: %v", err)
+
+			return false
+		}
+
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Found %d pods matching search criteria",
+			len(podsList))
+
+		for _, failedPod := range podsList {
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Pod %q in %q ns matches search criteria",
+				failedPod.Definition.Name, failedPod.Definition.Namespace)
+		}
+
+		return true
+	}).WithContext(ctx).WithPolling(5*time.Second).WithTimeout(1*time.Minute).Should(BeTrue(),
+		"Failed to search for pods with UnexpectedAdmissionError status")
+
+	if len(podsList) == 0 {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("No pods with UnexpectedAdmissionError status found")
+
+		return
+	}
+
+	By("Retrieving nodes list")
+
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Find nodes matching label %q", nodeLabel)
+
+	Eventually(func() bool {
+		nodeList, err = nodes.List(
+			APIClient,
+			metav1.ListOptions{LabelSelector: nodeLabel},
+		)
+
+		if err != nil {
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to list nodes: %w", err)
+
+			return false
+		}
+
+		return len(nodeList) > 0
+	}).WithContext(ctx).WithTimeout(1*time.Minute).WithPolling(5*time.Second).Should(BeTrue(),
+		fmt.Sprintf("Failed to find node(s) matching label: %q", nodeLabel))
+
+	for _, _node := range nodeList {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Node %q macthes label %q",
+			_node.Definition.Name, nodeLabel)
+	}
+
+	By("Filtering pods with UnexpectedAdmissionError that run on the target node(s)")
+
+	for _, failedPod := range podsList {
+		if failedPod.Definition.Status.Reason == "UnexpectedAdmissionError" {
+			for _, _node := range nodeList {
+				if _node.Definition.Name == failedPod.Definition.Spec.NodeName {
+					glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Deleting pod %q in %q ns running on %q",
+						failedPod.Definition.Name, failedPod.Definition.Namespace, _node.Definition.Name)
+
+					_, err := failedPod.DeleteAndWait(5 * time.Minute)
+					Expect(err).ToNot(HaveOccurred(), "could not delete pod in UnexpectedAdmissionError state")
+				}
+			}
+		}
+	}
 }

--- a/tests/system-tests/rdscore/tests/00_validate_top_level.go
+++ b/tests/system-tests/rdscore/tests/00_validate_top_level.go
@@ -64,13 +64,28 @@ var _ = Describe(
 				Label("kdump", "kdump-cp"), reportxml.ID("75620"),
 				rdscorecommon.VerifyKDumpOnControlPlane)
 
+			It("Cleanup UnexpectedAdmission pods after KDump test on Control Plane node",
+				Label("kdump", "kdump-cp", "kdump-cp-cleanup"),
+				MustPassRepeatedly(3),
+				rdscorecommon.CleanupUnexpectedAdmissionPodsCP)
+
 			It("Verifies KDump service on Worker node",
 				Label("kdump", "kdump-worker"), reportxml.ID("75621"),
 				rdscorecommon.VerifyKDumpOnWorkerMCP)
 
+			It("Cleanup UnexpectedAdmission pods after KDump test on Worker node",
+				Label("kdump", "kdump-worker", "kdump-worker-cleanup"),
+				MustPassRepeatedly(3),
+				rdscorecommon.CleanupUnexpectedAdmissionPodsWorker)
+
 			It("Verifies KDump service on CNF node",
 				Label("kdump", "kdump-cnf"), reportxml.ID("75622"),
 				rdscorecommon.VerifyKDumpOnCNFMCP)
+
+			It("Cleanup UnexpectedAdmission pods after KDump test on CNF node",
+				Label("kdump", "kdump-cnf", "kdump-cnf-cleanup"),
+				MustPassRepeatedly(3),
+				rdscorecommon.CleanupUnexpectedAdmissionPodsCNF)
 
 			It("Verifies mount namespace service on Control Plane node",
 				Label("mount-ns", "mount-ns-cp"), reportxml.ID("75048"),


### PR DESCRIPTION
While testing _kdump_ some running workloads are affected by the ungraceful node shutdown and end up in _UnexpectedAdmission_ state.
This pr addresses this by filtering pods with _UnexpectedAdmission_ state that were running on the node(s) were _kdump_ was tested.