### PR TITLE
system-tests vcore: remove use of WithmanagedNodes

### DIFF
--- a/tests/system-tests/vcore/internal/vcorecommon/odf.go
+++ b/tests/system-tests/vcore/internal/vcorecommon/odf.go
@@ -226,7 +226,6 @@ func VerifyODFStorageSystemConfig(ctx SpecContext) {
 
 	storageclusterObj, err = storageclusterObj.
 		WithAnnotations(annotations).
-		WithManageNodes(false).
 		WithManagedResources(managedResources).
 		WithMonDataDirHostPath("/var/lib/rook").
 		WithStorageDeviceSet(storageDeviceSet).Create()


### PR DESCRIPTION
Recent changes to the OCS types mean that the StorageCluster does not have the ManageNodes field anymore. In preparation for these changes in eco-goinfra, this PR removes the function's use in eco-gotests.

These tests are no longer relevant anyway so the plan to just remove the function has been okayed by system tests: [slack thread](https://redhat-internal.slack.com/archives/C06FJ6AC36Z/p1753449818278159).