### PR TITLE
cnf network: fix Layer2 flaky tests [4.15]

### DIFF
--- a/tests/cnf/core/network/metallb/tests/layer2-test.go
+++ b/tests/cnf/core/network/metallb/tests/layer2-test.go
@@ -218,7 +218,7 @@ func getLBServiceAnnouncingNodeName() string {
 	var allEvents []string
 
 	sort.Slice(serviceEvents, func(i int, j int) bool {
-		return serviceEvents[i].Object.LastTimestamp.Before(&serviceEvents[i].Object.LastTimestamp)
+		return serviceEvents[i].Object.LastTimestamp.Before(&serviceEvents[j].Object.LastTimestamp)
 	})
 	Expect(len(serviceEvents)).To(BeNumerically(">", 0), "No events were found")
 


### PR DESCRIPTION
backport https://github.com/openshift-kni/eco-gotests/pull/611
