### PR TITLE
Cert workaround

### DIFF
--- a/tests/cnf/ran-deployment/README.md
+++ b/tests/cnf/ran-deployment/README.md
@@ -26,7 +26,6 @@ results can be aggregated in a "union" set of results.
 
 | Name                                                 | Description                                                 |
 |------------------------------------------------------|-------------------------------------------------------------|
-| [rancluster](internal/rancluster/rancluster.go)      | Helpers for viewing the state of a cluster itself           |
 | [ranconfig](internal/ranconfig/config.go)            | Configures environment variables and default values         |
 | [raninittools](internal/raninittools/raninitools.go) | Provides an APIClient for access to cluster                 |
 | [ranparam](internal/ranparam/const.go)               | Labels and other constants used in the test suites          |
@@ -49,6 +48,11 @@ Currently, only the TALM tests need more than the first spoke kubeconfig.
 * `KUBECONFIG`: Global input that refers to the first spoke cluster.
 * `ECO_CNF_RAN_KUBECONFIG_HUB`: For tests that need a hub cluster, this is the path to its kubeconfig.
 * `ECO_CNF_RAN_KUBECONFIG_SPOKE2`: For tests that need a second spoke cluster, this is the path to its kubeconfig.
+
+#### Other environment variables
+
+* `ECO_CNF_RAN_SKIP_TLS_VERIFY`: Boolean for allowing the go-git library to skip TLS certificate validation for internal repositories.
+  * Set to either `true` or `false`. Default is `false`.
 
 ### Running the RAN deployment test suites
 

--- a/tests/cnf/ran-deployment/deploymenttypes/tests/deployment-types.go
+++ b/tests/cnf/ran-deployment/deploymenttypes/tests/deployment-types.go
@@ -233,12 +233,13 @@ func gitCloneToDirs(clustersApp,
 	Expect(err).ToNot(HaveOccurred(), "Failed to get policies app git source details")
 
 	siteconfigRepo, err = git.PlainClone(gitSiteConfigCloneDir, false, &git.CloneOptions{
-		URL:           clustersSource.RepoURL,
-		Tags:          git.NoTags,
-		ReferenceName: plumbing.ReferenceName(clustersSource.TargetRevision),
-		Depth:         1,
-		SingleBranch:  true,
-		Progress:      nil,
+		URL:             clustersSource.RepoURL,
+		Tags:            git.NoTags,
+		ReferenceName:   plumbing.ReferenceName(clustersSource.TargetRevision),
+		Depth:           1,
+		SingleBranch:    true,
+		Progress:        nil,
+		InsecureSkipTLS: RANConfig.SkipTLSVerify,
 	})
 	Expect(err).ToNot(HaveOccurred(), "Failed to git clone siteconfig repo %s branch %s to directory %s",
 		clustersSource.RepoURL, clustersSource.TargetRevision, gitSiteConfigCloneDir)
@@ -247,12 +248,13 @@ func gitCloneToDirs(clustersApp,
 	glog.V(tsparams.LogLevel).Infof("Path in worktree: %s", clustersSource.Path)
 
 	policiesRepo, err = git.PlainClone(gitPolicyTemplatesCloneDir, false, &git.CloneOptions{
-		URL:           policiesSource.RepoURL,
-		Tags:          git.NoTags,
-		ReferenceName: plumbing.ReferenceName(policiesSource.TargetRevision),
-		Depth:         1,
-		SingleBranch:  true,
-		Progress:      nil,
+		URL:             policiesSource.RepoURL,
+		Tags:            git.NoTags,
+		ReferenceName:   plumbing.ReferenceName(policiesSource.TargetRevision),
+		Depth:           1,
+		SingleBranch:    true,
+		Progress:        nil,
+		InsecureSkipTLS: RANConfig.SkipTLSVerify,
 	})
 	Expect(err).ToNot(HaveOccurred(), "Failed to git clone policies repo %s branch %s to directory %s",
 		policiesSource.RepoURL, policiesSource.TargetRevision, gitPolicyTemplatesCloneDir)

--- a/tests/cnf/ran-deployment/internal/ranconfig/config.go
+++ b/tests/cnf/ran-deployment/internal/ranconfig/config.go
@@ -10,12 +10,14 @@ import (
 	"github.com/openshift-kni/eco-gotests/tests/cnf/ran-deployment/internal/version"
 )
 
-// RANConfig contains configuration for the RAN directory.
+// RANConfig contains configuration for the RAN Deployment directory.
 type RANConfig struct {
 	*cnfconfig.CNFConfig
 	*HubConfig
 	*Spoke1Config
 	*Spoke2Config
+	// Allow skipping TLS verification for the go-git client.
+	SkipTLSVerify bool `default:"false" envconfig:"ECO_CNF_RAN_SKIP_TLS_VERIFY"`
 }
 
 // HubConfig contains the configuration for the hub cluster, if present.
@@ -61,6 +63,10 @@ func NewRANConfig() *RANConfig {
 	ranConfig.newHubConfig()
 	ranConfig.newSpoke1Config()
 	ranConfig.newSpoke2Config()
+
+	if ranConfig.SkipTLSVerify {
+		glog.V(ranparam.LogLevel).Infof("Skip TLS verification is true")
+	}
 
 	return &ranConfig
 }


### PR DESCRIPTION
Add environment variable setting (bool) to disable TLS certificate validation.


Needed for go-git library when git repo has a self-signed or internal certificate.