### PR TITLE
hwaccel: add new operator installer. separate CR utils for NFD.

### DIFF
--- a/tests/hw-accel/README.md
+++ b/tests/hw-accel/README.md
@@ -1,12 +1,226 @@
-# Ecosystem Edge Hardware Accelerators Team
+# Ecosystem Edge Hardware Accelerators - NFD
 
 ## Overview
-Hardware Accelerators Team groups together the following operators
+NFD tests are developed for the purpose of testing the deployment of the Node Feature Discovery (NFD) operator and its respective NodeFeatureDiscovery Custom Resource instance to automatically detect and label hardware and software capabilities of cluster nodes.
 
-| Name                                     | Description |
-|------------------------------------------| -----|
-| [Kernel Module Management Operator](kmm) | Tests related to KMM and KMM-Hub |
-| [Node Feature Discovery Operator](nfd) | Tests related to NFD |
-| [Nvidia GPU Operator](nvidiagpu) | Tests related to Nvidia GPU |
+The Node Feature Discovery Operator manages the deployment of out-of-tree kernel modules and associated device plug-ins in Kubernetes. It discovers hardware features available on each node in a Kubernetes cluster, and advertises those features using node labels.
 
-More details are found on the respective pages. 
+### Prerequisites and Supported setups
+* Regular cluster with multiple master nodes (VMs or BMs) and workers (VMs or BMs)/SNO
+* Public Clouds Cluster (AWS, GCP and Azure)
+* On Premise Cluster
+
+### Test suites:
+
+| Name                                          | Description                                                          |
+|-----------------------------------------------|----------------------------------------------------------------------|
+| [features](features/nfd_suite_test.go)        | Tests related to NFD operator deployment and feature discovery      |
+| [2upgrade](2upgrade/upgrade_suite_test.go)    | Tests related to NFD operator upgrade functionality                 |
+
+Notes:
+- `2upgrade` name is used to assure that ginkgo runs that before features.
+- `features` contains the main NFD functionality tests including label discovery, pod status checks, and node feature detection.
+
+### Internal pkgs
+
+[**get**](internal/get)
+- Utilities to obtain various objects like pod status, logs, restart count, node feature labels, CPU features, and resource counts.
+
+[**wait**](internal/wait/wait.go)
+- Helpers for waiting for various states of pods, nodes, and label discovery completion.
+
+[**set**](internal/set/featurelist.go)
+- Helper for setting CPU feature configurations including blacklist/whitelist management and custom NFD worker configurations.
+
+[**nfdconfig**](internal/nfdconfig/config.go)
+- Configuration management that captures and processes environment variables used for NFD test execution.
+
+[**nfddelete**](internal/nfddelete/feature_labels.go)
+- Helpers for cleaning up NFD-specific labels from cluster nodes and custom resources after test execution.
+- **`custom_resources.go`**: Comprehensive NFD custom resource cleanup with finalizer handling for operator uninstallation.
+- **`feature_labels.go`**: Node label cleanup utilities for test isolation.
+
+[**search**](internal/search/common_utils.go)
+- Common utilities for searching and string manipulation operations.
+
+[**nfdhelpersparams**](internal/nfdhelpersparams)
+- Constants and variables for NFD helper functions including valid pod name lists and container definitions.
+
+[**params**](internal/params/consts.go)
+- Configuration constants including default NFD worker configuration templates.
+
+### Eco-goinfra pkgs
+
+- [**nfd**](https://github.com/openshift-kni/eco-goinfra/tree/main/pkg/nfd)
+- [**olm**](https://github.com/openshift-kni/eco-goinfra/tree/main/pkg/olm)
+- [**nodes**](https://github.com/openshift-kni/eco-goinfra/tree/main/pkg/nodes)
+- [**pod**](https://github.com/openshift-kni/eco-goinfra/tree/main/pkg/pod)
+
+### Inputs and Environment Variables
+
+Parameters for the script are controlled by the following environment variables:
+
+#### Feature Discovery related
+- `ECO_HWACCEL_NFD_CR_IMAGE`: Custom NFD container image to use for NodeFeatureDiscovery CR. If not specified, the default operator image is used - _optional_
+- `ECO_HWACCEL_NFD_CATALOG_SOURCE`: Custom catalog source to be used for NFD operator installation. If not specified, the default "certified-operators" catalog is used - _optional_
+- `ECO_HWACCEL_NFD_AWS_TESTS`: Enable AWS-specific tests including day2 worker node addition. Set to "true" when running NFD tests against AWS clusters - _optional_
+- `ECO_HWACCEL_NFD_CPU_FLAGS_HELPER_IMAGE`: Container image used for CPU flags helper tests. Required when running AWS day2 worker tests - _required for AWS tests_
+
+#### Upgrade related
+- `ECO_HWACCEL_NFD_SUBSCRIPTION_NAME`: Name of subscription used to deploy the NFD operator - _required for upgrade tests_
+- `ECO_HWACCEL_NFD_CUSTOM_NFD_CATALOG_SOURCE`: Custom catalog source name used for performing operator upgrades - _required for upgrade tests_
+- `ECO_HWACCEL_NFD_UPGRADE_TARGET_VERSION`: Expected version of the operator after upgrade completion - _required for upgrade tests_
+
+#### General Test Framework Variables
+- `ECO_TEST_LABELS`: ginkgo query passed to the label-filter option for including/excluding tests - _optional_
+- `ECO_VERBOSE_SCRIPT`: prints verbose script information when executing the script - _optional_
+- `ECO_TEST_VERBOSE`: executes ginkgo with verbose test output - _optional_
+- `ECO_TEST_TRACE`: includes full stack trace from ginkgo tests when a failure occurs - _optional_
+- `ECO_TEST_FEATURES`: list of features to be tested. Should include "nfd" for NFD tests - _required_
+
+In case the required inputs are not set, the tests are skipped.
+
+### Running HW-Accel NFD Test Suites
+
+#### Running NFD Feature Discovery tests
+```bash
+$ export KUBECONFIG=/path/to/kubeconfig
+$ export ECO_DUMP_FAILED_TESTS=true
+$ export ECO_REPORTS_DUMP_DIR=/tmp/eco-gotests-logs-dir
+$ export ECO_TEST_FEATURES="nfd"
+$ export ECO_TEST_LABELS='nfd,discovery-of-labels'
+$ export ECO_VERBOSE_LEVEL=100
+$ export ECO_HWACCEL_NFD_CATALOG_SOURCE="certified-operators"
+$ export ECO_HWACCEL_NFD_CR_IMAGE="registry.redhat.io/openshift4/ose-node-feature-discovery:latest"
+$ make run-tests
+```
+
+#### Running NFD tests on AWS with day2 worker addition
+```bash
+$ export KUBECONFIG=/path/to/kubeconfig
+$ export ECO_TEST_FEATURES="nfd"
+$ export ECO_TEST_LABELS='nfd'
+$ export ECO_HWACCEL_NFD_AWS_TESTS=true
+$ export ECO_HWACCEL_NFD_CPU_FLAGS_HELPER_IMAGE="<cpu-flags-helper image specific to cluster architecture>"
+$ export ECO_HWACCEL_NFD_CATALOG_SOURCE="certified-operators"
+$ make run-tests
+```
+
+#### Running NFD Upgrade tests
+```bash
+$ export KUBECONFIG=/path/to/kubeconfig
+$ export ECO_TEST_FEATURES="nfd"
+$ export ECO_TEST_LABELS='nfd_upgrade'
+$ export ECO_HWACCEL_NFD_SUBSCRIPTION_NAME='nfd-subscription'
+$ export ECO_HWACCEL_NFD_UPGRADE_TARGET_VERSION='4.17.0'
+$ export ECO_HWACCEL_NFD_CUSTOM_NFD_CATALOG_SOURCE='custom-nfd-catalog'
+$ export ECO_HWACCEL_NFD_CATALOG_SOURCE="certified-operators"
+$ make run-tests
+```
+
+### Test Scenarios
+
+The NFD test suite covers the following scenarios:
+
+1. **Pod Status Verification**: Ensures all NFD pods (controller-manager, master, worker, topology) are running correctly
+2. **Log Analysis**: Checks NFD pod logs for error messages and exceptions
+3. **Restart Count Monitoring**: Verifies that NFD pods have zero restart counts
+4. **Feature Label Discovery**: Tests detection and labeling of CPU features, kernel configurations, and hardware capabilities
+5. **NUMA Detection**: Validates NUMA topology detection and labeling (when supported)
+6. **Blacklist/Whitelist Functionality**: Tests CPU feature filtering using blacklist and whitelist configurations
+7. **Day2 Worker Addition**: Tests NFD functionality when adding new worker nodes to AWS clusters
+8. **Operator Upgrade**: Tests upgrading NFD operator to newer versions
+
+### Generic Operator Installer and NFD CR Utilities
+
+The NFD tests now use a modern, clean approach with generic operator installer and standalone custom resource utilities:
+
+#### Basic NFD Deployment
+```go
+
+installConfig := nfdhelpers.GetStandardNFDConfig(apiClient)
+installer := deploy.NewOperatorInstaller(installConfig)
+err := installer.Install()
+
+// Wait for operator readiness
+ready, err := installer.IsReady(5 * time.Minute)
+
+/
+crUtils := deploy.NewNFDCRUtils(apiClient, "openshift-nfd")
+
+nfdConfig := deploy.NFDCRConfig{
+    EnableTopology: true,
+    Image:          "registry.redhat.io/openshift4/ose-node-feature-discovery:latest",
+}
+
+err = crUtils.DeployNFDCR("nfd-instance", nfdConfig)
+
+// Wait for CR readiness
+crReady, err := crUtils.IsNFDCRReady("nfd-instance", 3*time.Minute)
+```
+
+#### NFD with Custom Configuration
+```go
+// Use helper with custom catalog source
+options := &nfdhelpers.NFDInstallConfigOptions{
+    CatalogSource: nfdhelpers.StringPtr("custom-catalog"),
+}
+installConfig := nfdhelpers.GetDefaultNFDInstallConfig(apiClient, options)
+installer := deploy.NewOperatorInstaller(installConfig)
+```
+
+#### NFD with Custom Worker Configuration
+```go
+// Deploy NFD CR with custom worker configuration for CPU features blacklist/whitelist
+workerConfig := `
+sources:
+  cpu:
+    cpuid:
+      attributeBlacklist: ["BMI1", "BMI2"]
+      attributeWhitelist: ["SSE", "SSE2"]
+`
+
+err = crUtils.DeployNFDCRWithWorkerConfig("nfd-custom", nfdConfig, workerConfig)
+```
+
+#### Clean Uninstallation
+```go
+// Individual CR deletion (for tests)
+err := nfdCRUtils.DeleteNFDCR("nfd-instance")
+
+// Complete uninstallation with automatic CR cleanup
+uninstallConfig := nfdhelpers.GetDefaultNFDUninstallConfig(
+    apiClient,
+    "nfd-operator-group",
+    "nfd-subscription")
+uninstaller := deploy.NewOperatorUninstaller(uninstallConfig)
+err = uninstaller.Uninstall()
+// ✅ Automatically deletes CRs first (including finalizer handling)
+// ✅ Then removes operator, subscription, operator group
+```
+
+#### Alternative: Direct CR Cleanup
+```go
+// Direct cleanup of all NFD CRs (useful for tests)
+err := nfddelete.AllNFDCustomResources(apiClient, "openshift-nfd")
+
+// Or cleanup specific CRs
+err := nfddelete.AllNFDCustomResources(apiClient, "openshift-nfd",
+    "nfd-instance", "nfd-instance-custom")
+```
+
+### Benefits of the New Approach
+
+1. **Clean Separation**: Operator installation is separate from custom resource management
+2. **Reusable Components**: The generic installer works for NFD, KMM, AMD GPU, and other operators
+3. **Standalone Utilities**: NFD CR utilities can be used independently of operator installation
+4. **Better Error Handling**: Comprehensive validation and improved logging for troubleshooting
+5. **Simplified Usage**: Direct, intuitive API without complex factory patterns
+6. **Configuration Helpers**: NFD-specific helper functions eliminate repetitive configuration setup
+7. **Reduced Duplication**: Common NFD patterns are centralized in reusable helper functions
+
+### Additional Information
+
+NFD tests verify that hardware features are properly detected and labeled on cluster nodes. The tests support both standard feature detection and custom configurations through worker config modifications. Special attention is given to CPU feature detection, topology awareness, and proper cleanup of labels after test execution.
+
+The new deployment framework provides better reliability and easier maintenance while supporting all existing test scenarios and configurations.

--- a/tests/hw-accel/internal/deploy/csv-utils.go
+++ b/tests/hw-accel/internal/deploy/csv-utils.go
@@ -1,0 +1,204 @@
+package deploy
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/openshift-kni/eco-goinfra/pkg/olm"
+	"github.com/openshift-kni/eco-goinfra/pkg/schemes/olm/operators/v1alpha1"
+)
+
+// CSVUtils provides utilities for ClusterServiceVersion operations.
+type CSVUtils struct {
+	APIClient *clients.Settings
+	Namespace string
+	LogLevel  glog.Level
+}
+
+// NewCSVUtils creates a new CSV utilities instance.
+func NewCSVUtils(apiClient *clients.Settings, namespace string, logLevel glog.Level) *CSVUtils {
+	return &CSVUtils{
+		APIClient: apiClient,
+		Namespace: namespace,
+		LogLevel:  logLevel,
+	}
+}
+
+// GetCSVByPackageName finds a CSV in the namespace by package name.
+func (c *CSVUtils) GetCSVByPackageName(packageName string) (*olm.ClusterServiceVersionBuilder, error) {
+	glog.V(c.LogLevel).Infof("Looking for CSV with package name '%s' in namespace '%s'", packageName, c.Namespace)
+
+	csvList, err := olm.ListClusterServiceVersion(c.APIClient, c.Namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list CSVs in namespace %s: %w", c.Namespace, err)
+	}
+
+	if len(csvList) == 0 {
+		return nil, fmt.Errorf("no CSVs found in namespace %s", c.Namespace)
+	}
+
+	for _, csv := range csvList {
+		if strings.Contains(strings.ToLower(csv.Object.Name), strings.ToLower(packageName)) ||
+			strings.Contains(strings.ToLower(csv.Object.Spec.DisplayName), strings.ToLower(packageName)) {
+			glog.V(c.LogLevel).Infof("Found CSV: %s for package %s", csv.Object.Name, packageName)
+
+			return csv, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no CSV found for package '%s' in namespace %s", packageName, c.Namespace)
+}
+
+// GetCSVByName gets a specific CSV by name in the namespace.
+func (c *CSVUtils) GetCSVByName(csvName string) (*olm.ClusterServiceVersionBuilder, error) {
+	glog.V(c.LogLevel).Infof("Getting CSV '%s' in namespace '%s'", csvName, c.Namespace)
+
+	csv, err := olm.PullClusterServiceVersion(c.APIClient, csvName, c.Namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get CSV %s in namespace %s: %w", csvName, c.Namespace, err)
+	}
+
+	if csv == nil {
+		return nil, fmt.Errorf("CSV %s not found in namespace %s", csvName, c.Namespace)
+	}
+
+	return csv, nil
+}
+
+// IsCSVReady checks if a CSV is in the Succeeded phase.
+func (c *CSVUtils) IsCSVReady(csv *olm.ClusterServiceVersionBuilder) (bool, error) {
+	if csv == nil {
+		return false, fmt.Errorf("CSV is nil")
+	}
+
+	if csv.Object.Namespace != c.Namespace {
+		return false, fmt.Errorf("CSV %s is in namespace %s, expected namespace %s",
+			csv.Object.Name, csv.Object.Namespace, c.Namespace)
+	}
+
+	phase := csv.Object.Status.Phase
+
+	glog.V(c.LogLevel).Infof("CSV %s status: %s", csv.Object.Name, phase)
+
+	switch phase {
+	case v1alpha1.CSVPhaseSucceeded:
+		glog.V(c.LogLevel).Infof("CSV %s is ready (Succeeded)", csv.Object.Name)
+
+		return true, nil
+
+	case v1alpha1.CSVPhaseFailed:
+		return false, fmt.Errorf("CSV %s failed: %s", csv.Object.Name, csv.Object.Status.Message)
+
+	case v1alpha1.CSVPhasePending, v1alpha1.CSVPhaseInstalling, v1alpha1.CSVPhaseInstallReady:
+		glog.V(c.LogLevel).Infof("CSV %s is still installing (phase: %s)", csv.Object.Name, phase)
+
+		return false, nil
+
+	case v1alpha1.CSVPhaseReplacing, v1alpha1.CSVPhaseDeleting:
+		glog.V(c.LogLevel).Infof("CSV %s is being replaced or deleted (phase: %s)", csv.Object.Name, phase)
+
+		return false, nil
+
+	case v1alpha1.CSVPhaseUnknown, v1alpha1.CSVPhaseAny:
+		glog.V(c.LogLevel).Infof("CSV %s in unknown/any phase: %s", csv.Object.Name, phase)
+
+		return false, nil
+
+	default:
+		glog.V(c.LogLevel).Infof("CSV %s in unexpected phase: %s", csv.Object.Name, phase)
+
+		return false, nil
+	}
+}
+
+// WaitForCSVReady waits for a CSV to become ready within the specified timeout.
+func (c *CSVUtils) WaitForCSVReady(packageName string, timeout time.Duration) (bool, error) {
+	glog.V(c.LogLevel).Infof("Waiting for CSV readiness for package '%s' in namespace '%s' (timeout: %v)",
+		packageName, c.Namespace, timeout)
+
+	start := time.Now()
+	ticker := time.NewTicker(10 * time.Second)
+
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			csv, err := c.GetCSVByPackageName(packageName)
+			if err != nil {
+				glog.V(c.LogLevel).Infof("CSV not found yet for package %s: %v", packageName, err)
+
+				if time.Since(start) < timeout {
+					continue
+				}
+
+				return false, fmt.Errorf("timeout waiting for CSV for package %s: %w", packageName, err)
+			}
+
+			ready, err := c.IsCSVReady(csv)
+			if err != nil {
+				return false, fmt.Errorf("CSV readiness check failed: %w", err)
+			}
+
+			if ready {
+				glog.V(c.LogLevel).Infof("CSV for package %s is ready after %v", packageName, time.Since(start))
+
+				return true, nil
+			}
+
+			if time.Since(start) >= timeout {
+				return false, fmt.Errorf("timeout waiting for CSV readiness for package %s after %v", packageName, timeout)
+			}
+
+		case <-time.After(timeout):
+			return false, fmt.Errorf("timeout waiting for CSV readiness for package %s", packageName)
+		}
+	}
+}
+
+// ListCSVsInNamespace returns all CSVs in the namespace.
+func (c *CSVUtils) ListCSVsInNamespace() ([]*olm.ClusterServiceVersionBuilder, error) {
+	glog.V(c.LogLevel).Infof("Listing all CSVs in namespace '%s'", c.Namespace)
+
+	csvList, err := olm.ListClusterServiceVersion(c.APIClient, c.Namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list CSVs in namespace %s: %w", c.Namespace, err)
+	}
+
+	glog.V(c.LogLevel).Infof("Found %d CSVs in namespace %s", len(csvList), c.Namespace)
+
+	for _, csv := range csvList {
+		glog.V(c.LogLevel).Infof("CSV: %s, Phase: %s, Version: %s",
+			csv.Object.Name, csv.Object.Status.Phase, csv.Object.Spec.Version)
+	}
+
+	return csvList, nil
+}
+
+// GetCSVForOperator gets the CSV for a specific operator installation.
+func (c *CSVUtils) GetCSVForOperator(packageName, subscriptionName string) (*olm.ClusterServiceVersionBuilder, error) {
+	glog.V(c.LogLevel).Infof("Getting CSV for operator package '%s' via subscription '%s'", packageName, subscriptionName)
+
+	if subscriptionName != "" {
+		subscription, err := olm.PullSubscription(c.APIClient, subscriptionName, c.Namespace)
+		if err == nil && subscription != nil && subscription.Object.Status.CurrentCSV != "" {
+			csvName := subscription.Object.Status.CurrentCSV
+			glog.V(c.LogLevel).Infof("Found CSV name '%s' from subscription '%s'", csvName, subscriptionName)
+
+			csv, err := c.GetCSVByName(csvName)
+			if err == nil {
+				return csv, nil
+			}
+
+			glog.V(c.LogLevel).
+				Infof("Failed to get CSV %s from subscription, falling back to package search: %v",
+					csvName,
+					err)
+		}
+	}
+
+	return c.GetCSVByPackageName(packageName)
+}

--- a/tests/hw-accel/internal/deploy/operator-installer.go
+++ b/tests/hw-accel/internal/deploy/operator-installer.go
@@ -1,0 +1,313 @@
+package deploy
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/openshift-kni/eco-goinfra/pkg/namespace"
+	"github.com/openshift-kni/eco-goinfra/pkg/olm"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	// DefaultLogLevel for operator installation logging.
+	DefaultLogLevel = 90
+)
+
+// OperatorInstallConfig holds configuration for operator installation.
+type OperatorInstallConfig struct {
+	APIClient              *clients.Settings
+	Namespace              string
+	OperatorGroupName      string
+	SubscriptionName       string
+	PackageName            string
+	CatalogSource          string
+	CatalogSourceNamespace string
+	Channel                string
+	SkipNamespaceCreation  bool
+	SkipOperatorGroup      bool
+	LogLevel               glog.Level
+}
+
+// OperatorInstaller provides generic operator installation functionality.
+type OperatorInstaller struct {
+	config   OperatorInstallConfig
+	csvUtils *CSVUtils
+}
+
+// NewOperatorInstaller creates a new operator installer with the given configuration.
+func NewOperatorInstaller(config OperatorInstallConfig) *OperatorInstaller {
+	if config.LogLevel == 0 {
+		config.LogLevel = glog.Level(DefaultLogLevel)
+	}
+
+	csvUtils := NewCSVUtils(config.APIClient, config.Namespace, config.LogLevel)
+
+	return &OperatorInstaller{
+		config:   config,
+		csvUtils: csvUtils,
+	}
+}
+
+// Install deploys the operator following the standard OLM pattern.
+func (o *OperatorInstaller) Install() error {
+	glog.V(o.config.LogLevel).Infof("Starting operator installation: %s in namespace %s",
+		o.config.PackageName, o.config.Namespace)
+
+	if err := o.validateConfig(); err != nil {
+		return fmt.Errorf("invalid configuration: %w", err)
+	}
+
+	if !o.config.SkipNamespaceCreation {
+		if err := o.createNamespaceIfNotExist(); err != nil {
+			return fmt.Errorf("failed to create namespace: %w", err)
+		}
+
+		glog.V(o.config.LogLevel).
+			Infof("SUCCESS: Namespace %s created/verified",
+				o.config.Namespace)
+	} else {
+		glog.V(o.config.LogLevel).
+			Infof("Skipping namespace creation for global namespace: %s",
+				o.config.Namespace)
+	}
+
+	if !o.config.SkipOperatorGroup {
+		if err := o.createOperatorGroup(); err != nil {
+			return fmt.Errorf("failed to create operator group: %w", err)
+		}
+
+		glog.V(o.config.LogLevel).Infof("SUCCESS: OperatorGroup %s created", o.config.OperatorGroupName)
+	} else {
+		glog.V(o.config.LogLevel).Infof("Skipping operator group creation, using existing: %s", o.config.OperatorGroupName)
+	}
+
+	if err := o.createSubscription(); err != nil {
+		return fmt.Errorf("failed to create subscription: %w", err)
+	}
+
+	glog.V(o.config.LogLevel).Infof("SUCCESS: Subscription %s created", o.config.SubscriptionName)
+
+	return nil
+}
+
+// IsReady checks if the operator CSV is ready.
+func (o *OperatorInstaller) IsReady(timeout time.Duration) (bool, error) {
+	glog.V(o.config.LogLevel).Infof("Checking operator readiness for package=%s, namespace=%s",
+		o.config.PackageName, o.config.Namespace)
+
+	ready, err := o.csvUtils.WaitForCSVReady(o.config.PackageName, timeout)
+	if err != nil {
+		return false, fmt.Errorf("operator CSV readiness check failed: %w", err)
+	}
+
+	if ready {
+		glog.V(o.config.LogLevel).Infof("Operator %s is ready (CSV in Succeeded state)", o.config.PackageName)
+		glog.V(o.config.LogLevel).Infof("Operator %s installation completed", o.config.PackageName)
+	}
+
+	return ready, nil
+}
+
+// GetNamespace returns the operator namespace.
+func (o *OperatorInstaller) GetNamespace() string {
+	return o.config.Namespace
+}
+
+// GetPackageName returns the operator package name.
+func (o *OperatorInstaller) GetPackageName() string {
+	return o.config.PackageName
+}
+
+// GetCSVUtils returns the CSV utilities for advanced operations.
+func (o *OperatorInstaller) GetCSVUtils() *CSVUtils {
+	return o.csvUtils
+}
+
+// GetCSVStatus returns the current CSV status for debugging purposes.
+func (o *OperatorInstaller) GetCSVStatus() (string, error) {
+	csv, err := o.csvUtils.GetCSVByPackageName(o.config.PackageName)
+	if err != nil {
+		return "", fmt.Errorf("failed to get CSV for package %s: %w", o.config.PackageName, err)
+	}
+
+	return string(csv.Object.Status.Phase), nil
+}
+
+// validateConfig validates the operator installation configuration.
+func (o *OperatorInstaller) validateConfig() error {
+	if o.config.APIClient == nil {
+		return fmt.Errorf("API client cannot be nil")
+	}
+
+	if o.config.Namespace == "" {
+		return fmt.Errorf("namespace cannot be empty")
+	}
+
+	if o.config.PackageName == "" {
+		return fmt.Errorf("package name cannot be empty")
+	}
+
+	if o.config.SubscriptionName == "" {
+		return fmt.Errorf("subscription name cannot be empty")
+	}
+
+	if o.config.CatalogSource == "" {
+		return fmt.Errorf("catalog source cannot be empty")
+	}
+
+	return nil
+}
+
+// createNamespaceIfNotExist creates the namespace if it doesn't exist.
+func (o *OperatorInstaller) createNamespaceIfNotExist() error {
+	glog.V(o.config.LogLevel).Infof("Creating namespace %s if it doesn't exist", o.config.Namespace)
+
+	nsBuilder := namespace.NewBuilder(o.config.APIClient, o.config.Namespace)
+
+	if nsBuilder.Exists() {
+		nsObj, err := o.config.APIClient.CoreV1Interface.Namespaces().Get(
+			context.TODO(), o.config.Namespace, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to get namespace %s status: %w", o.config.Namespace, err)
+		}
+
+		if nsObj.Status.Phase == corev1.NamespaceTerminating {
+			glog.V(o.config.LogLevel).
+				Infof("Namespace %s is terminating, waiting for deletion to complete...",
+					o.config.Namespace)
+
+			if err := o.waitForNamespaceDeletion(); err != nil {
+				return fmt.Errorf("failed waiting for namespace %s deletion: %w", o.config.Namespace, err)
+			}
+
+			glog.V(o.config.LogLevel).
+				Infof("Namespace deletion complete, creating fresh namespace %s",
+					o.config.Namespace)
+		} else {
+			glog.V(o.config.LogLevel).
+				Infof("Namespace %s already exists and is active",
+					o.config.Namespace)
+
+			return nil
+		}
+	}
+
+	_, err := nsBuilder.Create()
+	if err != nil {
+		return fmt.Errorf("failed to create namespace %s: %w", o.config.Namespace, err)
+	}
+
+	glog.V(o.config.LogLevel).
+		Infof("Successfully created namespace %s",
+			o.config.Namespace)
+
+	return nil
+}
+
+// waitForNamespaceDeletion waits for the namespace to be deleted.
+func (o *OperatorInstaller) waitForNamespaceDeletion() error {
+	timeout := 5 * time.Minute
+	glog.V(o.config.LogLevel).Infof("Waiting up to %v for namespace %s to be deleted", timeout, o.config.Namespace)
+
+	err := wait.PollUntilContextTimeout(
+		context.TODO(), 5*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+			_, err := o.config.APIClient.CoreV1Interface.Namespaces().Get(
+				ctx, o.config.Namespace, metav1.GetOptions{})
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					glog.V(o.config.LogLevel).Infof("Namespace %s has been successfully deleted", o.config.Namespace)
+
+					return true, nil
+				}
+
+				glog.V(o.config.LogLevel).Infof("Error checking namespace %s: %v", o.config.Namespace, err)
+
+				return false, err
+			}
+
+			glog.V(o.config.LogLevel).Infof("Namespace %s still exists, continuing to wait...", o.config.Namespace)
+
+			return false, nil
+		})
+
+	if err != nil {
+		return fmt.Errorf("timeout waiting for namespace %s deletion: %w", o.config.Namespace, err)
+	}
+
+	return nil
+}
+
+// createOperatorGroup creates the operator group if it doesn't exist.
+func (o *OperatorInstaller) createOperatorGroup() error {
+	glog.V(o.config.LogLevel).Infof("Creating operator group %s in namespace %s",
+		o.config.OperatorGroupName, o.config.Namespace)
+
+	operatorGroupBuilder := olm.NewOperatorGroupBuilder(
+		o.config.APIClient, o.config.OperatorGroupName, o.config.Namespace)
+
+	if operatorGroupBuilder.Exists() {
+		glog.V(o.config.LogLevel).Infof("OperatorGroup %s already exists", o.config.OperatorGroupName)
+
+		return nil
+	}
+
+	_, err := operatorGroupBuilder.Create()
+	if err != nil {
+		if strings.Contains(err.Error(), "is being terminated") ||
+			strings.Contains(err.Error(), "NamespaceTerminating") {
+			return fmt.Errorf("cannot create operator group in terminating namespace %s. "+
+				"Please wait for namespace deletion to complete or use a different namespace: %w",
+				o.config.Namespace, err)
+		}
+
+		return fmt.Errorf("failed to create operator group %s: %w", o.config.OperatorGroupName, err)
+	}
+
+	return nil
+}
+
+// createSubscription creates the subscription if it doesn't exist.
+func (o *OperatorInstaller) createSubscription() error {
+	glog.V(o.config.LogLevel).Infof("Creating subscription %s in namespace %s",
+		o.config.SubscriptionName, o.config.Namespace)
+	glog.V(o.config.LogLevel).Infof("Subscription details: Package=%s, CatalogSource=%s, Channel=%s",
+		o.config.PackageName, o.config.CatalogSource, o.config.Channel)
+
+	sub := olm.NewSubscriptionBuilder(
+		o.config.APIClient,
+		o.config.SubscriptionName,
+		o.config.Namespace,
+		o.config.CatalogSource,
+		o.config.CatalogSourceNamespace,
+		o.config.PackageName)
+	sub.WithChannel(o.config.Channel)
+
+	if sub.Exists() {
+		glog.V(o.config.LogLevel).Infof("Subscription %s already exists", o.config.SubscriptionName)
+
+		return nil
+	}
+
+	_, err := sub.Create()
+
+	if err != nil {
+		if strings.Contains(err.Error(), "is being terminated") ||
+			strings.Contains(err.Error(), "NamespaceTerminating") {
+			return fmt.Errorf("cannot create subscription in terminating namespace %s. "+
+				"Please wait for namespace deletion to complete or use a different namespace: %w",
+				o.config.Namespace, err)
+		}
+
+		return fmt.Errorf("failed to create subscription %s: %w", o.config.SubscriptionName, err)
+	}
+
+	return nil
+}

