### PR TITLE
add mlx deviceId 4.18

### DIFF
--- a/tests/cnf/core/network/internal/netparam/netvars.go
+++ b/tests/cnf/core/network/internal/netparam/netvars.go
@@ -31,6 +31,8 @@ var (
 	MlxDeviceID = "1017"
 	// MlxBFDeviceID is the Mellanox Bluefield SRIOV Device ID.
 	MlxBFDeviceID = "a2d6"
+	// MlxConnectX6 is the Mellanox Bluefield SRIOV ConnectX-6 Device ID.
+	MlxConnectX6 = "101f"
 	// ClusterMonitoringNSLabel represents Cluster Monitoring label for a NS to enable Prometheus Scraping.
 	ClusterMonitoringNSLabel = map[string]string{"openshift.io/cluster-monitoring": "true"}
 	// MlxVendorID is the Mellanox Sriov Vendor ID.

--- a/tests/cnf/core/network/sriov/tests/qinq.go
+++ b/tests/cnf/core/network/sriov/tests/qinq.go
@@ -1098,9 +1098,10 @@ func defineAndCreateNADs(nadCVLAN100, nadCVLAN101, nadMasterBond0, intNet1 strin
 func setVFPromiscMode(nodeName, srIovInterfacesUnderTest, sriovDeviceID, onOff string) {
 	promiscVFCommand := fmt.Sprintf("ethtool --set-priv-flags %s vf-true-promisc-support %s",
 		srIovInterfacesUnderTest, onOff)
-	if sriovDeviceID == netparam.MlxDeviceID || sriovDeviceID == netparam.MlxBFDeviceID {
-		promiscVFCommand = fmt.Sprintf("ip link set %s promisc on",
-			srIovInterfacesUnderTest)
+	if sriovDeviceID == netparam.MlxDeviceID || sriovDeviceID == netparam.MlxBFDeviceID ||
+		sriovDeviceID == netparam.MlxConnectX6 {
+		promiscVFCommand = fmt.Sprintf("ip link set %s promisc %s",
+			srIovInterfacesUnderTest, onOff)
 	}
 
 	output, err := cmd.RunCommandOnHostNetworkPod(nodeName, NetConfig.SriovOperatorNamespace, promiscVFCommand)


### PR DESCRIPTION
back port - add deviceID to sriov qinq test cases 