### PR TITLE
cnf network: Remove unnecessary GW mode reversion calls

### DIFF
--- a/tests/cnf/core/network/metallb/tests/bfd-test.go
+++ b/tests/cnf/core/network/metallb/tests/bfd-test.go
@@ -315,9 +315,6 @@ var _ = Describe("BFD", Ordered, Label(tsparams.LabelBFDTestCases), ContinueOnFa
 		err = namespace.NewBuilder(APIClient, tsparams.TestNamespaceName).CleanObjects(
 			tsparams.DefaultTimeout, pod.GetGVR(), nad.GetGVR())
 		Expect(err).ToNot(HaveOccurred(), "Failed to clean test namespace")
-
-		By("Reverting Local GW mode")
-		setLocalGWMode(false)
 	})
 })
 

--- a/tests/cnf/core/network/metallb/tests/metallb-crds.go
+++ b/tests/cnf/core/network/metallb/tests/metallb-crds.go
@@ -112,9 +112,6 @@ var _ = Describe("MetalLb New CRDs", Ordered, Label("newcrds"), ContinueOnFailur
 		if len(cnfWorkerNodeList) > 2 {
 			removeNodeLabel(workerNodeList, metalLbTestsLabel)
 		}
-
-		By("Reverting GW mode to the Sharing")
-		setLocalGWMode(false)
 	})
 
 	It("Concurrent Layer2 and Layer3 should work concurrently Layer 2 and Layer 3", reportxml.ID("50059"), func() {


### PR DESCRIPTION
Removed redundant `setLocalGWMode(false)` calls from tests as they are no longer required. This simplifies the teardown process and ensures cleaner test logic.