### PR TITLE
system-test: increase time waiting for SR-IOV pod

### DIFF
--- a/tests/system-tests/rdscore/internal/rdscorecommon/sriov-validation.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/sriov-validation.go
@@ -572,7 +572,7 @@ func verifySRIOVConnectivity(nsOneName, nsTwoName, deployOneLabels, deployTwoLab
 
 	By(fmt.Sprintf("Waiting for pod %q to get Ready", podOne.Definition.Name))
 
-	err = podOne.WaitUntilReady(1 * time.Minute)
+	err = podOne.WaitUntilReady(3 * time.Minute)
 
 	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Pod %q in %q ns is not Ready",
 		podOne.Definition.Name, podOne.Definition.Namespace))
@@ -589,7 +589,7 @@ func verifySRIOVConnectivity(nsOneName, nsTwoName, deployOneLabels, deployTwoLab
 
 	By(fmt.Sprintf("Waiting for pod %q to get Ready", podTwo.Definition.Name))
 
-	err = podTwo.WaitUntilReady(1 * time.Minute)
+	err = podTwo.WaitUntilReady(3 * time.Minute)
 
 	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Pod %q in %q ns is not Ready",
 		podTwo.Definition.Name, podTwo.Definition.Namespace))


### PR DESCRIPTION
While re-running test container fails to start with next error message:
```
Error: 8021q: VLAN device already exists.
```
which is transient error and which is gone shortly after the failure.

As there's no hard requirement on how fast the pod should be recreated after scale down/up - extending timeout to 3 minutes