### PR TITLE
cnf network: metallb layer2 tests

### DIFF
--- a/tests/cnf/core/network/metallb/tests/layer2-test.go
+++ b/tests/cnf/core/network/metallb/tests/layer2-test.go
@@ -206,9 +206,15 @@ func getLBServiceAnnouncingNodeName() string {
 	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Failed to get events in namespace %s", tsparams.TestNamespaceName))
 
 	var allEvents []string
+	//nolint:varnamelen
+	sort.Slice(serviceEvents, func(i, j int) bool {
+		// Primary sort: LastTimestamp
+		if serviceEvents[i].Object.LastTimestamp.Time.Equal(serviceEvents[j].Object.LastTimestamp.Time) {
+			// Secondary sort: FirstTimestamp
+			return serviceEvents[i].Object.FirstTimestamp.Time.Before(serviceEvents[j].Object.FirstTimestamp.Time)
+		}
 
-	sort.Slice(serviceEvents, func(i int, j int) bool {
-		return serviceEvents[i].Object.FirstTimestamp.Before(&serviceEvents[j].Object.FirstTimestamp)
+		return serviceEvents[i].Object.LastTimestamp.Time.Before(serviceEvents[j].Object.LastTimestamp.Time)
 	})
 	Expect(len(serviceEvents)).To(BeNumerically(">", 0), "No events were found")
 


### PR DESCRIPTION
Adding both `firstTimestamp` and `lastTimestamp` criteria for sorting. 
In some cases, multiple events have either same `firstTimestamp` or same `lastTimestamp`.

https://jenkins-csb-kniqe-auto.dno.corp.redhat.com/job/ocp-eco-gotests/3754/
Example for same `firstTimestamp`