### PR TITLE
cnf network: fix metallb L2 flaky test

### DIFF
--- a/tests/cnf/core/network/metallb/tests/layer2-test.go
+++ b/tests/cnf/core/network/metallb/tests/layer2-test.go
@@ -208,7 +208,7 @@ func getLBServiceAnnouncingNodeName() string {
 	var allEvents []string
 
 	sort.Slice(serviceEvents, func(i int, j int) bool {
-		return serviceEvents[i].Object.LastTimestamp.Before(&serviceEvents[j].Object.LastTimestamp)
+		return serviceEvents[i].Object.FirstTimestamp.Before(&serviceEvents[j].Object.FirstTimestamp)
 	})
 	Expect(len(serviceEvents)).To(BeNumerically(">", 0), "No events were found")
 


### PR DESCRIPTION
Sorting isn't working when lastTimestamp is the same for multiple events. Hence, updating this to use firstTimestamp of the event.

