### PR TITLE
add mlx connect6 deviceID backport 4.17

### DIFF
--- a/tests/cnf/core/network/internal/netparam/netvars.go
+++ b/tests/cnf/core/network/internal/netparam/netvars.go
@@ -29,6 +29,8 @@ var (
 	MlxDeviceID = "1017"
 	// MlxBFDeviceID is the Mellanox Bluefield SRIOV Device ID.
 	MlxBFDeviceID = "a2d6"
+	// MlxConnectX6 is the Mellanox Bluefield SRIOV ConnectX-6 Device ID.
+	MlxConnectX6 = "101f"
 	// ClusterMonitoringNSLabel represents Cluster Monitoring label for a NS to enable Prometheus Scraping.
 	ClusterMonitoringNSLabel = map[string]string{"openshift.io/cluster-monitoring": "true"}
 	// MlxVendorID is the Mellanox Sriov Vendor ID.

--- a/tests/cnf/core/network/sriov/tests/qinq.go
+++ b/tests/cnf/core/network/sriov/tests/qinq.go
@@ -1096,9 +1096,10 @@ func defineAndCreateNADs(nadCVLAN100, nadCVLAN101, nadMasterBond0, intNet1 strin
 func setVFPromiscMode(nodeName, srIovInterfacesUnderTest, sriovDeviceID, onOff string) {
 	promiscVFCommand := fmt.Sprintf("ethtool --set-priv-flags %s vf-true-promisc-support %s",
 		srIovInterfacesUnderTest, onOff)
-	if sriovDeviceID == netparam.MlxDeviceID || sriovDeviceID == netparam.MlxBFDeviceID {
-		promiscVFCommand = fmt.Sprintf("ip link set %s promisc on",
-			srIovInterfacesUnderTest)
+	if sriovDeviceID == netparam.MlxDeviceID || sriovDeviceID == netparam.MlxBFDeviceID ||
+		sriovDeviceID == netparam.MlxConnectX6 {
+		promiscVFCommand = fmt.Sprintf("ip link set %s promisc %s",
+			srIovInterfacesUnderTest, onOff)
 	}
 
 	output, err := cmd.RunCommandOnHostNetworkPod(nodeName, NetConfig.SriovOperatorNamespace, promiscVFCommand)


### PR DESCRIPTION
Backport - MLX connection6 deviceID added to sriov qinq test cases