### PR TITLE
cnf-network: change all sriov policy to use 5 VFs

### DIFF
--- a/tests/cnf/core/network/policy/tests/multinetpolicysriov.go
+++ b/tests/cnf/core/network/policy/tests/multinetpolicysriov.go
@@ -73,7 +73,7 @@ var _ = Describe("SRIOV", Ordered, Label("multinetworkpolicy"), ContinueOnFailur
 			"policysriov",
 			NetConfig.SriovOperatorNamespace,
 			"sriovpolicy",
-			6,
+			5,
 			srIovInterfacesUnderTest,
 			NetConfig.WorkerLabelMap).Create()
 		Expect(err).ToNot(HaveOccurred(), "Failed to create SR-IOV policy")

--- a/tests/cnf/core/network/sriov/tests/allmulti.go
+++ b/tests/cnf/core/network/sriov/tests/allmulti.go
@@ -92,8 +92,8 @@ var _ = Describe("allmulti", Ordered, Label(tsparams.LabelSuite), ContinueOnFail
 			srIovPolicyNode1Name,
 			NetConfig.SriovOperatorNamespace,
 			srIovPolicyNode0ResName,
-			6,
-			[]string{fmt.Sprintf("%s#0-5", srIovInterfacesUnderTest[0])},
+			5,
+			[]string{fmt.Sprintf("%s#0-4", srIovInterfacesUnderTest[0])},
 			nodeSelectorWorker0).WithMTU(9000).WithVhostNet(true).Create()
 		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Failed to create an sriov policy on %s",
 			workerNodes[0].Definition.Name))
@@ -108,8 +108,8 @@ var _ = Describe("allmulti", Ordered, Label(tsparams.LabelSuite), ContinueOnFail
 			srIovPolicyNode2Name,
 			NetConfig.SriovOperatorNamespace,
 			srIovPolicyNode1ResName,
-			6,
-			[]string{fmt.Sprintf("%s#0-5", srIovInterfacesUnderTest[0])},
+			5,
+			[]string{fmt.Sprintf("%s#0-4", srIovInterfacesUnderTest[0])},
 			nodeSelectorWorker1).WithMTU(9000).WithVhostNet(true).Create()
 		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Failed to create an sriov policy on %s",
 			workerNodes[1].Definition.Name))

