### PR TITLE
system-test: re-shuffle EgressService tests. (#714)

### DIFF
--- a/tests/system-tests/rdscore/tests/00_validate_top_level.go
+++ b/tests/system-tests/rdscore/tests/00_validate_top_level.go
@@ -260,18 +260,6 @@ var _ = Describe(
 
 		Context("Ungraceful Cluster Reboot", Label("ungraceful-cluster-reboot"), func() {
 			BeforeAll(func(ctx SpecContext) {
-				By("Creating EgressService with ETP=Cluster and sourceIPBy=LoadBalancerIP")
-				rdscorecommon.VerifyEgressServiceWithClusterETPLoadbalancer(ctx)
-
-				By("Creating EgressService with ETP=Cluster and sourceIPBy=Network")
-				rdscorecommon.VerifyEgressServiceWithClusterETPNetwork(ctx)
-
-				By("Creating EgressService with ETP=Local and sourceIPBy=LoadBalancerIP")
-				rdscorecommon.VerifyEgressServiceWithLocalETP(ctx)
-
-				By("Creating EgressService with ETP=Local and sourceIPBy=Network")
-				rdscorecommon.VerifyEgressServiceWithLocalETPSourceIPByNetwork(ctx)
-
 				By("Creating EgressIP workload config")
 				rdscorecommon.CreateEgressIPTestDeployment()
 
@@ -308,6 +296,22 @@ var _ = Describe(
 				By("Creating SR-IOV workload on different nodes and different SR-IOV networks")
 				rdscorecommon.VerifySRIOVWorkloadsOnDifferentNodesDifferentNet(ctx)
 			})
+
+			It("Setups EgressService with Cluster ExternalTrafficPolicy",
+				Label("egress", "egress-etp-cluster", "egress-etp-cluster-loadbalancer"),
+				rdscorecommon.VerifyEgressServiceWithClusterETPLoadbalancer)
+
+			It("Setups EgressService with Cluster ExternalTrafficPolicy and sourceIPBy=Network",
+				Label("egress", "egress-etp-cluster", "egress-etp-cluster-network"),
+				rdscorecommon.VerifyEgressServiceWithClusterETPNetwork)
+
+			It("Setups EgressService with Local ExternalTrafficPolicy",
+				Label("egress", "egress-etp-local"),
+				rdscorecommon.VerifyEgressServiceWithLocalETP)
+
+			It("Setups EgressService with Local ExternalTrafficPolicy and sourceIPBy=Network",
+				Label("egress", "egress-etp-local", "egress-etp-local-network"),
+				rdscorecommon.VerifyEgressServiceWithLocalETPSourceIPByNetwork)
 
 			It("Verifies ungraceful cluster reboot",
 				Label("rds-core-hard-reboot"), reportxml.ID("30020"),
@@ -554,18 +558,6 @@ var _ = Describe(
 
 		Context("Graceful Cluster Reboot", Label("graceful-cluster-reboot"), func() {
 			BeforeAll(func(ctx SpecContext) {
-				By("Creating EgressService with ETP=Cluster and sourceIPBy=LoadBalancerIP")
-				rdscorecommon.VerifyEgressServiceWithClusterETPLoadbalancer(ctx)
-
-				By("Creating EgressService with ETP=Cluster and sourceIPBy=Network")
-				rdscorecommon.VerifyEgressServiceWithClusterETPNetwork(ctx)
-
-				By("Creating EgressService with ETP=Local and sourceIPBy=LoadBalancerIP")
-				rdscorecommon.VerifyEgressServiceWithLocalETP(ctx)
-
-				By("Creating EgressService with ETP=Local and sourceIPBy=Network")
-				rdscorecommon.VerifyEgressServiceWithLocalETPSourceIPByNetwork(ctx)
-
 				By("Creating EgressIP workload config")
 				rdscorecommon.CreateEgressIPTestDeployment()
 
@@ -602,6 +594,22 @@ var _ = Describe(
 				By("Creating SR-IOV workload on different nodes and different SR-IOV networks")
 				rdscorecommon.VerifySRIOVWorkloadsOnDifferentNodesDifferentNet(ctx)
 			})
+
+			It("Setups EgressService with Cluster ExternalTrafficPolicy",
+				Label("egress", "egress-etp-cluster", "egress-etp-cluster-loadbalancer"),
+				rdscorecommon.VerifyEgressServiceWithClusterETPLoadbalancer)
+
+			It("Setups EgressService with Cluster ExternalTrafficPolicy and sourceIPBy=Network",
+				Label("egress", "egress-etp-cluster", "egress-etp-cluster-network"),
+				rdscorecommon.VerifyEgressServiceWithClusterETPNetwork)
+
+			It("Setups EgressService with Local ExternalTrafficPolicy",
+				Label("egress", "egress-etp-local"),
+				rdscorecommon.VerifyEgressServiceWithLocalETP)
+
+			It("Setups EgressService with Local ExternalTrafficPolicy and sourceIPBy=Network",
+				Label("egress", "egress-etp-local", "egress-etp-local-network"),
+				rdscorecommon.VerifyEgressServiceWithLocalETPSourceIPByNetwork)
 
 			It("Verifies graceful cluster reboot",
 				Label("rds-core-soft-reboot"), reportxml.ID("30021"), rdscorecommon.VerifySoftReboot)


### PR DESCRIPTION
(cherry picked from commit 3d0a8973bff3eac8bcd17a21ea44192554de23f0)

There's a known bug with EgressService so moving some tests out from the BeforeAll section