### PR TITLE
cnf ran: remove use of brew from ztp-generator

### DIFF
--- a/tests/cnf/ran/internal/ranconfig/config.go
+++ b/tests/cnf/ran/internal/ranconfig/config.go
@@ -164,6 +164,11 @@ func (ranconfig *RANConfig) newHubConfig(configFile string) {
 		glog.V(ranparam.LogLevel).Infof("Failed to get ZTP version from hub: %v", err)
 	}
 
+	ranconfig.ZtpSiteGenerateImage, err = version.GetZTPSiteGenerateImage(ranconfig.HubConfig.HubAPIClient)
+	if err != nil {
+		glog.V(ranparam.LogLevel).Infof("Failed to get ZTP site generate image from hub: %v", err)
+	}
+
 	glog.V(ranparam.LogLevel).Infof("Found ZTP version on hub: %s", ranconfig.HubConfig.ZTPVersion)
 }
 

--- a/tests/cnf/ran/internal/ranconfig/default.yaml
+++ b/tests/cnf/ran/internal/ranconfig/default.yaml
@@ -15,5 +15,4 @@ ptpOperatorNamespace: "openshift-ptp"
 talmPreCachePolicies:
   - "^common(-v4\\.\\d\\d)?-config-policy"
   - "^common(-v4\\.\\d\\d)?-subscriptions-policy"
-ztpSiteGenerateImage: "registry-proxy.engineering.redhat.com/rh-osbs/openshift4-ztp-site-generate"
 ...


### PR DESCRIPTION
The ztp-site-generate container is now built through Konflux so will not appear in brew. This PR updates the ztp-generator test to instead use the ztp-site-generate image taken from the hub.