--- a/tests/cnf/core/network/sriov/tests/externalllymanaged.go
+++ b/tests/cnf/core/network/sriov/tests/externalllymanaged.go
@@ -109,11 +109,6 @@ var _ = Describe("ExternallyManaged", Ordered, Label(tsparams.LabelExternallyMan
 				By("Removing NMState policies")
 				err = nmstate.CleanAllNMStatePolicies(APIClient)
 				Expect(err).ToNot(HaveOccurred(), "Failed to remove all NMState policies")
-
-				if sriovenv.IsMellanoxDevice(sriovInterfacesUnderTest[0], workerNodeList[0].Object.Name) {
-					err = sriovenv.ConfigureSriovMlnxFirmwareOnWorkersAndWaitMCP(workerNodeList, sriovInterfacesUnderTest[0], false, 0)
-					Expect(err).ToNot(HaveOccurred(), "Failed to configure Mellanox firmware")
-				}
 			})
 
 			AfterEach(func() {
@@ -376,7 +371,7 @@ var _ = Describe("ExternallyManaged", Ordered, Label(tsparams.LabelExternallyMan
 					sriovAndResourceNameExManagedTrue,
 					NetConfig.SriovOperatorNamespace,
 					sriovAndResourceNameExManagedTrue,
-					3, []string{fmt.Sprintf("%s#%d-%d", pfInterface, 2, 2)}, NetConfig.WorkerLabelMap).
+					5, []string{fmt.Sprintf("%s#%d-%d", pfInterface, 2, 2)}, NetConfig.WorkerLabelMap).
 					WithExternallyManaged(true)
 
 				err = sriovenv.CreateSriovPolicyAndWaitUntilItsApplied(sriovPolicy, tsparams.MCOWaitTimeout)

--- a/tests/cnf/core/network/sriov/tests/metricsExporter.go
+++ b/tests/cnf/core/network/sriov/tests/metricsExporter.go
@@ -281,19 +281,19 @@ func definePolicy(role, devType, nicVendor, pfName string, vfRange int) *sriov.P
 	switch devType {
 	case "netdevice":
 		policy = sriov.NewPolicyBuilder(APIClient,
-			role+devType, NetConfig.SriovOperatorNamespace, role+devType, 2, []string{pfName}, NetConfig.WorkerLabelMap).
+			role+devType, NetConfig.SriovOperatorNamespace, role+devType, 5, []string{pfName}, NetConfig.WorkerLabelMap).
 			WithDevType("netdevice").
 			WithVFRange(vfRange, vfRange)
 	case "vfiopci":
 		if nicVendor != netparam.MlxVendorID {
 			policy = sriov.NewPolicyBuilder(APIClient,
-				role+devType, NetConfig.SriovOperatorNamespace, role+devType, 2, []string{pfName}, NetConfig.WorkerLabelMap).
+				role+devType, NetConfig.SriovOperatorNamespace, role+devType, 5, []string{pfName}, NetConfig.WorkerLabelMap).
 				WithDevType("vfio-pci").
 				WithVFRange(vfRange, vfRange).
 				WithRDMA(false)
 		} else {
 			policy = sriov.NewPolicyBuilder(APIClient,
-				role+devType, NetConfig.SriovOperatorNamespace, role+devType, 2, []string{pfName}, NetConfig.WorkerLabelMap).
+				role+devType, NetConfig.SriovOperatorNamespace, role+devType, 5, []string{pfName}, NetConfig.WorkerLabelMap).
 				WithDevType("netdevice").
 				WithVFRange(vfRange, vfRange).
 				WithRDMA(true)

--- a/tests/cnf/core/network/sriov/tests/mlxSecureBoot.go
+++ b/tests/cnf/core/network/sriov/tests/mlxSecureBoot.go
@@ -96,10 +96,6 @@ var _ = Describe("Mellanox Secure Boot", Ordered, Label(tsparams.LabelMlxSecureB
 				err = sriovenv.ConfigureSecureBoot(bmcClient, "disable")
 				Expect(err).ToNot(HaveOccurred(), "Failed to disable a secure boot")
 			}
-
-			By("Disabling Mellanox firmware and wait for the cluster becomes stable")
-			err = sriovenv.ConfigureSriovMlnxFirmwareOnWorkersAndWaitMCP(workerNodeList, sriovInterfacesUnderTest[0], false, 0)
-			Expect(err).ToNot(HaveOccurred(), "Failed to configure Mellanox firmware")
 		})
 
 		It("End-to-End SR-IOV Configuration and Validation", reportxml.ID("77014"), func() {
@@ -120,7 +116,7 @@ var _ = Describe("Mellanox Secure Boot", Ordered, Label(tsparams.LabelMlxSecureB
 				sriovAndResourceNameSecureBoot,
 				NetConfig.SriovOperatorNamespace,
 				sriovAndResourceNameSecureBoot,
-				2,
+				5,
 				sriovInterfacesUnderTest[:1],
 				map[string]string{"kubernetes.io/hostname": workerNodeList[0].Definition.Name})
 

--- a/tests/cnf/core/network/sriov/tests/qinq.go
+++ b/tests/cnf/core/network/sriov/tests/qinq.go
@@ -356,8 +356,8 @@ var _ = Describe("QinQ", Ordered, Label(tsparams.LabelQinQTestCases), ContinueOn
 				srIovPolicyNetDevice,
 				NetConfig.SriovOperatorNamespace,
 				srIovPolicyResNameNetDevice,
-				10,
-				[]string{fmt.Sprintf("%s#0-9", srIovInterfacesUnderTest[0])},
+				5,
+				[]string{fmt.Sprintf("%s#0-4", srIovInterfacesUnderTest[0])},
 				NetConfig.WorkerLabelMap).Create()
 			Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Failed to create sriovnetwork policy %s",
 				srIovPolicyNetDevice))
@@ -645,11 +645,6 @@ var _ = Describe("QinQ", Ordered, Label(tsparams.LabelQinQTestCases), ContinueOn
 			By("Removing NMState policies")
 			err = nmstate.CleanAllNMStatePolicies(APIClient)
 			Expect(err).ToNot(HaveOccurred(), "Failed to remove all NMState policies")
-
-			if sriovenv.IsMellanoxDevice(srIovInterfacesUnderTest[0], workerNodeList[0].Object.Name) {
-				err = sriovenv.ConfigureSriovMlnxFirmwareOnWorkersAndWaitMCP(workerNodeList, srIovInterfacesUnderTest[0], false, 0)
-				Expect(err).ToNot(HaveOccurred(), "Failed to configure Mellanox firmware")
-			}
 		})
 	})
 