--- a/tests/hw-accel/internal/deploy/operator-uninstaller.go
+++ b/tests/hw-accel/internal/deploy/operator-uninstaller.go
@@ -1,0 +1,242 @@
+package deploy
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/openshift-kni/eco-goinfra/pkg/namespace"
+	"github.com/openshift-kni/eco-goinfra/pkg/olm"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// CustomResourceCleaner defines an interface for custom resource cleanup.
+type CustomResourceCleaner interface {
+	CleanupCustomResources() error
+}
+
+// OperatorUninstallConfig holds configuration for operator uninstallation.
+type OperatorUninstallConfig struct {
+	APIClient             *clients.Settings
+	Namespace             string
+	OperatorGroupName     string
+	SubscriptionName      string
+	SkipNamespaceDeletion bool
+	SkipOperatorGroup     bool
+	CustomResourceCleaner CustomResourceCleaner
+	LogLevel              glog.Level
+}
+
+// OperatorUninstaller provides generic operator uninstallation functionality.
+type OperatorUninstaller struct {
+	config OperatorUninstallConfig
+}
+
+// NewOperatorUninstaller creates a new operator uninstaller with the given configuration.
+func NewOperatorUninstaller(config OperatorUninstallConfig) *OperatorUninstaller {
+	if config.LogLevel == 0 {
+		config.LogLevel = glog.Level(DefaultLogLevel)
+	}
+
+	return &OperatorUninstaller{config: config}
+}
+
+// Uninstall removes the operator following the reverse OLM pattern.
+func (u *OperatorUninstaller) Uninstall() error {
+	glog.V(u.config.LogLevel).Infof("Starting operator uninstallation from namespace %s", u.config.Namespace)
+
+	if err := u.validateConfig(); err != nil {
+		return fmt.Errorf("invalid configuration: %w", err)
+	}
+
+	if u.config.CustomResourceCleaner != nil {
+		glog.V(u.config.LogLevel).Infof("Running custom resource cleanup")
+
+		if err := u.config.CustomResourceCleaner.CleanupCustomResources(); err != nil {
+			glog.V(u.config.LogLevel).Infof("Warning: custom resource cleanup failed: %v", err)
+		}
+	}
+
+	if err := u.deleteCSV(); err != nil {
+		glog.V(u.config.LogLevel).Infof("Warning: failed to delete CSV: %v", err)
+	}
+
+	if err := u.deleteSubscription(); err != nil {
+		glog.V(u.config.LogLevel).Infof("Warning: failed to delete subscription: %v", err)
+	}
+
+	if !u.config.SkipOperatorGroup {
+		if err := u.deleteOperatorGroup(); err != nil {
+			glog.V(u.config.LogLevel).Infof("Warning: failed to delete operator group: %v", err)
+		}
+	} else {
+		glog.V(u.config.LogLevel).
+			Infof("Skipping operator group deletion for shared operator group: %s",
+				u.config.OperatorGroupName)
+	}
+
+	if !u.config.SkipNamespaceDeletion {
+		if err := u.deleteNamespace(); err != nil {
+			glog.V(u.config.LogLevel).Infof("Warning: failed to delete namespace: %v", err)
+		}
+	} else {
+		glog.V(u.config.LogLevel).Infof("Skipping namespace deletion for global namespace: %s", u.config.Namespace)
+	}
+
+	glog.V(u.config.LogLevel).Infof("Operator uninstallation completed for namespace %s", u.config.Namespace)
+
+	return nil
+}
+
+// validateConfig validates the operator uninstallation configuration.
+func (u *OperatorUninstaller) validateConfig() error {
+	if u.config.APIClient == nil {
+		return fmt.Errorf("API client cannot be nil")
+	}
+
+	if u.config.Namespace == "" {
+		return fmt.Errorf("namespace cannot be empty")
+	}
+
+	return nil
+}
+
+// deleteCSV finds and deletes the ClusterServiceVersion.
+func (u *OperatorUninstaller) deleteCSV() error {
+	glog.V(u.config.LogLevel).Infof("Looking for CSV to delete in namespace %s", u.config.Namespace)
+
+	clusterServices, err := olm.ListClusterServiceVersion(u.config.APIClient, u.config.Namespace)
+	if err != nil {
+		return fmt.Errorf("failed to list CSVs: %w", err)
+	}
+
+	if len(clusterServices) == 0 {
+		glog.V(u.config.LogLevel).Infof("No CSVs found in namespace %s", u.config.Namespace)
+
+		return nil
+	}
+
+	for _, csv := range clusterServices {
+		glog.V(u.config.LogLevel).Infof("Deleting CSV: %s", csv.Definition.Name)
+
+		if err := u.deleteResourceWithTimeout(csv, 60*time.Second); err != nil {
+			return fmt.Errorf("failed to delete CSV %s: %w", csv.Definition.Name, err)
+		}
+
+		glog.V(u.config.LogLevel).Infof("SUCCESS: CSV %s deleted", csv.Definition.Name)
+	}
+
+	return nil
+}
+
+// deleteSubscription deletes the subscription.
+func (u *OperatorUninstaller) deleteSubscription() error {
+	if u.config.SubscriptionName == "" {
+		glog.V(u.config.LogLevel).Infof("No subscription name specified, skipping subscription deletion")
+
+		return nil
+	}
+
+	glog.V(u.config.LogLevel).Infof("Deleting subscription: %s", u.config.SubscriptionName)
+
+	sub, err := olm.PullSubscription(u.config.APIClient, u.config.SubscriptionName, u.config.Namespace)
+	if err != nil {
+		glog.V(u.config.LogLevel).Infof("Subscription %s not found: %v", u.config.SubscriptionName, err)
+
+		return nil
+	}
+
+	if sub == nil {
+		glog.V(u.config.LogLevel).Infof("Subscription %s not found", u.config.SubscriptionName)
+
+		return nil
+	}
+
+	if err := u.deleteResourceWithTimeout(sub, 60*time.Second); err != nil {
+		return fmt.Errorf("failed to delete subscription %s: %w", u.config.SubscriptionName, err)
+	}
+
+	glog.V(u.config.LogLevel).Infof("SUCCESS: Subscription %s deleted", u.config.SubscriptionName)
+
+	return nil
+}
+
+// deleteOperatorGroup deletes the operator group.
+func (u *OperatorUninstaller) deleteOperatorGroup() error {
+	if u.config.OperatorGroupName == "" {
+		glog.V(u.config.LogLevel).Infof("No operator group name specified, skipping operator group deletion")
+
+		return nil
+	}
+
+	glog.V(u.config.LogLevel).Infof("Deleting operator group: %s", u.config.OperatorGroupName)
+
+	operatorGroup, err := olm.PullOperatorGroup(u.config.APIClient, u.config.OperatorGroupName, u.config.Namespace)
+	if err != nil {
+		glog.V(u.config.LogLevel).Infof("OperatorGroup %s not found: %v", u.config.OperatorGroupName, err)
+
+		return nil
+	}
+
+	if operatorGroup == nil {
+		glog.V(u.config.LogLevel).Infof("OperatorGroup %s not found", u.config.OperatorGroupName)
+
+		return nil
+	}
+
+	if err := u.deleteResourceWithTimeout(operatorGroup, 60*time.Second); err != nil {
+		return fmt.Errorf("failed to delete operator group %s: %w", u.config.OperatorGroupName, err)
+	}
+
+	glog.V(u.config.LogLevel).Infof("SUCCESS: OperatorGroup %s deleted", u.config.OperatorGroupName)
+
+	return nil
+}
+
+// deleteNamespace deletes the namespace if it exists.
+func (u *OperatorUninstaller) deleteNamespace() error {
+	glog.V(u.config.LogLevel).Infof("Deleting namespace: %s", u.config.Namespace)
+
+	nsBuilder := namespace.NewBuilder(u.config.APIClient, u.config.Namespace)
+
+	if !nsBuilder.Exists() {
+		glog.V(u.config.LogLevel).Infof("Namespace %s does not exist", u.config.Namespace)
+
+		return nil
+	}
+
+	err := nsBuilder.DeleteAndWait(120 * time.Second)
+	if err != nil {
+		return fmt.Errorf("failed to delete namespace %s: %w", u.config.Namespace, err)
+	}
+
+	glog.V(u.config.LogLevel).Infof("SUCCESS: Namespace %s deleted", u.config.Namespace)
+
+	return nil
+}
+
+// deleteResourceWithTimeout deletes a resource and waits for it to be removed.
+func (u *OperatorUninstaller) deleteResourceWithTimeout(resource interface{}, timeout time.Duration) error {
+	type deletable interface {
+		Delete() error
+		Exists() bool
+	}
+
+	delRes, ok := resource.(deletable)
+	if !ok {
+		return fmt.Errorf("resource does not implement required delete interface")
+	}
+
+	if err := delRes.Delete(); err != nil {
+		return err
+	}
+
+	return wait.PollUntilContextTimeout(
+		context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+			exists := delRes.Exists()
+
+			return !exists, nil
+		})
+}

