### PR TITLE
DRAFT: cnf-network: adapt tests for clusters with Restricted IP forwarding

### DIFF
--- a/tests/cnf/core/network/metallb/internal/cmd/cmd.go
+++ b/tests/cnf/core/network/metallb/internal/cmd/cmd.go
@@ -11,7 +11,8 @@ import (
 // DefineRouteAndSleep creates route and appends sleep CMD.
 func DefineRouteAndSleep(dstNet, nextHop string) []string {
 	cmd := DefineRoute(dstNet, nextHop)
-	cmd[2] += " && sleep INF"
+	cmd[2] += ` && (echo 1 > /proc/sys/net/ipv4/ip_forward 2>/dev/null || true); \
+trap : TERM INT; sleep infinity & wait`
 
 	return cmd
 }

--- a/tests/cnf/core/network/metallb/internal/tsparams/mlbvars.go
+++ b/tests/cnf/core/network/metallb/internal/tsparams/mlbvars.go
@@ -85,6 +85,13 @@ var (
 	IBPGPProtocol = "iBGP"
 	// TestLabel represents node label for testing.
 	TestLabel = map[string]string{"test": "label"}
+	// IPForwardAndSleepCmd enables IPv4 forwarding and keep the container running command.
+	IPForwardAndSleepCmd = []string{
+		"/bin/bash",
+		"-c",
+		`echo 1 > /proc/sys/net/ipv4/ip_forward 2>/dev/null || true; \
+trap : TERM INT; sleep infinity & wait`,
+	}
 	// MetalLbBgpMetrics represents the list of expected metallb metrics.
 	MetalLbBgpMetrics = []string{"frrk8s_bgp_keepalives_sent", "frrk8s_bgp_keepalives_received",
 		"frrk8s_bgp_notifications_sent", "frrk8s_bgp_opens_received", "frrk8s_bgp_opens_sent",

--- a/tests/cnf/core/network/metallb/tests/bfd-test.go
+++ b/tests/cnf/core/network/metallb/tests/bfd-test.go
@@ -393,8 +393,7 @@ func createBFDProfileAndVerifyIfItsReady(frrk8sPods []*pod.Builder) *metallb.BFD
 	By("Creating BFD profile")
 
 	bfdProfile, err := metallb.NewBFDBuilder(APIClient, "bfdprofile", NetConfig.MlbOperatorNamespace).
-		WithRcvInterval(300).WithTransmitInterval(300).WithEchoInterval(100).
-		WithEchoMode(true).WithPassiveMode(false).WithMinimumTTL(5).
+		WithRcvInterval(300).WithPassiveMode(false).WithMinimumTTL(5).
 		WithMultiplier(3).Create()
 	Expect(err).ToNot(HaveOccurred(), "Failed to create BFD profile")
 	Expect(bfdProfile.Exists()).To(BeTrue(), "BFD profile doesn't exist")

--- a/tests/cnf/core/network/metallb/tests/bgp-remote-as-dynamic.go
+++ b/tests/cnf/core/network/metallb/tests/bgp-remote-as-dynamic.go
@@ -267,12 +267,12 @@ func setupBGPRemoteASMultiHopTest(ipv4metalLbIPList, hubIPv4ExternalAddresses, e
 	By("Creating FRR Hub pod on worker node 0")
 
 	_ = createFrrHubPod(hubPodWorkerName[0],
-		workerNodeList[0].Object.Name, hubConfigMap.Definition.Name, []string{}, hub0BRstaticIPAnnotation)
+		workerNodeList[0].Object.Name, hubConfigMap.Definition.Name, tsparams.IPForwardAndSleepCmd, hub0BRstaticIPAnnotation)
 
 	By("Creating FRR Hub pod on worker node 1")
 
 	_ = createFrrHubPod(hubPodWorkerName[1],
-		workerNodeList[1].Object.Name, hubConfigMap.Definition.Name, []string{}, hub1BRstaticIPAnnotation)
+		workerNodeList[1].Object.Name, hubConfigMap.Definition.Name, tsparams.IPForwardAndSleepCmd, hub1BRstaticIPAnnotation)
 
 	By("Creating configmap and MetalLb Master pod")
 

--- a/tests/cnf/core/network/metallb/tests/frrk8-tests.go
+++ b/tests/cnf/core/network/metallb/tests/frrk8-tests.go
@@ -405,11 +405,17 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelFRRTestCases), ContinueOnFa
 
 				By("Creating FRR Hub pod on worker node 0")
 				_ = createFrrHubPod(hubPodWorker0,
-					workerNodeList[0].Object.Name, hubConfigMap.Definition.Name, []string{}, hub0BRstaticIPAnnotation)
+					workerNodeList[0].Object.Name,
+					hubConfigMap.Definition.Name,
+					tsparams.IPForwardAndSleepCmd,
+					hub0BRstaticIPAnnotation)
 
 				By("Creating FRR Hub pod on worker node 1")
 				_ = createFrrHubPod(hubPodWorker1,
-					workerNodeList[1].Object.Name, hubConfigMap.Definition.Name, []string{}, hub1BRstaticIPAnnotation)
+					workerNodeList[1].Object.Name,
+					hubConfigMap.Definition.Name,
+					tsparams.IPForwardAndSleepCmd,
+					hub1BRstaticIPAnnotation)
 
 				By("Creating configmap and MetalLb Master pod")
 				frrPod := createMasterFrrPod(tsparams.LocalBGPASN, frrExternalMasterIPAddress, nodeAddrList,
@@ -479,11 +485,17 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelFRRTestCases), ContinueOnFa
 
 				By("Creating FRR Hub pod on worker node 0")
 				_ = createFrrHubPod(hubPodWorker0,
-					workerNodeList[0].Object.Name, hubConfigMap.Definition.Name, []string{}, hub0BRstaticIPAnnotation)
+					workerNodeList[0].Object.Name,
+					hubConfigMap.Definition.Name,
+					tsparams.IPForwardAndSleepCmd,
+					hub0BRstaticIPAnnotation)
 
 				By("Creating FRR Hub pod on worker node 1")
 				_ = createFrrHubPod(hubPodWorker1,
-					workerNodeList[1].Object.Name, hubConfigMap.Definition.Name, []string{}, hub1BRstaticIPAnnotation)
+					workerNodeList[1].Object.Name,
+					hubConfigMap.Definition.Name,
+					tsparams.IPForwardAndSleepCmd,
+					hub1BRstaticIPAnnotation)
 
 				By("Creating MetalLb Master pod configMap")
 				frrPod := createMasterFrrPod(tsparams.RemoteBGPASN, frrExternalMasterIPAddress, nodeAddrList,
@@ -578,12 +590,12 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelFRRTestCases), ContinueOnFa
 
 				By("Creating FRR Hub pod on worker node 0")
 				_ = createFrrHubPod(hubPodWorker0,
-					workerNodeList[0].Object.Name, createHubConfigMapSecInt.Definition.Name, []string{},
+					workerNodeList[0].Object.Name, createHubConfigMapSecInt.Definition.Name, tsparams.IPForwardAndSleepCmd,
 					hub0BRStaticSecIntIPAnnotation)
 
 				By("Creating FRR Hub pod on worker node 1")
 				_ = createFrrHubPod(hubPodWorker1,
-					workerNodeList[1].Object.Name, createHubConfigMapSecInt.Definition.Name, []string{},
+					workerNodeList[1].Object.Name, createHubConfigMapSecInt.Definition.Name, tsparams.IPForwardAndSleepCmd,
 					hub1SecIntIPAnnotation)
 
 				By("Creating MetalLb Master pod configMap")


### PR DESCRIPTION
Modified the test logic to support clusters where IP forwarding is restricted by default.
