### PR TITLE
hw-accel: update kmm events strings

### DIFF
--- a/tests/hw-accel/kmm/internal/kmmparams/const.go
+++ b/tests/hw-accel/kmm/internal/kmmparams/const.go
@@ -228,15 +228,15 @@ const (
 	// ReasonBuildCompleted represents event reason for a build completed.
 	ReasonBuildCompleted = "BuildCompleted"
 	// ReasonBuildCreated represents event reason for a build created.
-	ReasonBuildCreated = "BuildCreated"
+	ReasonBuildCreated = "BuildimageCreated"
 	// ReasonBuildStarted represents event reason for a build started.
 	ReasonBuildStarted = "BuildStarted"
 	// ReasonBuildSucceeded represents event reason for a build succeeded.
-	ReasonBuildSucceeded = "BuildSucceeded"
+	ReasonBuildSucceeded = "BuildimageSucceeded"
 	// ReasonSignCreated represents event reason for a sign created.
-	ReasonSignCreated = "SignCreated"
+	ReasonSignCreated = "SignimageCreated"
 	// ReasonSignSucceeded represents event reason for a sign succeeded.
-	ReasonSignSucceeded = "SignSucceeded"
+	ReasonSignSucceeded = "SignimageSucceeded"
 	// ReasonModuleLoaded represents event reason for a module loaded.
 	ReasonModuleLoaded = "ModuleLoaded"
 	// ReasonModuleUnloaded represents event reason for a module unloaded.


### PR DESCRIPTION
Updating event names based on new format

```
05:03:14  I0618 03:03:14.452898   25346 signing-test.go:165] Checking event: BuildStarted
05:03:14  I0618 03:03:14.452914   25346 signing-test.go:165] Checking event: BuildCompleted
05:03:14  I0618 03:03:14.452917   25346 signing-test.go:165] Checking event: BuildimageCreated
05:03:14  I0618 03:03:14.452920   25346 signing-test.go:165] Checking event: BuildimageSucceeded
05:03:14  I0618 03:03:14.452923   25346 signing-test.go:165] Checking event: SignimageCreated
05:03:14  I0618 03:03:14.452927   25346 signing-test.go:165] Checking event: SignimageSucceeded
```