--- a/tests/hw-accel/nfd/internal/nfddelete/custom_resources.go
+++ b/tests/hw-accel/nfd/internal/nfddelete/custom_resources.go
@@ -1,0 +1,153 @@
+package nfddelete
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/golang/glog"
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	nodefeature "github.com/openshift-kni/eco-goinfra/pkg/nfd"
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/internal/deploy"
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/nfd/nfdparams"
+)
+
+// NFDCustomResourceCleaner implements CustomResourceCleaner for NFD operators.
+type NFDCustomResourceCleaner struct {
+	APIClient *clients.Settings
+	Namespace string
+	LogLevel  glog.Level
+}
+
+// NewNFDCustomResourceCleaner creates a new NFD custom resource cleaner.
+func NewNFDCustomResourceCleaner(
+	apiClient *clients.Settings,
+	namespace string,
+	logLevel glog.Level) *NFDCustomResourceCleaner {
+	return &NFDCustomResourceCleaner{
+		APIClient: apiClient,
+		Namespace: namespace,
+		LogLevel:  logLevel,
+	}
+}
+
+// CleanupCustomResources implements the CustomResourceCleaner interface for NFD.
+func (n *NFDCustomResourceCleaner) CleanupCustomResources() error {
+	glog.V(n.LogLevel).Infof("Deleting NodeFeatureDiscovery custom resources in namespace %s", n.Namespace)
+
+	potentialCRNames := []string{
+		"nfd-instance",
+		"nfd-instance-custom",
+		"nfd-instance-test",
+		"nfd",
+		"nodefeaturelist",
+	}
+
+	deletedCount := 0
+
+	for _, crName := range potentialCRNames {
+		if err := n.deleteNFDCRByName(crName); err != nil {
+			glog.V(n.LogLevel).Infof("NFD CR %s: %v", crName, err)
+		} else {
+			deletedCount++
+		}
+	}
+
+	if deletedCount == 0 {
+		glog.V(n.LogLevel).Infof("No NodeFeatureDiscovery custom resources found to delete")
+	} else {
+		glog.V(n.LogLevel).Infof("Successfully deleted %d NodeFeatureDiscovery custom resources", deletedCount)
+	}
+
+	return nil
+}
+
+// deleteNFDCRByName attempts to delete a specific NFD CR by name with finalizer handling.
+func (n *NFDCustomResourceCleaner) deleteNFDCRByName(crName string) error {
+	glog.V(n.LogLevel).Infof("Attempting to delete NFD CR: %s", crName)
+
+	nfdCR, err := nodefeature.Pull(n.APIClient, crName, n.Namespace)
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "not found") ||
+			strings.Contains(strings.ToLower(err.Error()), "does not exist") {
+			glog.V(n.LogLevel).Infof("NFD CR %s not found (already deleted or doesn't exist)", crName)
+
+			return nil
+		}
+
+		return fmt.Errorf("failed to pull NFD CR %s: %w", crName, err)
+	}
+
+	if nfdCR == nil {
+		glog.V(n.LogLevel).Infof("NFD CR %s not found", crName)
+
+		return nil
+	}
+
+	glog.V(n.LogLevel).Infof("Found NFD CR %s, proceeding with deletion", crName)
+
+	if len(nfdCR.Object.Finalizers) > 0 {
+		glog.V(n.LogLevel).Infof("Clearing finalizers for NFD CR %s: %v", crName, nfdCR.Object.Finalizers)
+
+		nfdCR.Definition.Finalizers = []string{}
+
+		_, err := nfdCR.Update(true)
+		if err != nil {
+			glog.V(n.LogLevel).Infof("Warning: failed to clear finalizers for NFD CR %s: %v", crName, err)
+
+			glog.V(n.LogLevel).Infof("Successfully cleared finalizers for NFD CR %s", crName)
+		}
+	}
+
+	_, err = nfdCR.Delete()
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "not found") {
+			glog.V(n.LogLevel).Infof("NFD CR %s already deleted during finalizer cleanup", crName)
+
+			return nil
+		}
+
+		return fmt.Errorf("failed to delete NFD CR %s: %w", crName, err)
+	}
+
+	glog.V(n.LogLevel).Infof("Successfully deleted NFD CR %s", crName)
+
+	return nil
+}
+
+// AllNFDCustomResources deletes all NFD custom resources by names.
+// This is a convenience function for direct use in tests.
+func AllNFDCustomResources(apiClient *clients.Settings, namespace string, crNames ...string) error {
+	glog.V(nfdparams.LogLevel).Infof("Deleting specified NFD custom resources in namespace %s", namespace)
+
+	if len(crNames) == 0 {
+		crNames = []string{
+			"nfd-instance",
+			"nfd-instance-custom",
+			"nfd-instance-test",
+			"nfd",
+		}
+	}
+
+	cleaner := NewNFDCustomResourceCleaner(apiClient, namespace, glog.Level(nfdparams.LogLevel))
+
+	deletedCount := 0
+
+	for _, crName := range crNames {
+		if err := cleaner.deleteNFDCRByName(crName); err != nil {
+			glog.V(nfdparams.LogLevel).Infof("NFD CR %s: %v", crName, err)
+		} else {
+			deletedCount++
+		}
+	}
+
+	if deletedCount == 0 {
+		glog.V(nfdparams.LogLevel).Infof("No NFD custom resources found to delete")
+	} else {
+		glog.V(nfdparams.LogLevel).Infof("Successfully deleted %d NFD custom resources", deletedCount)
+	}
+
+	return nil
+}
+
+// Interface verification.
+var _ deploy.CustomResourceCleaner = (*NFDCustomResourceCleaner)(nil)

