### PR TITLE
gitopsztp: fix issue with node delete path

### DIFF
--- a/tests/cnf/ran/gitopsztp/tests/ztp-argocd-node-delete.go
+++ b/tests/cnf/ran/gitopsztp/tests/ztp-argocd-node-delete.go
@@ -114,12 +114,12 @@ var _ = Describe("ZTP Argo CD Node Deletion Tests", Label(tsparams.LabelArgoCdNo
 		// This time the path not being found is an error since if one path for the test is found, the other
 		// being missing is an actual issue, not just a skip because the test is not applicable.
 		By("updating the Argo CD app to apply the suppression to the spec")
-		exists := clustersApp.DoesGitPathExist(tsparams.ZtpTestPathNodeDeleteAddSuppression)
-		Expect(exists).To(BeTrue(), "Already applied node delete crAnnotation but cannot find node delete suppression path")
-
 		// Since UpdateAndWaitForSync appends the git path, we need to reset it first to the original path
 		// before appending the new path.
 		clustersApp.Definition.Spec.Source.Path = originalClustersGitPath
+		exists := clustersApp.DoesGitPathExist(tsparams.ZtpTestPathNodeDeleteAddSuppression)
+		Expect(exists).To(BeTrue(), "Already applied node delete crAnnotation but cannot find node delete suppression path")
+
 		err = gitdetails.UpdateAndWaitForSync(clustersApp, false, tsparams.ZtpTestPathNodeDeleteAddSuppression)
 		Expect(err).ToNot(HaveOccurred(), "Failed to update Argo CD git path")
 


### PR DESCRIPTION
Caused by #606.

Although that PR correctly identified that appending the add suppression path would cause an error since the crAnnotation path had already been appended, it failed to account for the existence check which would be affected by the same issue. This PR just moves the fix of that issue to before the git path is checked for existence.