@@ -1027,8 +1022,8 @@ func defineCreateSriovNetPolices(vfioPCIName, vfioPCIResName, sriovInterface,
 		vfioPCIName,
 		NetConfig.SriovOperatorNamespace,
 		vfioPCIResName,
-		6,
-		[]string{fmt.Sprintf("%s#0-5", sriovInterface)},
+		5,
+		[]string{fmt.Sprintf("%s#0-4", sriovInterface)},
 		NetConfig.WorkerLabelMap).WithVhostNet(true)
 
 	switch reqDriver {

--- a/tests/cnf/core/network/sriov/tests/rdmametricsapi.go
+++ b/tests/cnf/core/network/sriov/tests/rdmametricsapi.go
@@ -73,8 +73,8 @@ var _ = Describe("rdmaMetricsAPI", Ordered, Label(tsparams.LabelRdmaMetricsAPITe
 
 				By("Create Sriov Node Policy and Network")
 
-				tPol1 = defineAndCreateNodePolicy("rdmapolicy1", "sriovpf1", sriovInterfacesUnderTest[0], 2, 1)
-				tPol2 = defineAndCreateNodePolicy("rdmapolicy2", "sriovpf2", sriovInterfacesUnderTest[1], 2, 1)
+				tPol1 = defineAndCreateNodePolicy("rdmapolicy1", "sriovpf1", sriovInterfacesUnderTest[0], 5, 1)
+				tPol2 = defineAndCreateNodePolicy("rdmapolicy2", "sriovpf2", sriovInterfacesUnderTest[1], 5, 1)
 				tNet1 = defineAndCreateSriovNetworkWithRdma("sriovnet1", tPol1.Object.Spec.ResourceName, true)
 				tNet2 = defineAndCreateSriovNetworkWithRdma("sriovnet2", tPol2.Object.Spec.ResourceName, true)
 

--- a/tests/system-tests/vcore/internal/vcorecommon/sriov-validation.go
+++ b/tests/system-tests/vcore/internal/vcorecommon/sriov-validation.go
@@ -151,7 +151,7 @@ func VerifySRIOVConfig(ctx SpecContext) {
 		sriovNet1Name,
 		vcoreparams.SRIOVNamespace,
 		net1ResourceName,
-		8,
+		5,
 		snnpPfname1,
 		VCoreConfig.VCorePpLabelMap)
 	if !sriovNetworkNodePolicy1.Exists() {
@@ -171,7 +171,7 @@ func VerifySRIOVConfig(ctx SpecContext) {
 		sriovNet2Name,
 		vcoreparams.SRIOVNamespace,
 		net1ResourceName,
-		8,
+		5,
 		snnpPfname2,
 		VCoreConfig.VCorePpLabelMap)
 	if !sriovNetworkNodePolicy2.Exists() {


### PR DESCRIPTION
This change helps to reduce overall test runtime by avoiding node reboots when applying new policies to Mellanox (mlnx) devices. Previously, VF count mismatches could trigger unnecessary reboots, slowing down the CI cycle.