--- a/tests/hw-accel/nfd/internal/nfdhelpers/config.go
+++ b/tests/hw-accel/nfd/internal/nfdhelpers/config.go
@@ -1,0 +1,170 @@
+package nfdhelpers
+
+import (
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/internal/deploy"
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/nfd/internal/nfddelete"
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/nfd/nfdparams"
+)
+
+// NFDInstallConfigOptions holds optional overrides for NFD installation configuration.
+type NFDInstallConfigOptions struct {
+	OperatorGroupName      *string
+	SubscriptionName       *string
+	CatalogSource          *string
+	CatalogSourceNamespace *string
+	Channel                *string
+	LogLevel               *glog.Level
+}
+
+// GetDefaultNFDInstallConfig returns the standard NFD installation configuration with optional overrides.
+func GetDefaultNFDInstallConfig(
+	apiClient *clients.Settings,
+	options *NFDInstallConfigOptions) deploy.OperatorInstallConfig {
+	config := deploy.OperatorInstallConfig{
+		APIClient:              apiClient,
+		Namespace:              nfdparams.NFDNamespace,
+		OperatorGroupName:      "nfd-operator-group",
+		SubscriptionName:       "nfd-subscription",
+		PackageName:            "nfd",
+		CatalogSource:          "redhat-operators",
+		CatalogSourceNamespace: "openshift-marketplace",
+		Channel:                "stable",
+
+		LogLevel: glog.Level(nfdparams.LogLevel),
+	}
+
+	if options != nil {
+		if options.OperatorGroupName != nil {
+			config.OperatorGroupName = *options.OperatorGroupName
+		}
+
+		if options.SubscriptionName != nil {
+			config.SubscriptionName = *options.SubscriptionName
+		}
+
+		if options.CatalogSource != nil {
+			config.CatalogSource = *options.CatalogSource
+		}
+
+		if options.CatalogSourceNamespace != nil {
+			config.CatalogSourceNamespace = *options.CatalogSourceNamespace
+		}
+
+		if options.Channel != nil {
+			config.Channel = *options.Channel
+		}
+
+		if options.LogLevel != nil {
+			config.LogLevel = *options.LogLevel
+		}
+	}
+
+	return config
+}
+
+// GetDefaultNFDUninstallConfig returns the standard NFD uninstallation configuration.
+func GetDefaultNFDUninstallConfig(apiClient *clients.Settings,
+	operatorGroupName,
+	subscriptionName string) deploy.OperatorUninstallConfig {
+	nfdCleaner := nfddelete.NewNFDCustomResourceCleaner(apiClient, nfdparams.NFDNamespace, glog.Level(nfdparams.LogLevel))
+
+	return deploy.OperatorUninstallConfig{
+		APIClient:             apiClient,
+		Namespace:             nfdparams.NFDNamespace,
+		OperatorGroupName:     operatorGroupName,
+		SubscriptionName:      subscriptionName,
+		CustomResourceCleaner: nfdCleaner,
+		LogLevel:              glog.Level(nfdparams.LogLevel),
+	}
+}
+
+// GetGenericOperatorUninstallConfig returns uninstall configuration for non-NFD operators.
+func GetGenericOperatorUninstallConfig(apiClient *clients.Settings,
+	namespace,
+	operatorGroupName,
+	subscriptionName string) deploy.OperatorUninstallConfig {
+	return deploy.OperatorUninstallConfig{
+		APIClient:             apiClient,
+		Namespace:             namespace,
+		OperatorGroupName:     operatorGroupName,
+		SubscriptionName:      subscriptionName,
+		CustomResourceCleaner: nil,
+		LogLevel:              glog.Level(nfdparams.LogLevel),
+	}
+}
+
+// GetOperatorUninstallConfigWithCleaner returns uninstall configuration with custom resource cleaner.
+// Example usage for other operators (KMM, AMD GPU, etc.):
+//
+//	type KMMCustomResourceCleaner struct { ... }
+//	func (k *KMMCustomResourceCleaner) CleanupCustomResources() error { ... }
+//
+//	kmmCleaner := &KMMCustomResourceCleaner{...}
+//	config := GetOperatorUninstallConfigWithCleaner(apiClient, "kmm-namespace", "kmm-group", "kmm-sub", kmmCleaner)
+func GetOperatorUninstallConfigWithCleaner(
+	apiClient *clients.Settings,
+	namespace, operatorGroupName, subscriptionName string,
+	cleaner deploy.CustomResourceCleaner) deploy.OperatorUninstallConfig {
+	return deploy.OperatorUninstallConfig{
+		APIClient:             apiClient,
+		Namespace:             namespace,
+		OperatorGroupName:     operatorGroupName,
+		SubscriptionName:      subscriptionName,
+		CustomResourceCleaner: cleaner,
+		LogLevel:              glog.Level(nfdparams.LogLevel),
+	}
+}
+
+// StringPtr returns a pointer to the given string (helper for options).
+func StringPtr(s string) *string {
+	return &s
+}
+
+// LogLevelPtr returns a pointer to the given glog.Level (helper for options).
+func LogLevelPtr(level glog.Level) *glog.Level {
+	return &level
+}
+
+// GetStandardNFDConfig returns the most common NFD configuration.
+func GetStandardNFDConfig(apiClient *clients.Settings) deploy.OperatorInstallConfig {
+	return GetDefaultNFDInstallConfig(apiClient, nil)
+}
+
+// GetUpgradeTestNFDConfig returns NFD configuration optimized for upgrade tests.
+func GetUpgradeTestNFDConfig(apiClient *clients.Settings, catalogSource string) deploy.OperatorInstallConfig {
+	options := &NFDInstallConfigOptions{
+		OperatorGroupName: StringPtr("op-nfd"),
+		SubscriptionName:  StringPtr("nfd"),
+		CatalogSource:     StringPtr(catalogSource),
+	}
+
+	return GetDefaultNFDInstallConfig(apiClient, options)
+}
+
+// GetNFDCSVUtils returns a CSV utility instance for NFD operations.
+func GetNFDCSVUtils(apiClient *clients.Settings) *deploy.CSVUtils {
+	return deploy.NewCSVUtils(apiClient, nfdparams.NFDNamespace, glog.Level(nfdparams.LogLevel))
+}
+
+// WaitForNFDOperatorReady waits for NFD operator CSV to be ready - convenience function.
+func WaitForNFDOperatorReady(apiClient *clients.Settings, timeout time.Duration) (bool, error) {
+	csvUtils := GetNFDCSVUtils(apiClient)
+
+	return csvUtils.WaitForCSVReady("nfd", timeout)
+}
+
+// CheckNFDOperatorStatus checks the current status of the NFD operator CSV.
+func CheckNFDOperatorStatus(apiClient *clients.Settings) (string, error) {
+	csvUtils := GetNFDCSVUtils(apiClient)
+	csv, err := csvUtils.GetCSVByPackageName("nfd")
+
+	if err != nil {
+		return "", err
+	}
+
+	return string(csv.Object.Status.Phase), nil
+}

