### PR TITLE
cnf network: define TerminationGracePeriod for test pods

### DIFF
--- a/tests/cnf/core/network/dpdk/tests/rootless.go
+++ b/tests/cnf/core/network/dpdk/tests/rootless.go
@@ -498,6 +498,7 @@ var _ = Describe("rootless", Ordered, Label(tsparams.LabelSuite), ContinueOnFail
 				WithLabel("test", "dpdk").
 				WithSecondaryNetwork(clientPodNetConfig).
 				WithHugePages().
+				WithTerminationGracePeriodSeconds(90).
 				CreateAndWaitUntilReady(tsparams.WaitTimeout)
 			Expect(err).ToNot(HaveOccurred(), "Fail to create deployment")
 			deploymentPod := fetchNewDeploymentPod("deployment-one")
@@ -686,7 +687,8 @@ func defineAndCreateDPDKPod(
 
 	dpdkPod := pod.NewBuilder(APIClient, podName, tsparams.TestNamespaceName,
 		NetConfig.DpdkTestContainer).WithSecondaryNetwork(serverPodNetConfig).
-		DefineOnNode(nodeName).RedefineDefaultContainer(*dpdkContainerCfg).WithHugePages()
+		DefineOnNode(nodeName).RedefineDefaultContainer(*dpdkContainerCfg).WithHugePages().
+		WithTerminationGracePeriodSeconds(90)
 
 	if podSC != nil {
 		dpdkPod = dpdkPod.WithSecurityContext(podSC)


### PR DESCRIPTION
Increasing termination grace period of test pods from 30secs(default) to 90secs.
When the test pods are deleted in AfterEach, resource cleanup is not completed and new test deploys another test pod with same sriov resource. This leads to test failure and passes when it is run alone manually. 