--- a/tests/hw-accel/nfd/internal/set/featurelist.go
+++ b/tests/hw-accel/nfd/internal/set/featurelist.go
@@ -2,7 +2,7 @@ package set
 
 import (
 	"github.com/openshift-kni/eco-goinfra/pkg/clients"
-	"github.com/openshift-kni/eco-gotests/tests/hw-accel/internal/deploy"
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/nfd/nfdparams"
 	"gopkg.in/yaml.v2"
 )
 
@@ -29,11 +29,11 @@ type PCIDevice struct {
 type Sources struct {
 	CPU    *CPUConfig    `yaml:"cpu,omitempty"`
 	PCI    []PCIDevice   `yaml:"pci,omitempty"`
-	USB    []interface{} `yaml:"usb,omitempty"`    // Add the necessary struct for USB if needed
-	Custom []interface{} `yaml:"custom,omitempty"` // Add the necessary struct for Custom if needed
+	USB    []interface{} `yaml:"usb,omitempty"`
+	Custom []interface{} `yaml:"custom,omitempty"`
 }
 
-// CPUConfigLabels set cpu blacklist/whitelist.
+// CPUConfigLabels set cpu blacklist/whitelist using the new NFD CR utilities.
 func CPUConfigLabels(apiClient *clients.Settings,
 	blackListLabels,
 	whiteListLabels []string,
@@ -54,7 +54,14 @@ func CPUConfigLabels(apiClient *clients.Settings,
 		panic(err)
 	}
 
-	err = deploy.DeployNfdWithCustomConfig(namespace, enableTopology, string(modifiedCPUYAML), image)
+	nfdCRUtils := NewNFDCRUtils(apiClient, namespace, nfdparams.NfdInstance)
+
+	nfdConfig := NFDCRConfig{
+		EnableTopology: enableTopology,
+		Image:          image,
+	}
+
+	err = nfdCRUtils.DeployNFDCRWithWorkerConfig(nfdConfig, string(modifiedCPUYAML))
 	if err != nil {
 		panic(err)
 	}

--- a/tests/hw-accel/nfd/internal/set/nfd-cr-utils.go
+++ b/tests/hw-accel/nfd/internal/set/nfd-cr-utils.go
@@ -1,0 +1,264 @@
+package set
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/openshift-kni/eco-goinfra/pkg/clients"
+	nodefeature "github.com/openshift-kni/eco-goinfra/pkg/nfd"
+	"github.com/openshift-kni/eco-goinfra/pkg/olm"
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/nfd/internal/wait"
+	"github.com/openshift-kni/eco-gotests/tests/hw-accel/nfd/nfdparams"
+	"gopkg.in/yaml.v2"
+)
+
+// NFDCRConfig holds configuration for NFD custom resource.
+type NFDCRConfig struct {
+	EnableTopology bool   `json:"enableTopology,omitempty"`
+	Image          string `json:"image,omitempty"`
+	WorkerConfig   string `json:"workerConfig,omitempty"`
+}
+
+// NFDCRUtils provides utilities for managing NFD custom resources.
+type NFDCRUtils struct {
+	APIClient *clients.Settings
+	Namespace string
+	LogLevel  glog.Level
+	CrName    string
+}
+
+// NewNFDCRUtils creates a new NFD CR utilities instance.
+func NewNFDCRUtils(apiClient *clients.Settings, namespace string, name string) *NFDCRUtils {
+	return &NFDCRUtils{
+		APIClient: apiClient,
+		Namespace: namespace,
+		LogLevel:  glog.Level(nfdparams.LogLevel),
+		CrName:    name,
+	}
+}
+
+// DeployNFDCR deploys a NodeFeatureDiscovery custom resource.
+func (nfd *NFDCRUtils) DeployNFDCR(config NFDCRConfig) error {
+	glog.V(nfd.LogLevel).Infof("Deploying NFD CR '%s' in namespace '%s'", nfd.CrName, nfd.Namespace)
+
+	nfdBuilder, err := nfd.createNFDBuilder(config)
+	if err != nil {
+		return fmt.Errorf("failed to create NFD builder: %w", err)
+	}
+
+	if nfd.CrName != "" {
+		nfdBuilder.Definition.Name = nfd.CrName
+	}
+
+	glog.V(nfd.LogLevel).Infof("Creating NFD CR: %v", nfdBuilder.Definition)
+	_, err = nfdBuilder.Create()
+
+	if err != nil {
+		return fmt.Errorf("failed to create NFD CR: %w", err)
+	}
+
+	glog.V(nfd.LogLevel).Infof("SUCCESS: NFD CR '%s' deployed", nfdBuilder.Definition.Name)
+
+	return nil
+}
+
+// DeleteNFDCR deletes a NodeFeatureDiscovery custom resource.
+func (nfd *NFDCRUtils) DeleteNFDCR() error {
+	glog.V(nfd.LogLevel).Infof("Deleting NFD CR '%s' from namespace '%s'", nfd.CrName, nfd.Namespace)
+
+	nfdBuilder, err := nodefeature.Pull(nfd.APIClient, nfd.CrName, nfd.Namespace)
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "not found") ||
+			strings.Contains(strings.ToLower(err.Error()), "does not exist") {
+			glog.V(nfd.LogLevel).Infof("NFD CR '%s' not found", nfd.CrName)
+
+			return nil
+		}
+
+		return fmt.Errorf("failed to pull NFD CR: %w", err)
+	}
+
+	if nfdBuilder == nil {
+		glog.V(nfd.LogLevel).Infof("NFD CR '%s' not found", nfd.CrName)
+
+		return nil
+	}
+
+	nfdBuilder.Definition.Finalizers = []string{}
+
+	_, err = nfdBuilder.Update(true)
+	if err != nil {
+		glog.V(nfd.LogLevel).Infof("Warning: failed to update NFD CR finalizers: %v", err)
+	}
+
+	_, err = nfdBuilder.Delete()
+	if err != nil {
+		return fmt.Errorf("failed to delete NFD CR: %w", err)
+	}
+
+	glog.V(nfd.LogLevel).Infof("SUCCESS: NFD CR '%s' deleted", nfd.CrName)
+
+	return nil
+}
+
+// IsNFDCRReady checks if a NodeFeatureDiscovery custom resource is ready.
+func (nfd *NFDCRUtils) IsNFDCRReady(timeout time.Duration) (bool, error) {
+	glog.V(nfd.LogLevel).Infof("Checking NFD CR readiness: %s", nfd.CrName)
+
+	nfdBuilder, err := nodefeature.Pull(nfd.APIClient, nfd.CrName, nfd.Namespace)
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "not found") ||
+			strings.Contains(strings.ToLower(err.Error()), "does not exist") {
+			glog.V(nfd.LogLevel).Infof("NFD CR '%s' not found yet - not ready", nfd.CrName)
+
+			return false, nil
+		}
+
+		return false, fmt.Errorf("failed to pull NFD CR: %w", err)
+	}
+
+	if nfdBuilder != nil {
+		glog.V(nfd.LogLevel).Infof("NFD CR '%s' found - checking pods", nfdBuilder.Definition.Name)
+
+		return wait.ForPodsRunning(nfd.APIClient, timeout, nfd.Namespace)
+	}
+
+	return false, fmt.Errorf("NFD CR '%s' not found", nfd.CrName)
+}
+
+// DeployNFDCRWithWorkerConfig deploys NFD CR with custom worker configuration.
+func (nfd *NFDCRUtils) DeployNFDCRWithWorkerConfig(config NFDCRConfig, workerConfig string) error {
+	glog.V(nfd.LogLevel).Infof("Deploying NFD CR '%s' with custom worker config", nfd.CrName)
+
+	nfdBuilder, err := nfd.createNFDBuilder(config)
+	if err != nil {
+		return fmt.Errorf("failed to create NFD builder: %w", err)
+	}
+
+	if nfd.CrName != "" {
+		nfdBuilder.Definition.Name = nfd.CrName
+	}
+
+	if workerConfig != "" {
+		nfdBuilder.Definition.Spec.WorkerConfig.ConfigData = workerConfig
+
+		glog.V(nfd.LogLevel).Infof("Applied custom worker config to NFD CR")
+	}
+
+	_, err = nfdBuilder.Create()
+	if err != nil {
+		return fmt.Errorf("failed to create NFD CR with worker config: %w", err)
+	}
+
+	glog.V(nfd.LogLevel).Infof("SUCCESS: NFD CR '%v' with worker config deployed", nfdBuilder.Definition)
+
+	return nil
+}
+
+// PrintCr prints the NFD CR configuration.
+func (nfd *NFDCRUtils) PrintCr() error {
+	nfdBuilder, err := nodefeature.Pull(nfd.APIClient, nfd.CrName, nfd.Namespace)
+
+	if err != nil {
+		glog.V(nfd.LogLevel).Infof("Failed to pull NFD CR: %v", err)
+
+		return fmt.Errorf("failed to pull NFD CR: %w", err)
+	}
+
+	if nfdBuilder != nil {
+		yml, err := yaml.Marshal(nfdBuilder.Definition)
+		if err != nil {
+			return fmt.Errorf("failed to marshal NFD CR: %w", err)
+		}
+
+		glog.Infof("NFD CR '%s' ", string(yml))
+
+		return nil
+	}
+
+	return fmt.Errorf("NFD CR '%s' not found", nfd.CrName)
+}
+
+// createNFDBuilder creates NFD builder from CSV examples.
+func (nfd *NFDCRUtils) createNFDBuilder(config NFDCRConfig) (*nodefeature.Builder, error) {
+	clusterServiceVersion, err := olm.ListClusterServiceVersion(nfd.APIClient, nfd.Namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list CSVs: %w", err)
+	}
+
+	if len(clusterServiceVersion) == 0 {
+		return nil, fmt.Errorf("no CSV found in %s namespace", nfd.Namespace)
+	}
+
+	var nfdCSV *olm.ClusterServiceVersionBuilder
+
+	for _, csv := range clusterServiceVersion {
+		if strings.Contains(strings.ToLower(csv.Object.Name), "nfd") {
+			nfdCSV = csv
+
+			break
+		}
+	}
+
+	if nfdCSV == nil {
+		return nil, fmt.Errorf("NFD CSV not found in namespace %s", nfd.Namespace)
+	}
+
+	glog.V(nfd.LogLevel).Infof("Using NFD CSV: %s", nfdCSV.Object.Name)
+
+	almExamples, err := nfdCSV.GetAlmExamples()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ALM examples: %w", err)
+	}
+
+	almExamples, err = nfd.editAlmExample(almExamples)
+	if err != nil {
+		return nil, fmt.Errorf("failed to filter ALM examples: %w", err)
+	}
+
+	nfdBuilder := nodefeature.NewBuilderFromObjectString(nfd.APIClient, almExamples)
+
+	nfdBuilder.Definition.Spec.TopologyUpdater = config.EnableTopology
+
+	if config.Image != "" {
+		nfdBuilder.Definition.Spec.Operand.Image = config.Image
+		glog.V(nfd.LogLevel).Infof("Using custom NFD image: %s", config.Image)
+	}
+
+	return nfdBuilder, nil
+}
+
+// editAlmExample filters ALM examples to include only NodeFeatureDiscovery.
+func (nfd *NFDCRUtils) editAlmExample(almExample string) (string, error) {
+	var items []map[string]interface{}
+	err := json.Unmarshal([]byte(almExample), &items)
+
+	if err != nil {
+		return "", fmt.Errorf("failed to unmarshal ALM examples JSON: %w", err)
+	}
+
+	var filtered []map[string]interface{}
+
+	for _, item := range items {
+		if kind, ok := item["kind"]; ok && kind == "NodeFeatureDiscovery" {
+			filtered = append(filtered, item)
+		}
+	}
+
+	if len(filtered) == 0 {
+		return "", fmt.Errorf("no NodeFeatureDiscovery found in ALM examples")
+	}
+
+	output, err := json.MarshalIndent(filtered, "", "  ")
+
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal filtered JSON: %w", err)
+	}
+
+	glog.V(nfd.LogLevel).Infof("Filtered ALM examples to %d NodeFeatureDiscovery objects", len(filtered))
+
+	return string(output), nil
+}

--- a/tests/hw-accel/nfd/nfdparams/consts.go
+++ b/tests/hw-accel/nfd/nfdparams/consts.go
@@ -8,4 +8,6 @@ const (
 	Label = "nfd_upgrade"
 	// LogLevel glog verbose value.
 	LogLevel = 90
+	// NfdInstance name of the NFD instance.
+	NfdInstance = "nfd-instance"
 )


### PR DESCRIPTION
add new oepratorinstaller, seperate cr utils, make nfd using it and update Readme. 
Added new struct (operator installer/uninstaller) and functions for handle operator installation using OLM.
separate CR deployment in this case nfd (cr-utils).
Update NFD Readme with all the necessary information. 