### PR TITLE
global: update to wsl_v5

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,7 +43,7 @@ linters:
     - unparam
     - usetesting
     - varnamelen
-    - wsl
+    - wsl_v5
   disable:
     - ireturn
   settings:
@@ -137,8 +137,6 @@ linters:
         - github.com/openshift-kni/eco-gotests/tests/lca/imagebasedinstall/mgmt/internal/mgmtinittools
         - github.com/openshift-kni/eco-gotests/tests/system-tests/diskencryption/internal/diskencryptioninittools
         - github.com/openshift-kni/eco-gotests/tests/system-tests/o-cloud/internal/ocloudinittools
-    wsl:
-      strict-append: false
   exclusions:
     generated: lax
     presets:

--- a/internal/report/cache.go
+++ b/internal/report/cache.go
@@ -431,8 +431,8 @@ func loadCacheFile(cacheFileName string) (*SuiteTree, error) {
 	}
 
 	tree := &SuiteTree{}
-	err = json.NewDecoder(decompressor).Decode(tree)
 
+	err = json.NewDecoder(decompressor).Decode(tree)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/report/command.go
+++ b/internal/report/command.go
@@ -143,6 +143,7 @@ func GetRemoteRevisions(ctx context.Context, repo string, branches iter.Seq[stri
 // command and logs them if the command fails.
 func execCommand(command *exec.Cmd) error {
 	var stdout, stderr bytes.Buffer
+
 	command.Stdout = &stdout
 	command.Stderr = &stderr
 
@@ -161,6 +162,7 @@ func execCommand(command *exec.Cmd) error {
 // captures the stdout and stderr of the command and logs them if the command fails.
 func execCommandWithStdout(command *exec.Cmd) (string, error) {
 	var stdout, stderr bytes.Buffer
+
 	command.Stdout = &stdout
 	command.Stderr = &stderr
 

--- a/internal/report/tree.go
+++ b/internal/report/tree.go
@@ -65,8 +65,8 @@ func NewFromFile(path string) (*SuiteTree, error) {
 	}
 
 	reports := []types.Report{}
-	err = json.Unmarshal(reportsBytes, &reports)
 
+	err = json.Unmarshal(reportsBytes, &reports)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/accel/internal/accelconfig/config.go
+++ b/tests/accel/internal/accelconfig/config.go
@@ -36,6 +36,7 @@ func NewAccelConfig() *AccelConfig {
 	log.Print("Creating new AccelConfig")
 
 	var accelConfig AccelConfig
+
 	accelConfig.GeneralConfig = config.NewConfig()
 
 	_, filename, _, _ := runtime.Caller(0)

--- a/tests/accel/upgrade/internal/createres/create.go
+++ b/tests/accel/upgrade/internal/createres/create.go
@@ -24,7 +24,6 @@ func Workload(apiClient *clients.Settings, workloadImage string) (*deployment.Bu
 		AccelConfig.IBUWorkloadImage, []string{"/hello-openshift"}).WithPorts(
 		[]corev1.ContainerPort{{Name: "http", ContainerPort: 8080}}).
 		WithSecurityContext(upgradeparams.DefaultSC).GetContainerCfg()
-
 	if err != nil {
 		return nil, fmt.Errorf("failed to get containerConfig with error: %w", err)
 	}
@@ -33,7 +32,6 @@ func Workload(apiClient *clients.Settings, workloadImage string) (*deployment.Bu
 		upgradeinittools.HubAPIClient, upgradeparams.DeploymentName, upgradeparams.TestNamespaceName, map[string]string{
 			"app": upgradeparams.DeploymentName,
 		}, *containerConfig).WithLabel("app", upgradeparams.DeploymentName).CreateAndWaitUntilReady(time.Second * 120)
-
 	if err != nil {
 		return nil, fmt.Errorf("failed to create workload with error: %w", err)
 	}
@@ -52,7 +50,6 @@ func Service(apiClient *clients.Settings, port int32) (*service.Builder, error) 
 		upgradeparams.ServicePort,
 		upgradeparams.ServicePort,
 		corev1.Protocol("TCP"))
-
 	if err != nil {
 		glog.V(90).Infof("Error defining service port: %v", err)
 
@@ -66,7 +63,6 @@ func Service(apiClient *clients.Settings, port int32) (*service.Builder, error) 
 		upgradeparams.TestNamespaceName,
 		upgradeparams.ContainerLabelsMap,
 		*svcPort).Create()
-
 	if err != nil {
 		glog.V(90).Infof("Error creating service: %v", err)
 
@@ -83,7 +79,6 @@ func Service(apiClient *clients.Settings, port int32) (*service.Builder, error) 
 func WorkloadRoute(apiClient *clients.Settings) (*route.Builder, error) {
 	workloadRoute, err := route.NewBuilder(
 		apiClient, upgradeparams.DeploymentName, upgradeparams.TestNamespaceName, upgradeparams.DeploymentName).Create()
-
 	if err != nil {
 		glog.V(90).Infof("Error creating route: %v", err)
 

--- a/tests/accel/upgrade/internal/deleteres/delete.go
+++ b/tests/accel/upgrade/internal/deleteres/delete.go
@@ -81,7 +81,6 @@ func Service(apiClient *clients.Settings) error {
 		upgradeparams.DeploymentName, upgradeparams.TestNamespaceName)
 
 	svcDemo, err := service.Pull(apiClient, upgradeparams.DeploymentName, upgradeparams.TestNamespaceName)
-
 	if err != nil && svcDemo == nil {
 		glog.V(90).Infof("Service %q not found in %q namespace",
 			upgradeparams.DeploymentName, upgradeparams.TestNamespaceName)
@@ -107,7 +106,6 @@ func Namespace(apiClient *clients.Settings) error {
 	glog.V(90).Infof("Deleting namespace %q", upgradeparams.TestNamespaceName)
 
 	nsDemo, err := namespace.Pull(apiClient, upgradeparams.TestNamespaceName)
-
 	if err != nil && nsDemo == nil {
 		glog.V(90).Infof("Namespace %q not found", upgradeparams.TestNamespaceName)
 

--- a/tests/assisted/internal/assistedconfig/config.go
+++ b/tests/assisted/internal/assistedconfig/config.go
@@ -16,6 +16,7 @@ func NewAssistedConfig() *AssistedConfig {
 	log.Print("Creating new AssistedConfig struct")
 
 	var assistedConfig AssistedConfig
+
 	assistedConfig.GeneralConfig = config.NewConfig()
 
 	return &assistedConfig

--- a/tests/assisted/ztp/internal/ztpconfig/config.go
+++ b/tests/assisted/ztp/internal/ztpconfig/config.go
@@ -60,6 +60,7 @@ func NewZTPConfig() *ZTPConfig {
 	glog.V(ztpparams.ZTPLogLevel).Info("Creating new ZTPConfig struct")
 
 	var ztpconfig ZTPConfig
+
 	ztpconfig.AssistedConfig = assistedconfig.NewAssistedConfig()
 
 	ztpconfig.HubConfig = new(HubConfig)

--- a/tests/assisted/ztp/operator/tests/build-artifacts-rootfs.go
+++ b/tests/assisted/ztp/operator/tests/build-artifacts-rootfs.go
@@ -142,8 +142,8 @@ func getISOVolumeID(path string) (string, error) {
 	// is offset 40 bytes into the primary volume descriptor
 	// Ref: https://github.com/openshift/assisted-image-service/blob/main/pkg/isoeditor/isoutil.go#L208
 	volID := make([]byte, 32)
-	_, err = iso.ReadAt(volID, 32808)
 
+	_, err = iso.ReadAt(volID, 32808)
 	if err != nil {
 		return "", err
 	}
@@ -162,6 +162,7 @@ func getCoreOSRootfsValue(path string) (string, error) {
 	}
 
 	defer img.Close()
+
 	reader := cpio.NewReader(img)
 
 	for hdr, err := reader.Next(); !errors.Is(err, io.EOF); hdr, err = reader.Next() {

--- a/tests/assisted/ztp/operator/tests/check_fips.go
+++ b/tests/assisted/ztp/operator/tests/check_fips.go
@@ -155,8 +155,8 @@ func extractBinaryFromPod(
 	}
 
 	var buf bytes.Buffer
-	buf, err = podbuilder.Copy(binary, containerName, tar)
 
+	buf, err = podbuilder.Copy(binary, containerName, tar)
 	if err != nil {
 		glog.V(ztpparams.ZTPLogLevel).Infof("Got error reading file to buffer. The error is : %s", err)
 

--- a/tests/assisted/ztp/operator/tests/infraenv-multiarch-image.go
+++ b/tests/assisted/ztp/operator/tests/infraenv-multiarch-image.go
@@ -476,8 +476,8 @@ type Images struct {
 // and returns the payload release version and image location.
 func readJSON(urlContent []byte) (Images, error) {
 	var images Images
-	err := json.Unmarshal(urlContent, &images)
 
+	err := json.Unmarshal(urlContent, &images)
 	if err != nil {
 		return images, err
 	}

--- a/tests/cnf/core/internal/coreconfig/config.go
+++ b/tests/cnf/core/internal/coreconfig/config.go
@@ -26,13 +26,14 @@ func NewCoreConfig() *CoreConfig {
 	log.Print("Creating new CoreConfig struct")
 
 	var coreConf CoreConfig
+
 	coreConf.CNFConfig = cnfconfig.NewCNFConfig()
 
 	_, filename, _, _ := runtime.Caller(0)
 	baseDir := filepath.Dir(filename)
 	confFile := filepath.Join(baseDir, PathToDefaultCnfCoreParamsFile)
-	err := readFile(&coreConf, confFile)
 
+	err := readFile(&coreConf, confFile)
 	if err != nil {
 		log.Printf("Error to read config file %s", confFile)
 
@@ -40,7 +41,6 @@ func NewCoreConfig() *CoreConfig {
 	}
 
 	err = readEnv(&coreConf)
-
 	if err != nil {
 		log.Print("Error to read environment variables")
 
@@ -61,8 +61,8 @@ func readFile(coreConfig *CoreConfig, cfgFile string) error {
 	}()
 
 	decoder := yaml.NewDecoder(openedCfgFile)
-	err = decoder.Decode(&coreConfig)
 
+	err = decoder.Decode(&coreConfig)
 	if err != nil {
 		return err
 	}

--- a/tests/cnf/core/network/day1day2/internal/day1day2env/day1day2env.go
+++ b/tests/cnf/core/network/day1day2/internal/day1day2env/day1day2env.go
@@ -33,7 +33,6 @@ func DoesClusterSupportDay1Day2Tests(requiredCPNodeNumber, requiredWorkerNodeNum
 		APIClient,
 		metav1.ListOptions{LabelSelector: labels.Set(NetConfig.WorkerLabelMap).String()},
 	)
-
 	if err != nil {
 		return err
 	}
@@ -48,7 +47,6 @@ func DoesClusterSupportDay1Day2Tests(requiredCPNodeNumber, requiredWorkerNodeNum
 		APIClient,
 		metav1.ListOptions{LabelSelector: labels.Set(NetConfig.ControlPlaneLabelMap).String()},
 	)
-
 	if err != nil {
 		return err
 	}
@@ -118,7 +116,6 @@ func CheckConnectivityBetweenMasterAndWorkers() error {
 		APIClient,
 		metav1.ListOptions{LabelSelector: labels.Set(NetConfig.ControlPlaneLabelMap).String()},
 	)
-
 	if err != nil {
 		return err
 	}
@@ -127,7 +124,6 @@ func CheckConnectivityBetweenMasterAndWorkers() error {
 		APIClient,
 		metav1.ListOptions{LabelSelector: labels.Set(NetConfig.WorkerLabelMap).String()},
 	)
-
 	if err != nil {
 		return err
 	}
@@ -164,7 +160,6 @@ func isNMStateOperatorDeployed() error {
 
 	nmstateOperatorDeployment, err := deployment.Pull(
 		APIClient, "nmstate-operator", NetConfig.NMStateOperatorNamespace)
-
 	if err != nil {
 		return fmt.Errorf("error to pull nmstate-operator deployment from the cluster")
 	}

--- a/tests/cnf/core/network/day1day2/internal/juniper/juniper.go
+++ b/tests/cnf/core/network/day1day2/internal/juniper/juniper.go
@@ -19,6 +19,7 @@ func DumpInterfaceConfigs(currentSession *JunosSession, switchInterfaces []strin
 		if err != nil {
 			return err
 		}
+
 		InterfaceConfigs = append(InterfaceConfigs, config)
 	}
 

--- a/tests/cnf/core/network/day1day2/internal/juniper/switchcmd.go
+++ b/tests/cnf/core/network/day1day2/internal/juniper/switchcmd.go
@@ -94,7 +94,6 @@ func NewSession(host, user, password string) (*JunosSession, error) {
 
 			return true, nil
 		})
-
 	if err != nil {
 		return nil, err
 	}
@@ -294,8 +293,8 @@ func (j *JunosSession) runCommand(command string) (string, error) {
 
 func (j *JunosSession) doesSessionExist() bool {
 	glog.V(90).Infof("Checking that the SSH session %d exists", j.Session.SessionID)
-	reply, err := j.getChassisInventory()
 
+	reply, err := j.getChassisInventory()
 	if err != nil || reply == "" {
 		return false
 	}

--- a/tests/cnf/core/network/dpdk/internal/dpdkenv/dpdkenv.go
+++ b/tests/cnf/core/network/dpdk/internal/dpdkenv/dpdkenv.go
@@ -18,7 +18,6 @@ func DoesClusterSupportDpdkTests(
 	glog.V(90).Infof("Verifying if cluster supports dpdk tests")
 
 	err := netenv.DoesClusterHasEnoughNodes(apiClient, netConfig, 1, 2)
-
 	if err != nil {
 		return err
 	}
@@ -27,7 +26,6 @@ func DoesClusterSupportDpdkTests(
 		apiClient,
 		metav1.ListOptions{LabelSelector: labels.Set(netConfig.WorkerLabelMap).String()},
 	)
-
 	if err != nil {
 		return err
 	}

--- a/tests/cnf/core/network/dpdk/tests/rootless.go
+++ b/tests/cnf/core/network/dpdk/tests/rootless.go
@@ -788,7 +788,6 @@ func isPciAddressAvailable(clientPod *pod.Builder) bool {
 	var err error
 
 	pciAddressList, err := getPCIAddressListFromSrIovNetworkName(podNetAnnotation)
-
 	if err != nil {
 		return false
 	}
@@ -802,8 +801,8 @@ func isPciAddressAvailable(clientPod *pod.Builder) bool {
 
 func getPCIAddressListFromSrIovNetworkName(podNetworkStatus string) ([]string, error) {
 	var podNetworkStatusType []podNetworkAnnotation
-	err := json.Unmarshal([]byte(podNetworkStatus), &podNetworkStatusType)
 
+	err := json.Unmarshal([]byte(podNetworkStatus), &podNetworkStatusType)
 	if err != nil {
 		return nil, err
 	}
@@ -918,7 +917,6 @@ func testRouteInjection(clientPod *pod.Builder, nextHopInterface string) {
 func discoverNICVendor(srIovInterfaceUnderTest, workerNodeName string) (string, error) {
 	upSrIovInterfaces, err := sriov.NewNetworkNodeStateBuilder(
 		APIClient, workerNodeName, NetConfig.SriovOperatorNamespace).GetUpNICs()
-
 	if err != nil {
 		return "", err
 	}

--- a/tests/cnf/core/network/internal/cmd/cmd.go
+++ b/tests/cnf/core/network/internal/cmd/cmd.go
@@ -92,13 +92,11 @@ func RxTrafficOnClientPod(clientPod *pod.Builder, clientRxCmd string) error {
 		clientRxCmd, clientPod.Definition.Name)
 
 	err := clientPod.WaitUntilRunning(time.Minute)
-
 	if err != nil {
 		return fmt.Errorf("failed to wait until pod is running with error %w", err)
 	}
 
 	clientOut, err := clientPod.ExecCommand([]string{"/bin/bash", "-c", clientRxCmd})
-
 	if err.Error() != timeoutError {
 		return fmt.Errorf("failed to run the dpdk-pmd command on the client pod %s with output %s and %w",
 			clientRxCmd, clientOut.String(), err)
@@ -152,7 +150,6 @@ func getNumberOfPackets(line, firstFieldSubstr string) int {
 	}
 
 	numberOfPackets, err := strconv.Atoi(splitLine[1])
-
 	if err != nil {
 		glog.V(90).Infof("failed to convert string to integer %s", err)
 

--- a/tests/cnf/core/network/internal/cmd/switchcmd.go
+++ b/tests/cnf/core/network/internal/cmd/switchcmd.go
@@ -82,7 +82,6 @@ func NewSession(host, user, password string) (*Junos, error) {
 
 			return true, nil
 		})
-
 	if err != nil {
 		return nil, err
 	}

--- a/tests/cnf/core/network/internal/define/nad.go
+++ b/tests/cnf/core/network/internal/define/nad.go
@@ -39,7 +39,6 @@ func TapNad(
 	}
 
 	tap, err := nad.NewBuilder(apiClient, name, nsname).WithPlugins(name, &plugins).Create()
-
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +62,6 @@ func VlanNad(
 	apiClient *clients.Settings, name, nsName, intName string, vlanID uint16, ipam *nad.IPAM) (*nad.Builder, error) {
 	masterPlugin, err := nad.NewMasterVlanPlugin(name, vlanID).WithMasterInterface(intName).
 		WithIPAM(ipam).WithLinkInContainer().GetMasterPluginConfig()
-
 	if err != nil {
 		return nil, err
 	}

--- a/tests/cnf/core/network/internal/netconfig/config.go
+++ b/tests/cnf/core/network/internal/netconfig/config.go
@@ -52,13 +52,14 @@ func NewNetConfig() *NetworkConfig {
 	log.Print("Creating new NetworkConfig struct")
 
 	var netConf NetworkConfig
+
 	netConf.CoreConfig = coreconfig.NewCoreConfig()
 
 	_, filename, _, _ := runtime.Caller(0)
 	baseDir := filepath.Dir(filename)
 	confFile := filepath.Join(baseDir, PathToDefaultCnfCoreNetParamsFile)
-	err := readFile(&netConf, confFile)
 
+	err := readFile(&netConf, confFile)
 	if err != nil {
 		log.Printf("Error to read config file %s", confFile)
 
@@ -66,7 +67,6 @@ func NewNetConfig() *NetworkConfig {
 	}
 
 	err = readEnv(&netConf)
-
 	if err != nil {
 		log.Print("Error to read environment variables")
 
@@ -114,7 +114,6 @@ func (netConfig *NetworkConfig) GetVLAN() (uint16, error) {
 	}
 
 	vlanInt, err := strconv.Atoi(netConfig.VLAN)
-
 	if err != nil {
 		return 0, err
 	}
@@ -241,8 +240,8 @@ func readFile(netConfig *NetworkConfig, cfgFile string) error {
 	}()
 
 	decoder := yaml.NewDecoder(openedCfgFile)
-	err = decoder.Decode(&netConfig)
 
+	err = decoder.Decode(&netConfig)
 	if err != nil {
 		return err
 	}

--- a/tests/cnf/core/network/internal/netenv/netenv.go
+++ b/tests/cnf/core/network/internal/netenv/netenv.go
@@ -35,7 +35,6 @@ func DoesClusterHasEnoughNodes(
 		apiClient,
 		metav1.ListOptions{LabelSelector: labels.Set(netConfig.WorkerLabelMap).String()},
 	)
-
 	if err != nil {
 		return err
 	}
@@ -48,7 +47,6 @@ func DoesClusterHasEnoughNodes(
 		apiClient,
 		metav1.ListOptions{LabelSelector: labels.Set(netConfig.ControlPlaneLabelMap).String()},
 	)
-
 	if err != nil {
 		return err
 	}
@@ -72,7 +70,6 @@ func IsSriovDeployed(apiClient *clients.Settings, netConfig *netconfig.NetworkCo
 	for _, sriovDaemonsetName := range netparam.OperatorSriovDaemonsets {
 		sriovDaemonset, err := daemonset.Pull(
 			apiClient, sriovDaemonsetName, netConfig.SriovOperatorNamespace)
-
 		if err != nil {
 			return fmt.Errorf("error to pull SR-IOV daemonset %s from the cluster", sriovDaemonsetName)
 		}
@@ -140,7 +137,6 @@ func DeployPerformanceProfile(
 	}
 
 	performanceProfiles, err := nto.ListProfiles(apiClient)
-
 	if err != nil {
 		return fmt.Errorf("fail to list PerformanceProfile objects on cluster due to: %w", err)
 	}
@@ -157,13 +153,11 @@ func DeployPerformanceProfile(
 		glog.V(90).Infof("PerformanceProfile doesn't exist on cluster. Removing all pre-existing profiles")
 
 		err := nto.CleanAllPerformanceProfiles(apiClient)
-
 		if err != nil {
 			return fmt.Errorf("fail to clean pre-existing performance profiles due to %w", err)
 		}
 
 		err = mcp.WaitToBeStableFor(time.Minute, netparam.MCOWaitTimeout)
-
 		if err != nil {
 			return err
 		}
@@ -173,7 +167,6 @@ func DeployPerformanceProfile(
 
 	_, err = nto.NewBuilder(apiClient, profileName, isolatedCPU, reservedCPU, netConfig.WorkerLabelMap).
 		WithHugePages("1G", []v2.HugePage{{Size: "1G", Count: hugePages1GCount}}).Create()
-
 	if err != nil {
 		return fmt.Errorf("fail to deploy PerformanceProfile due to: %w", err)
 	}
@@ -304,13 +297,11 @@ func SetStaticRoute(frrPod *pod.Builder, action, destIP, containerName string,
 // WaitForMcpStable waits for the stability of the MCP with the given name.
 func WaitForMcpStable(apiClient *clients.Settings, waitingTime, stableDuration time.Duration, mcpName string) error {
 	mcp, err := mco.Pull(apiClient, mcpName)
-
 	if err != nil {
 		return fmt.Errorf("fail to pull mcp %s from cluster due to: %s", mcpName, err.Error())
 	}
 
 	err = mcp.WaitToBeStableFor(stableDuration, waitingTime)
-
 	if err != nil {
 		return fmt.Errorf("cluster is not stable: %s", err.Error())
 	}

--- a/tests/cnf/core/network/internal/netenv/sriov.go
+++ b/tests/cnf/core/network/internal/netenv/sriov.go
@@ -31,7 +31,6 @@ func WaitForSriovAndMCPStable(
 // WaitForSriovStable waits until all the SR-IOV node states are in sync.
 func WaitForSriovStable(apiClient *clients.Settings, waitingTime time.Duration, sriovOperatorNamespace string) error {
 	networkNodeStateList, err := sriov.ListNetworkNodeState(apiClient, sriovOperatorNamespace)
-
 	if err != nil {
 		return fmt.Errorf("failed to fetch nodes state %w", err)
 	}

--- a/tests/cnf/core/network/internal/netnmstate/netnmstate.go
+++ b/tests/cnf/core/network/internal/netnmstate/netnmstate.go
@@ -30,12 +30,10 @@ func CreateNewNMStateAndWaitUntilItsRunning(timeout time.Duration) error {
 	glog.V(90).Infof("Verifying if NMState instance is installed")
 
 	nmstateInstance, err := nmstate.PullNMstate(APIClient, netparam.NMState)
-
 	if err == nil {
 		glog.V(90).Infof("NMState exists. Removing NMState.")
 
 		_, err = nmstateInstance.Delete()
-
 		if err != nil {
 			return err
 		}
@@ -131,7 +129,6 @@ func ConfigureVFsAndWaitUntilItsConfigured(
 
 	// NodeNetworkStates exist for each node and share the same name.
 	nodeList, err := nodes.List(APIClient, metav1.ListOptions{LabelSelector: labels.Set(nodeLabel).String()})
-
 	if err != nil {
 		return err
 	}
@@ -451,7 +448,6 @@ func isNMStateDeployedAndReady(timeout time.Duration) error {
 
 			return true, nil
 		})
-
 	if err != nil {
 		return err
 	}

--- a/tests/cnf/core/network/metallb/internal/frr/frr.go
+++ b/tests/cnf/core/network/metallb/internal/frr/frr.go
@@ -302,7 +302,6 @@ func IsProtocolConfigured(frrPod *pod.Builder, protocol string) (bool, error) {
 // GetMetricsByPrefix pulls all metrics from frr pods and sort them in the list by given prefix.
 func GetMetricsByPrefix(frrPod *pod.Builder, metricPrefix string) ([]string, error) {
 	stdout, err := frrPod.ExecCommand([]string{"curl", "localhost:7573/metrics"}, "frr")
-
 	if err != nil {
 		return nil, err
 	}
@@ -377,8 +376,8 @@ func FetchBGPConnectTimeValue(frrk8sPods []*pod.Builder, bgpPeerIP string) (int,
 
 		// Parsing JSON
 		var bgpData map[string]BGPConnectionInfo
-		err = json.Unmarshal(output.Bytes(), &bgpData)
 
+		err = json.Unmarshal(output.Bytes(), &bgpData)
 		if err != nil {
 			return 0, fmt.Errorf("error parsing BGP neighbor JSON for pod %s: %w", frrk8sPod.Definition.Name, err)
 		}
@@ -407,8 +406,8 @@ func ValidateBGPRemoteAS(frrk8sPods []*pod.Builder, bgpPeerIP string, expectedRe
 
 		// Parsing JSON
 		var bgpData map[string]BGPConnectionInfo
-		err = json.Unmarshal(output.Bytes(), &bgpData)
 
+		err = json.Unmarshal(output.Bytes(), &bgpData)
 		if err != nil {
 			return fmt.Errorf("error parsing BGP neighbor JSON for pod %s: %w", frrk8sPod.Definition.Name, err)
 		}
@@ -435,7 +434,6 @@ func getBgpStatus(frrPod *pod.Builder, cmd string, containerName ...string) (*bg
 	glog.V(90).Infof("Getting bgp status from container: %s of pod: %s", cName, frrPod.Definition.Name)
 
 	bgpStateOut, err := frrPod.ExecCommand(append(netparam.VtySh, cmd))
-
 	if err != nil {
 		return nil, err
 	}
@@ -458,7 +456,6 @@ func GetGracefulRestartStatus(frrPod *pod.Builder, neighborIP string) (GRStatus,
 	glog.V(90).Infof("Getting GracefulRestart status from container: %s of pod: %s", "frr", frrPod.Definition.Name)
 
 	grStateOut, err := frrPod.ExecCommand(append(netparam.VtySh, "sh bgp neighbors graceful-restart json"))
-
 	if err != nil {
 		glog.V(90).Infof("Failed to execute Graceful Restart command")
 
@@ -529,7 +526,6 @@ func VerifyBGPReceivedRoutesOnFrrNodes(frrk8sPods []*pod.Builder) (string, error
 
 		// Parse the JSON output to get the BGP routes
 		bgpRoutes, err := parseBGPReceivedRoutes(output.String())
-
 		if err != nil {
 			return "", fmt.Errorf("error parsing BGP JSON from pod %s: %w", frrk8sPod.Definition.Name, err)
 		}
@@ -602,7 +598,6 @@ func ResetBGPConnection(frrPod *pod.Builder) error {
 // ValidateLocalPref verifies local pref from FRR is equal to configured Local Pref.
 func ValidateLocalPref(frrPod *pod.Builder, localPref uint32, ipFamily string) error {
 	bgpStatus, err := getBgpStatus(frrPod, fmt.Sprintf("show ip bgp %s json", ipFamily))
-
 	if err != nil {
 		return fmt.Errorf("failed to get BGP status %w", err)
 	}
@@ -718,8 +713,8 @@ func GetInterfaceStatus(frrPod *pod.Builder, interfaceName string, containerName
 	glog.V(90).Infof("Getting interface status from container: %s of pod: %s", cName, frrPod.Definition.Name)
 
 	cmd := fmt.Sprintf("show interface %s json", interfaceName)
-	interfaceStateOut, err := frrPod.ExecCommand(append(netparam.VtySh, cmd), tsparams.FRRContainerName)
 
+	interfaceStateOut, err := frrPod.ExecCommand(append(netparam.VtySh, cmd), tsparams.FRRContainerName)
 	if err != nil {
 		glog.V(90).Infof(fmt.Sprintf("Failed to execute command show interface %s json", interfaceName))
 
@@ -728,8 +723,8 @@ func GetInterfaceStatus(frrPod *pod.Builder, interfaceName string, containerName
 
 	// JSON is a map[string]InterfaceDetails
 	ifaceMap := make(map[string]InterfaceDetails)
-	err = json.Unmarshal(interfaceStateOut.Bytes(), &ifaceMap)
 
+	err = json.Unmarshal(interfaceStateOut.Bytes(), &ifaceMap)
 	if err != nil {
 		glog.V(90).Infof("Failed to unmarshal JSON: %s", interfaceStateOut.String())
 

--- a/tests/cnf/core/network/metallb/internal/metallbenv/metallbenv.go
+++ b/tests/cnf/core/network/metallb/internal/metallbenv/metallbenv.go
@@ -34,7 +34,6 @@ func DoesClusterSupportMetalLbTests(requiredCPNodeNumber, requiredWorkerNodeNumb
 		APIClient,
 		metav1.ListOptions{LabelSelector: labels.Set(NetConfig.WorkerLabelMap).String()},
 	)
-
 	if err != nil {
 		return err
 	}
@@ -49,7 +48,6 @@ func DoesClusterSupportMetalLbTests(requiredCPNodeNumber, requiredWorkerNodeNumb
 		APIClient,
 		metav1.ListOptions{LabelSelector: labels.Set(NetConfig.ControlPlaneLabelMap).String()},
 	)
-
 	if err != nil {
 		return err
 	}
@@ -89,7 +87,6 @@ func CreateNewMetalLbDaemonSetAndWaitUntilItsRunning(timeout time.Duration, node
 	}
 
 	_, err = metalLbIo.Create()
-
 	if err != nil {
 		return fmt.Errorf("failed to create MetalLB daemonset: %w", err)
 	}
@@ -109,7 +106,6 @@ func CreateNewMetalLbDaemonSetAndWaitUntilItsRunning(timeout time.Duration, node
 
 			return true, nil
 		})
-
 	if err != nil {
 		return fmt.Errorf("failed to pull MetalLB daemonset: %w", err)
 	}
@@ -159,7 +155,6 @@ func GetMetalLbIPByIPStack() ([]string, []string, error) {
 	glog.V(90).Infof("Getting MetalLb virtual ip addresses.")
 
 	metalLbIPList, err := NetConfig.GetMetalLbVirIP()
-
 	if err != nil {
 		return nil, nil, err
 	}
@@ -195,7 +190,6 @@ func IsEnvVarMetalLbIPinNodeExtNetRange(nodeExtAddresses, metalLbEnvIPv4, metalL
 
 	for _, nodeExtAddress := range nodeExtAddresses {
 		ipaddr, subnet, err := net.ParseCIDR(nodeExtAddress)
-
 		if err != nil {
 			return err
 		}
@@ -275,7 +269,6 @@ func isMetalLbDeployed() error {
 
 	metalLbController, err := deployment.Pull(
 		APIClient, tsparams.OperatorControllerManager, NetConfig.MlbOperatorNamespace)
-
 	if err != nil {
 		return fmt.Errorf("error to pull metallb controller deployment %s from cluster", tsparams.OperatorControllerManager)
 	}
@@ -286,7 +279,6 @@ func isMetalLbDeployed() error {
 	}
 
 	metalLbWebhook, err := deployment.Pull(APIClient, tsparams.OperatorWebhook, NetConfig.MlbOperatorNamespace)
-
 	if err != nil {
 		return fmt.Errorf("error to pull webhook deployment object %s from cluster", tsparams.OperatorWebhook)
 	}

--- a/tests/cnf/core/network/metallb/internal/prometheus/prometheus.go
+++ b/tests/cnf/core/network/metallb/internal/prometheus/prometheus.go
@@ -31,8 +31,8 @@ func PodMetricsPresentInDB(prometheusPod *pod.Builder, podName string, uniqueMet
 			"curl",
 			fmt.Sprintf("%squery?query=%s", "http://localhost:9090/api/v1/", metricsKey),
 		}
-		stdout, err := prometheusPod.ExecCommand(command)
 
+		stdout, err := prometheusPod.ExecCommand(command)
 		if err != nil {
 			glog.V(90).Infof("Fail to collect metric %s. Stdout %s", metricsKey, stdout.String())
 
@@ -40,8 +40,8 @@ func PodMetricsPresentInDB(prometheusPod *pod.Builder, podName string, uniqueMet
 		}
 
 		var queryOutput queryOutput
-		err = json.Unmarshal(stdout.Bytes(), &queryOutput)
 
+		err = json.Unmarshal(stdout.Bytes(), &queryOutput)
 		if err != nil {
 			return false, err
 		}

--- a/tests/cnf/core/network/metallb/tests/metallb-crds.go
+++ b/tests/cnf/core/network/metallb/tests/metallb-crds.go
@@ -172,7 +172,6 @@ func addOrDeleteNodeSecIPAddViaFRRK8S(action string,
 
 	buffer, err := frrk8sPods[0].ExecCommand([]string{"ip", "add", action,
 		ipaddress, "dev", secInterface}, "frr")
-
 	if err != nil && strings.Contains(buffer.String(), "already assigned") {
 		glog.V(90).Infof("Warning: Address %s is already assigned to %s", ipaddress, secInterface)
 

--- a/tests/cnf/core/network/policy/tests/multinetpolicysriov.go
+++ b/tests/cnf/core/network/policy/tests/multinetpolicysriov.go
@@ -675,7 +675,6 @@ func runTraffic(clientPod *pod.Builder, serverIP, protocol string, port int) err
 		[]string{"testcmd", fmt.Sprintf("-port=%d", port), "-interface=net1",
 			fmt.Sprintf("-server=%s", serverIP), fmt.Sprintf("-protocol=%s", protocol), "-mtu=1200"},
 	)
-
 	if err != nil {
 		return fmt.Errorf("%w: %s", err, buffer.String())
 	}
@@ -772,6 +771,7 @@ func createServerPod(
 		initContainer, err := pod.NewContainerBuilder(
 			fmt.Sprintf("init%d", idx), NetConfig.CnfNetTestContainer, initCommand).GetContainerCfg()
 		Expect(err).ToNot(HaveOccurred(), "Failed to define init container")
+
 		initContainers = append(initContainers, initContainer)
 
 		serverPod5003Container, err := pod.NewContainerBuilder(
@@ -779,6 +779,7 @@ func createServerPod(
 			setTestCmdServer(protocol, removePrefixFromIP(serverIP), port5003)).
 			GetContainerCfg()
 		Expect(err).ToNot(HaveOccurred(), "Failed to define server 5003 pod container")
+
 		serverPodContainers = append(serverPodContainers, serverPod5003Container)
 
 		serverPod5001Container, err := pod.NewContainerBuilder(
@@ -786,6 +787,7 @@ func createServerPod(
 			setTestCmdServer(protocol, removePrefixFromIP(serverIP), port5001)).
 			GetContainerCfg()
 		Expect(err).ToNot(HaveOccurred(), "Failed to define server 5001 pod container")
+
 		serverPodContainers = append(serverPodContainers, serverPod5001Container)
 	}
 

--- a/tests/cnf/core/network/sriov/internal/sriovenv/bmc.go
+++ b/tests/cnf/core/network/sriov/internal/sriovenv/bmc.go
@@ -40,7 +40,6 @@ func ConfigureSecureBoot(bmcClient *bmc.BMC, action string) error {
 
 				return false, nil
 			})
-
 		if err != nil {
 			glog.V(90).Infof("Failed to enable secure boot")
 
@@ -64,7 +63,6 @@ func ConfigureSecureBoot(bmcClient *bmc.BMC, action string) error {
 
 				return false, nil
 			})
-
 		if err != nil {
 			glog.V(90).Infof("Failed to disable secure boot")
 
@@ -141,7 +139,6 @@ func powerCycleNode(bmcClient *bmc.BMC) error {
 
 			return false, nil
 		})
-
 	if err != nil {
 		glog.V(90).Infof("Failed to power cycle the system")
 

--- a/tests/cnf/core/network/sriov/internal/sriovenv/sriovenv.go
+++ b/tests/cnf/core/network/sriov/internal/sriovenv/sriovenv.go
@@ -31,7 +31,6 @@ func ValidateSriovInterfaces(workerNodeList []*nodes.Builder, requestedNumber in
 
 	availableUpSriovInterfaces, err := sriov.NewNetworkNodeStateBuilder(APIClient,
 		workerNodeList[0].Definition.Name, NetConfig.SriovOperatorNamespace).GetUpNICs()
-
 	if err != nil {
 		return fmt.Errorf("failed get SR-IOV devices from the node %s", workerNodeList[0].Definition.Name)
 	}
@@ -144,9 +143,9 @@ func IsSriovDeployed() error {
 
 	for _, sriovDaemonsetName := range tsparams.OperatorSriovDaemonsets {
 		glog.V(90).Infof("Validating daemonset %s exists and ready", sriovDaemonsetName)
+
 		sriovDaemonset, err := daemonset.Pull(
 			APIClient, sriovDaemonsetName, NetConfig.SriovOperatorNamespace)
-
 		if err != nil {
 			glog.V(90).Infof("Pulling daemonset %s failed", sriovDaemonsetName)
 
@@ -168,8 +167,8 @@ func IsSriovDeployed() error {
 func IsMellanoxDevice(intName, nodeName string) bool {
 	glog.V(90).Infof("Checking if specific interface %s on node %s is a Mellanox device.", intName, nodeName)
 	sriovNetworkState := sriov.NewNetworkNodeStateBuilder(APIClient, nodeName, NetConfig.SriovOperatorNamespace)
-	driverName, err := sriovNetworkState.GetDriverName(intName)
 
+	driverName, err := sriovNetworkState.GetDriverName(intName)
 	if err != nil {
 		glog.V(90).Infof("Failed to get driver name for interface %s on node %s: %w", intName, nodeName, err)
 
@@ -188,8 +187,8 @@ func ConfigureSriovMlnxFirmwareOnWorkers(
 
 		sriovNetworkState := sriov.NewNetworkNodeStateBuilder(
 			APIClient, workerNode.Object.Name, NetConfig.SriovOperatorNamespace)
-		pciAddress, err := sriovNetworkState.GetPciAddress(sriovInterfaceName)
 
+		pciAddress, err := sriovNetworkState.GetPciAddress(sriovInterfaceName)
 		if err != nil {
 			glog.V(90).Infof("Failed to get PCI address for the interface %s", sriovInterfaceName)
 
@@ -200,7 +199,6 @@ func ConfigureSriovMlnxFirmwareOnWorkers(
 			[]string{"bash", "-c",
 				fmt.Sprintf("mstconfig -y -d %s set SRIOV_EN=%t NUM_OF_VFS=%d && chroot /host reboot",
 					pciAddress, enableSriov, numVfs)})
-
 		if err != nil {
 			glog.V(90).Infof("Failed to configure SR-IOV firmware.")
 
@@ -286,10 +284,10 @@ func CreateAndWaitTestPodWithSecondaryNetwork(
 	glog.V(90).Infof("Creating a test pod name %s", podName)
 
 	secNetwork := pod.StaticIPAnnotationWithMacAddress(sriovResNameTest, testIPs, testMac)
+
 	testPod, err := pod.NewBuilder(APIClient, podName, tsparams.TestNamespaceName, NetConfig.CnfNetTestContainer).
 		DefineOnNode(testNodeName).WithPrivilegedFlag().
 		WithSecondaryNetwork(secNetwork).CreateAndWaitUntilRunning(netparam.DefaultTimeout)
-
 	if err != nil {
 		glog.V(90).Infof("Failed to create pod %s with secondary network", podName)
 
@@ -320,7 +318,6 @@ func CreatePodsAndRunTraffic(
 		serverMac,
 		clientIPs,
 		serverIPs)
-
 	if err != nil {
 		glog.V(90).Infof("Failed to create test pods")
 
@@ -343,8 +340,8 @@ func ConfigureSriovMlnxFirmwareOnWorkersAndWaitMCP(
 	}
 
 	time.Sleep(10 * time.Second)
-	err = netenv.WaitForMcpStable(APIClient, tsparams.MCOWaitTimeout, 1*time.Minute, NetConfig.CnfMcpLabel)
 
+	err = netenv.WaitForMcpStable(APIClient, tsparams.MCOWaitTimeout, 1*time.Minute, NetConfig.CnfMcpLabel)
 	if err != nil {
 		glog.V(90).Infof("Machineconfigpool is not stable")
 

--- a/tests/cnf/core/network/sriov/tests/externalllymanaged.go
+++ b/tests/cnf/core/network/sriov/tests/externalllymanaged.go
@@ -540,6 +540,7 @@ func getVfsUnderTest(busyVfs []string) []string {
 		if len(runes) > 0 {
 			runes[len(runes)-1] = '1'
 		}
+
 		vfsUnderTest = append(vfsUnderTest, string(runes))
 	}
 

--- a/tests/cnf/core/network/sriov/tests/qinq.go
+++ b/tests/cnf/core/network/sriov/tests/qinq.go
@@ -874,8 +874,8 @@ func disableQinQOnSwitch(switchCredentials *sriovenv.SwitchCredentials, switchIn
 		commands := []string{fmt.Sprintf("delete interfaces %s vlan-tagging", switchInterface)}
 		commands = append(commands, fmt.Sprintf("delete interfaces %s encapsulation extended-vlan-bridge",
 			switchInterface))
-		err = jnpr.Config(commands)
 
+		err = jnpr.Config(commands)
 		if err != nil {
 			return err
 		}
@@ -906,6 +906,7 @@ func defineAndCreateServerDPDKPod(
 	serverPodNetConfig []*multus.NetworkSelectionElement,
 	podCmd []string) *pod.Builder {
 	var rootUser int64
+
 	securityContext := corev1.SecurityContext{
 		RunAsUser: &rootUser,
 		Capabilities: &corev1.Capabilities{
@@ -945,6 +946,7 @@ func defineAndCreateClientDPDKPod(
 	nodeName string,
 	serverPodNetConfig []*multus.NetworkSelectionElement) *pod.Builder {
 	var rootUser = int64(0)
+
 	securityContext := corev1.SecurityContext{
 		RunAsUser: &rootUser,
 		Capabilities: &corev1.Capabilities{

--- a/tests/cnf/internal/cnfconfig/cnfconfig.go
+++ b/tests/cnf/internal/cnfconfig/cnfconfig.go
@@ -26,13 +26,14 @@ func NewCNFConfig() *CNFConfig {
 	log.Print("Creating new CNFConfig struct")
 
 	var coreConf CNFConfig
+
 	coreConf.GeneralConfig = config.NewConfig()
 
 	_, filename, _, _ := runtime.Caller(0)
 	baseDir := filepath.Dir(filename)
 	confFile := filepath.Join(baseDir, PathToDefaultCnfParamsFile)
-	err := readFile(&coreConf, confFile)
 
+	err := readFile(&coreConf, confFile)
 	if err != nil {
 		log.Printf("Error to read config file %s", confFile)
 
@@ -40,7 +41,6 @@ func NewCNFConfig() *CNFConfig {
 	}
 
 	err = readEnv(&coreConf)
-
 	if err != nil {
 		log.Print("Error to read environment variables")
 
@@ -61,8 +61,8 @@ func readFile(cnfConfig *CNFConfig, cfgFile string) error {
 	}()
 
 	decoder := yaml.NewDecoder(openedCfgFile)
-	err = decoder.Decode(&cnfConfig)
 
+	err = decoder.Decode(&cnfConfig)
 	if err != nil {
 		return err
 	}

--- a/tests/cnf/ran-deployment/internal/ranconfig/config.go
+++ b/tests/cnf/ran-deployment/internal/ranconfig/config.go
@@ -48,6 +48,7 @@ func NewRANConfig() *RANConfig {
 	glog.V(ranparam.LogLevel).Infof("Creating new RANConfig struct")
 
 	var ranConfig RANConfig
+
 	ranConfig.HubConfig = new(HubConfig)
 	ranConfig.Spoke1Config = new(Spoke1Config)
 	ranConfig.Spoke2Config = new(Spoke2Config)

--- a/tests/cnf/ran-deployment/internal/version/version.go
+++ b/tests/cnf/ran-deployment/internal/version/version.go
@@ -14,7 +14,6 @@ import (
 // version if the latest version could not be found.
 func GetOCPVersion(client *clients.Settings) (string, error) {
 	clusterVersion, err := clusterversion.Pull(client)
-
 	if err != nil {
 		return "", err
 	}

--- a/tests/cnf/ran/gitopsztp/internal/helper/helper.go
+++ b/tests/cnf/ran/gitopsztp/internal/helper/helper.go
@@ -28,8 +28,8 @@ func WaitForPolicyToExist(
 	err := wait.PollUntilContextTimeout(
 		context.TODO(), tsparams.ArgoCdChangeInterval, timeout, true, func(ctx context.Context) (bool, error) {
 			var err error
-			policy, err = ocm.PullPolicy(client, name, namespace)
 
+			policy, err = ocm.PullPolicy(client, name, namespace)
 			if err == nil {
 				return true, nil
 			}
@@ -52,8 +52,8 @@ func WaitForServiceAccountToExist(
 	err := wait.PollUntilContextTimeout(
 		context.TODO(), tsparams.ArgoCdChangeInterval, timeout, true, func(ctx context.Context) (bool, error) {
 			var err error
-			builder, err = serviceaccount.Pull(client, name, namespace)
 
+			builder, err = serviceaccount.Pull(client, name, namespace)
 			if err == nil {
 				return true, nil
 			}

--- a/tests/cnf/ran/gitopsztp/tests/ztp-bios-day-zero.go
+++ b/tests/cnf/ran/gitopsztp/tests/ztp-bios-day-zero.go
@@ -127,7 +127,6 @@ func GetNodeNames(spokeAPIClient *clients.Settings) ([]string, error) {
 	nodeList, err := nodes.List(
 		spokeAPIClient,
 	)
-
 	if err != nil {
 		return nil, err
 	}

--- a/tests/cnf/ran/gitopsztp/tests/ztp-cluster-instance-delete.go
+++ b/tests/cnf/ran/gitopsztp/tests/ztp-cluster-instance-delete.go
@@ -211,31 +211,38 @@ var _ = Describe("ZTP Siteconfig Operator's Cluster Instance Delete Tests",
 //nolint:wsl
 func validateAISpokeClusterInstallCRsRemoved() {
 	By("checking the infra env manifests removed on hub")
+
 	_, err := assisted.PullInfraEnvInstall(HubAPIClient, RANConfig.Spoke1Name, RANConfig.Spoke1Name)
 	Expect(err).To(HaveOccurred(), "Found spoke infra env manifests but expected to be removed")
 
 	By("checking the bare metal host manifests removed on hub")
+
 	_, err = bmh.Pull(HubAPIClient, RANConfig.Spoke1Name, RANConfig.Spoke1Name)
 	Expect(err).To(HaveOccurred(), "Found spoke bmh manifests but expected to be removed")
 
 	By("checking the cluster deployment manifests removed on hub")
+
 	_, err = hive.PullClusterDeployment(HubAPIClient, RANConfig.Spoke1Name, RANConfig.Spoke1Name)
 	Expect(err).To(HaveOccurred(), "Found spoke cluster deployment manifests but expected to be removed")
 
 	By("checking the NM state config manifests removed on hub")
+
 	nmStateConfigList, err := assisted.ListNmStateConfigs(HubAPIClient, RANConfig.Spoke1Name)
 	Expect(err).ToNot(HaveOccurred(), "Failed to list NM state config manifests")
 	Expect(nmStateConfigList).To(BeEmpty(), "Found spoke NM state config manifests but expected to be removed")
 
 	By("checking the klusterlet addon config manifests removed on hub")
+
 	_, err = ocm.PullKAC(HubAPIClient, RANConfig.Spoke1Name, RANConfig.Spoke1Name)
 	Expect(err).To(HaveOccurred(), "Found spoke kac manifests but expected to be removed")
 
 	By("checking the agent cluster install manifests removed on hub")
+
 	_, err = assisted.PullAgentClusterInstall(HubAPIClient, RANConfig.Spoke1Name, RANConfig.Spoke1Name)
 	Expect(err).To(HaveOccurred(), "Found spoke ACI manifests but expected to be removed")
 
 	By("verifying installed spoke cluster should still be functional")
+
 	_, err = version.GetOCPVersion(Spoke1APIClient)
 	Expect(err).ToNot(HaveOccurred(), "Failed to get OCP version from spoke and verify spoke cluster access")
 }

--- a/tests/cnf/ran/internal/ranconfig/config.go
+++ b/tests/cnf/ran/internal/ranconfig/config.go
@@ -85,6 +85,7 @@ func NewRANConfig() *RANConfig {
 	glog.V(ranparam.LogLevel).Infof("Creating new RANConfig struct")
 
 	var ranConfig RANConfig
+
 	ranConfig.CNFConfig = cnfconfig.NewCNFConfig()
 
 	_, filename, _, _ := runtime.Caller(0)

--- a/tests/cnf/ran/internal/ranhelper/ranhelper.go
+++ b/tests/cnf/ran/internal/ranhelper/ranhelper.go
@@ -34,15 +34,15 @@ func DoesContainerExistInPod(pod *pod.Builder, containerName string) bool {
 // UnmarshalRaw converts raw bytes for a K8s CR into the actual type.
 func UnmarshalRaw[T any](raw []byte) (*T, error) {
 	untyped := &unstructured.Unstructured{}
-	err := untyped.UnmarshalJSON(raw)
 
+	err := untyped.UnmarshalJSON(raw)
 	if err != nil {
 		return nil, err
 	}
 
 	var typed T
-	err = runtime.DefaultUnstructuredConverter.FromUnstructured(untyped.UnstructuredContent(), &typed)
 
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(untyped.UnstructuredContent(), &typed)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/cnf/ran/oran/tests/oran-provision.go
+++ b/tests/cnf/ran/oran/tests/oran-provision.go
@@ -179,8 +179,8 @@ func verifySpokeProvisioning() error {
 	By("verifying spoke 1 policy ConfigMap was created")
 
 	ztpNamespace := fmt.Sprintf("ztp-%s-%s", tsparams.ClusterTemplateName, RANConfig.ClusterTemplateAffix)
-	_, err = configmap.Pull(HubAPIClient, RANConfig.Spoke1Name+"-pg", ztpNamespace)
 
+	_, err = configmap.Pull(HubAPIClient, RANConfig.Spoke1Name+"-pg", ztpNamespace)
 	if err != nil {
 		glog.V(tsparams.LogLevel).Infof("Failed to verify spoke 1 policy ConfigMap was created: %v", err)
 

--- a/tests/cnf/ran/powermanagement/internal/collect/collect.go
+++ b/tests/cnf/ran/powermanagement/internal/collect/collect.go
@@ -210,6 +210,7 @@ func parsePodCountAndCpus(maxPodCount, cpuCount int) []int {
 	for i := 1; i <= podCount-1; i++ {
 		cpus = append(cpus, cpuPerPod)
 	}
+
 	cpus = append(cpus, cpuCount-cpuPerPod*(podCount-1))
 
 	return cpus

--- a/tests/cnf/ran/powermanagement/internal/helper/helper.go
+++ b/tests/cnf/ran/powermanagement/internal/helper/helper.go
@@ -137,14 +137,13 @@ func SetCPUFreq(
 			// Get current isolated core frequency from spoke cluster and compare to desired frequency
 			cmdOut, err := cluster.ExecCommandOnSNOWithRetries(Spoke1APIClient, ranparam.RetryCount,
 				ranparam.RetryInterval, spokeCommandIsolatedCPUs)
-
 			if err != nil {
 				return false, fmt.Errorf("command failed: %s", cmdOut)
 			}
 
 			cmdOut = strings.TrimSpace(cmdOut)
-			currIsolatedCoreFreq, err := strconv.Atoi(cmdOut)
 
+			currIsolatedCoreFreq, err := strconv.Atoi(cmdOut)
 			if err != nil {
 				glog.V(tsparams.LogLevel).Infof("converting cpu frequency %s to an int failed: %w", cmdOut, err)
 
@@ -158,14 +157,13 @@ func SetCPUFreq(
 			// Get current isolated core frequency from spoke cluster and compare to desired frequency
 			cmdOut, err = cluster.ExecCommandOnSNOWithRetries(Spoke1APIClient, ranparam.RetryCount,
 				ranparam.RetryInterval, spokeCommandReservedCPUs)
-
 			if err != nil {
 				return false, fmt.Errorf("command failed: %s", cmdOut)
 			}
 
 			cmdOut = strings.TrimSpace(cmdOut)
-			currReservedFreq, err := strconv.Atoi(cmdOut)
 
+			currReservedFreq, err := strconv.Atoi(cmdOut)
 			if err != nil {
 				glog.V(tsparams.LogLevel).Infof("converting cpu frequency %s to an int failed: %w", cmdOut, err)
 

--- a/tests/cnf/ran/talm/tests/talm-precache.go
+++ b/tests/cnf/ran/talm/tests/talm-precache.go
@@ -609,7 +609,6 @@ func checkPrecachePodLog(client *clients.Settings) error {
 
 			return false, nil
 		})
-
 	if err != nil && plog != "" {
 		glog.V(tsparams.LogLevel).Infof("generated pod logs: ", plog)
 	}

--- a/tests/hw-accel/internal/deploy/deploy-nfd.go
+++ b/tests/hw-accel/internal/deploy/deploy-nfd.go
@@ -115,7 +115,6 @@ func (n *NfdAPIResource) DeployNfd(waitTime int, addTopology bool, nfdInstanceIm
 	}
 
 	deploymentReady, err := n.IsDeploymentReady(time.Minute*time.Duration(waitTime), NfdController)
-
 	if err != nil {
 		glog.V(logLevel).Infof(
 			"Error %s not found\n cause: %s", NfdController, err.Error())
@@ -220,7 +219,6 @@ func (n *NfdAPIResource) IsDeploymentReady(waitTime time.Duration,
 
 			return true, nil
 		})
-
 	if timeOutError != nil {
 		return false, err
 	}
@@ -253,7 +251,6 @@ func (n *NfdAPIResource) deploy() error {
 
 func newNfdBuilder(namespace string, enableTopology bool, image string) (*nodefeature.Builder, error) {
 	clusters, err := olm.ListClusterServiceVersion(APIClient, namespace)
-
 	if err != nil {
 		return nil, err
 	}
@@ -367,7 +364,6 @@ func (n *NfdAPIResource) createNameSpaceIfNotExist() {
 
 func findCSV(namespace string) (string, error) {
 	clusterServices, err := olm.ListClusterServiceVersion(APIClient, namespace)
-
 	if err == nil && len(clusterServices) > 0 {
 		return clusterServices[0].Definition.Name, nil
 	}
@@ -401,8 +397,8 @@ func (n *NfdAPIResource) removeResource(resourceName string,
 		}
 
 		nfdbuilder.Definition.Finalizers = []string{}
-		_, updateErr := nfdbuilder.Update(true)
 
+		_, updateErr := nfdbuilder.Update(true)
 		if updateErr != nil {
 			return err
 		}
@@ -429,7 +425,6 @@ func (n *NfdAPIResource) removeResource(resourceName string,
 	}
 
 	err = deleteAndWait(builder, 60*time.Second)
-
 	if err != nil {
 		return err
 	}
@@ -439,8 +434,8 @@ func (n *NfdAPIResource) removeResource(resourceName string,
 
 func editAlmExample(almExample string) (string, error) {
 	var items []map[string]interface{}
-	err := json.Unmarshal([]byte(almExample), &items)
 
+	err := json.Unmarshal([]byte(almExample), &items)
 	if err != nil {
 		glog.Errorf("Failed to unmarshal JSON: %v", err)
 

--- a/tests/hw-accel/internal/deploy/operator-installer.go
+++ b/tests/hw-accel/internal/deploy/operator-installer.go
@@ -237,7 +237,6 @@ func (o *OperatorInstaller) waitForNamespaceDeletion() error {
 
 			return false, nil
 		})
-
 	if err != nil {
 		return fmt.Errorf("timeout waiting for namespace %s deletion: %w", o.config.Namespace, err)
 	}
@@ -297,7 +296,6 @@ func (o *OperatorInstaller) createSubscription() error {
 	}
 
 	_, err := sub.Create()
-
 	if err != nil {
 		if strings.Contains(err.Error(), "is being terminated") ||
 			strings.Contains(err.Error(), "NamespaceTerminating") {

--- a/tests/hw-accel/internal/hwaccelconfig/config.go
+++ b/tests/hw-accel/internal/hwaccelconfig/config.go
@@ -16,6 +16,7 @@ func NewHwAccelConfig() *HwAccelConfig {
 	log.Print("Creating new HwAccelConfig struct")
 
 	var hwaccelConfig HwAccelConfig
+
 	hwaccelConfig.GeneralConfig = config.NewConfig()
 
 	return &hwaccelConfig

--- a/tests/hw-accel/kmm/internal/await/await.go
+++ b/tests/hw-accel/kmm/internal/await/await.go
@@ -29,7 +29,6 @@ func BuildPodCompleted(apiClient *clients.Settings, nsname string, timeout time.
 
 			if buildPod[nsname] == "" {
 				pods, err := pod.List(apiClient, nsname, metav1.ListOptions{FieldSelector: "status.phase=Running"})
-
 				if err != nil {
 					glog.V(kmmparams.KmmLogLevel).Infof("build list error: %s", err)
 				}
@@ -99,7 +98,6 @@ func ModuleUndeployed(apiClient *clients.Settings, nsName string, timeout time.D
 	return wait.PollUntilContextTimeout(
 		context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			pods, err := pod.List(apiClient, nsName, metav1.ListOptions{})
-
 			if err != nil {
 				glog.V(kmmparams.KmmLogLevel).Infof("pod list error: %s\n", err)
 
@@ -118,7 +116,6 @@ func ModuleObjectDeleted(apiClient *clients.Settings, moduleName, nsName string,
 	return wait.PollUntilContextTimeout(
 		context.TODO(), time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			_, err := kmm.Pull(apiClient, moduleName, nsName)
-
 			if err != nil {
 				glog.V(kmmparams.KmmLogLevel).Infof("error while pulling the module; most likely it is deleted")
 			}
@@ -161,13 +158,11 @@ func deploymentPerLabel(apiClient *clients.Settings, moduleName, label string,
 			var err error
 
 			nodeBuilder, err := nodes.List(apiClient, metav1.ListOptions{LabelSelector: labels.Set(selector).String()})
-
 			if err != nil {
 				glog.V(kmmparams.KmmLogLevel).Infof("could not discover %v nodes", selector)
 			}
 
 			nodesForSelector, err := get.NumberOfNodesForSelector(apiClient, selector)
-
 			if err != nil {
 				glog.V(kmmparams.KmmLogLevel).Infof("nodes list error: %s", err)
 

--- a/tests/hw-accel/kmm/internal/check/check.go
+++ b/tests/hw-accel/kmm/internal/check/check.go
@@ -24,7 +24,6 @@ import (
 // NodeLabel checks if label is present on the node.
 func NodeLabel(apiClient *clients.Settings, moduleName, nsname string, nodeSelector map[string]string) (bool, error) {
 	nodeBuilder, err := nodes.List(apiClient, metav1.ListOptions{LabelSelector: labels.Set(nodeSelector).String()})
-
 	if err != nil {
 		glog.V(kmmparams.KmmLogLevel).Infof("could not discover %v nodes", nodeSelector)
 	}
@@ -74,8 +73,8 @@ func ModuleSigned(apiClient *clients.Settings, modName, message, nsname, image s
 
 	processedImage := strings.ReplaceAll(image, "$KERNEL_FULL_VERSION", kernelVersion)
 	testPod := pod.NewBuilder(apiClient, "image-checker", nsname, processedImage)
-	_, err = testPod.CreateAndWaitUntilRunning(2 * time.Minute)
 
+	_, err = testPod.CreateAndWaitUntilRunning(2 * time.Minute)
 	if err != nil {
 		glog.V(kmmparams.KmmLogLevel).Infof("Could not create signing verification pod. Got error : %v", err)
 
@@ -85,7 +84,6 @@ func ModuleSigned(apiClient *clients.Settings, modName, message, nsname, image s
 	glog.V(kmmparams.KmmLogLevel).Infof("\n\nPodName: %v\n\n", testPod.Object.Name)
 
 	buff, err := testPod.ExecCommand(command, "test")
-
 	if err != nil {
 		return err
 	}
@@ -119,7 +117,6 @@ func runCommandOnTestPods(apiClient *clients.Settings,
 				FieldSelector: "status.phase=Running",
 				LabelSelector: kmmparams.KmmTestHelperLabelName,
 			})
-
 			if err != nil {
 				glog.V(kmmparams.KmmLogLevel).Infof("deployment list error: %s\n", err)
 
@@ -134,7 +131,6 @@ func runCommandOnTestPods(apiClient *clients.Settings,
 					iterPod.Object.Name, command, message)
 
 				buff, err := iterPod.ExecCommand(command, "test")
-
 				if err != nil {
 					return false, err
 				}

--- a/tests/hw-accel/kmm/internal/get/get.go
+++ b/tests/hw-accel/kmm/internal/get/get.go
@@ -18,7 +18,6 @@ import (
 // NumberOfNodesForSelector returns the number or worker nodes.
 func NumberOfNodesForSelector(apiClient *clients.Settings, selector map[string]string) (int, error) {
 	nodeBuilder, err := nodes.List(apiClient, metav1.ListOptions{LabelSelector: labels.Set(selector).String()})
-
 	if err != nil {
 		fmt.Println("could not discover number of nodes")
 
@@ -96,7 +95,6 @@ func MachineConfigPoolName(apiClient *clients.Settings) string {
 		apiClient,
 		metav1.ListOptions{LabelSelector: labels.Set(map[string]string{"kubernetes.io": ""}).String()},
 	)
-
 	if err != nil {
 		glog.V(kmmparams.KmmLogLevel).Infof("could not discover nodes")
 
@@ -117,7 +115,6 @@ func MachineConfigPoolName(apiClient *clients.Settings) string {
 // SigningData returns struct used for creating secrets for module signing.
 func SigningData(key string, value string) map[string][]byte {
 	val, err := base64.StdEncoding.DecodeString(value)
-
 	if err != nil {
 		glog.V(kmmparams.KmmLogLevel).Infof("Error decoding signing key")
 	}
@@ -187,7 +184,6 @@ func KmmHubOperatorVersion(apiClient *clients.Settings) (ver *version.Version, e
 func operatorVersion(apiClient *clients.Settings, namePattern, namespace string) (ver *version.Version, err error) {
 	csv, err := olm.ListClusterServiceVersionWithNamePattern(apiClient, namePattern,
 		namespace)
-
 	if err != nil {
 		return nil, err
 	}

--- a/tests/hw-accel/nfd/features/nfd_suite_test.go
+++ b/tests/hw-accel/nfd/features/nfd_suite_test.go
@@ -20,6 +20,7 @@ func TestFeatures(t *testing.T) {
 	reporterConfig.JUnitReport = GeneralConfig.GetJunitReportPath(currentFile)
 
 	RegisterFailHandler(Fail)
+
 	tsparams.Labels = append(tsparams.Labels, "feature")
 	RunSpecs(t, "NFD", Label(tsparams.Labels...), reporterConfig)
 }

--- a/tests/hw-accel/nfd/internal/get/getCpuFeature.go
+++ b/tests/hw-accel/nfd/internal/get/getCpuFeature.go
@@ -32,8 +32,8 @@ func CPUInfo(apiClient *clients.Settings, name, nsname, containerName, image str
 	for _, nodeName := range workerNodesNames {
 		podWorker := pod.NewBuilder(apiClient, nodeName+name, nsname, image)
 		containerBuilder := pod.NewContainerBuilder(containerName, image, []string{"./cpucheck"})
-		container, err := containerBuilder.GetContainerCfg()
 
+		container, err := containerBuilder.GetContainerCfg()
 		if err != nil {
 			glog.V(nfdparams.LogLevel).Infof("Failed to define the default container settings %v", err)
 		}
@@ -65,8 +65,8 @@ func CPUInfo(apiClient *clients.Settings, name, nsname, containerName, image str
 		}
 
 		podLogs := apiClient.Pods(nsname).GetLogs(podWorker.Definition.Name, &con).Do(context.TODO())
-		_, err = podWorker.DeleteAndWait(5 * time.Minute)
 
+		_, err = podWorker.DeleteAndWait(5 * time.Minute)
 		if err != nil {
 			glog.V(nfdparams.LogLevel).Infof(
 				"Error creating pod: %s", err.Error())

--- a/tests/hw-accel/nfd/internal/get/podsState.go
+++ b/tests/hw-accel/nfd/internal/get/podsState.go
@@ -41,6 +41,7 @@ func PodStatus(apiClient *clients.Settings, nsname string) ([]PodState, error) {
 		for _, nfdPodName := range nfdhelpersparams.ValidPodNameList {
 			if strings.Contains(onePod.Object.Name, nfdPodName) {
 				nfdResources[nfdPodName]--
+
 				podStateList = append(podStateList, PodState{Name: onePod.Object.Name, State: string(state)})
 			}
 		}

--- a/tests/hw-accel/nfd/internal/get/restartCount.go
+++ b/tests/hw-accel/nfd/internal/get/restartCount.go
@@ -8,7 +8,6 @@ import (
 // PodRestartCount get pod's reset count.
 func PodRestartCount(apiClient *clients.Settings, nsname, podName string) (int32, error) {
 	podWorker, err := pod.Pull(apiClient, podName, nsname)
-
 	if err != nil {
 		return 0, err
 	}

--- a/tests/hw-accel/nfd/internal/nfdhelpers/config.go
+++ b/tests/hw-accel/nfd/internal/nfdhelpers/config.go
@@ -160,8 +160,8 @@ func WaitForNFDOperatorReady(apiClient *clients.Settings, timeout time.Duration)
 // CheckNFDOperatorStatus checks the current status of the NFD operator CSV.
 func CheckNFDOperatorStatus(apiClient *clients.Settings) (string, error) {
 	csvUtils := GetNFDCSVUtils(apiClient)
-	csv, err := csvUtils.GetCSVByPackageName("nfd")
 
+	csv, err := csvUtils.GetCSVByPackageName("nfd")
 	if err != nil {
 		return "", err
 	}

--- a/tests/hw-accel/nfd/internal/set/nfd-cr-utils.go
+++ b/tests/hw-accel/nfd/internal/set/nfd-cr-utils.go
@@ -54,8 +54,8 @@ func (nfd *NFDCRUtils) DeployNFDCR(config NFDCRConfig) error {
 	}
 
 	glog.V(nfd.LogLevel).Infof("Creating NFD CR: %v", nfdBuilder.Definition)
-	_, err = nfdBuilder.Create()
 
+	_, err = nfdBuilder.Create()
 	if err != nil {
 		return fmt.Errorf("failed to create NFD CR: %w", err)
 	}
@@ -161,7 +161,6 @@ func (nfd *NFDCRUtils) DeployNFDCRWithWorkerConfig(config NFDCRConfig, workerCon
 // PrintCr prints the NFD CR configuration.
 func (nfd *NFDCRUtils) PrintCr() error {
 	nfdBuilder, err := nodefeature.Pull(nfd.APIClient, nfd.CrName, nfd.Namespace)
-
 	if err != nil {
 		glog.V(nfd.LogLevel).Infof("Failed to pull NFD CR: %v", err)
 
@@ -234,8 +233,8 @@ func (nfd *NFDCRUtils) createNFDBuilder(config NFDCRConfig) (*nodefeature.Builde
 // editAlmExample filters ALM examples to include only NodeFeatureDiscovery.
 func (nfd *NFDCRUtils) editAlmExample(almExample string) (string, error) {
 	var items []map[string]interface{}
-	err := json.Unmarshal([]byte(almExample), &items)
 
+	err := json.Unmarshal([]byte(almExample), &items)
 	if err != nil {
 		return "", fmt.Errorf("failed to unmarshal ALM examples JSON: %w", err)
 	}
@@ -253,7 +252,6 @@ func (nfd *NFDCRUtils) editAlmExample(almExample string) (string, error) {
 	}
 
 	output, err := json.MarshalIndent(filtered, "", "  ")
-
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal filtered JSON: %w", err)
 	}

--- a/tests/hw-accel/nfd/internal/wait/wait.go
+++ b/tests/hw-accel/nfd/internal/wait/wait.go
@@ -73,7 +73,6 @@ func CheckLabel(apiClient *clients.Settings,
 
 			return false, nil
 		})
-
 	if err != nil {
 		glog.V(nfdparams.LogLevel).Infof("Feature label wait failed: %v", err)
 
@@ -107,7 +106,6 @@ func ForNodeReadiness(apiClient *clients.Settings,
 
 			return checkReadiness, nil
 		})
-
 	if err != nil {
 		return false, err
 	}
@@ -136,7 +134,6 @@ func ForPodsRunning(apiClient *clients.Settings, timeout time.Duration, nsname s
 
 			return true, nil
 		})
-
 	if err != nil {
 		return false, err
 	}

--- a/tests/hw-accel/nvidiagpu/internal/check/check.go
+++ b/tests/hw-accel/nvidiagpu/internal/check/check.go
@@ -89,7 +89,6 @@ func NodeWithLabel(apiClient *clients.Settings, nodeLabel string, nodeSelector m
 func NFDDeploymentsReady(apiClient *clients.Settings) (bool, error) {
 	// here check if the 2 NFD deployments in openshift-nfd namespace are ready, first nfd operator
 	nfdOperatorDeployment, err1 := deployment.Pull(apiClient, nfdOperatorDeployment, hwaccelparams.NFDNamespace)
-
 	if err1 != nil {
 		glog.V(gpuparams.GpuLogLevel).Infof("Error trying to pull NFD operator deployment:  %v ", err1)
 
@@ -101,7 +100,6 @@ func NFDDeploymentsReady(apiClient *clients.Settings) (bool, error) {
 
 	// Check nfd-master deployment.
 	nfdMasterDeployment, err2 := deployment.Pull(apiClient, nfdMasterDeployment, hwaccelparams.NFDNamespace)
-
 	if err2 != nil {
 		glog.V(gpuparams.GpuLogLevel).Infof("Error trying to pull NFD master deployment:  %v ", err2)
 

--- a/tests/hw-accel/nvidiagpu/internal/deploy/deploy-nfd.go
+++ b/tests/hw-accel/nvidiagpu/internal/deploy/deploy-nfd.go
@@ -42,7 +42,6 @@ func CreateNFDNamespace(apiClient *clients.Settings) error {
 	glog.V(gpuparams.GpuLogLevel).Infof("Creating the namespace:  %v", hwaccelparams.NFDNamespace)
 
 	createdNfdNsBuilder, err := nfdNsBuilder.Create()
-
 	if err != nil {
 		glog.V(gpuparams.GpuLogLevel).Infof("error creating NFD namespace '%s' :  %v ",
 			createdNfdNsBuilder.Definition.Name, err)
@@ -62,7 +61,6 @@ func CreateNFDNamespace(apiClient *clients.Settings) error {
 	})
 
 	newLabeledNfdNsBuilder, err := labeledNfdNsBuilder.Update()
-
 	if err != nil {
 		glog.V(gpuparams.GpuLogLevel).Infof("error labeling NFD namespace %S :  %v ",
 			newLabeledNfdNsBuilder.Definition.Name, err)
@@ -90,7 +88,6 @@ func CreateNFDOperatorGroup(apiClient *clients.Settings) error {
 			nfdOperatorGroupName)
 
 		nfdOgBuilderCreated, err := nfdOgBuilder.Create()
-
 		if err != nil {
 			glog.V(gpuparams.GpuLogLevel).Infof("error creating NFD operatorgroup %v :  %v ",
 				nfdOgBuilderCreated.Definition.Name, err)
@@ -115,7 +112,6 @@ func CreateNFDSubscription(apiClient *clients.Settings) error {
 	glog.V(gpuparams.GpuLogLevel).Infof("Creating the NFD subscription, i.e Deploy the NFD operator")
 
 	createdNfdSub, err := nfdSubBuilder.Create()
-
 	if err != nil {
 		glog.V(gpuparams.GpuLogLevel).Infof("error creating NFD subscription %v :  %v ",
 			createdNfdSub.Definition.Name, err)
@@ -142,7 +138,6 @@ func CheckNFDOperatorDeployed(apiClient *clients.Settings, waitTime time.Duratio
 	glog.V(gpuparams.GpuLogLevel).Infof("Check if the NFD operator deployment is ready")
 
 	nfdOperatorDeployment, err := deployment.Pull(apiClient, nfdOperatorDeploymentName, hwaccelparams.NFDNamespace)
-
 	if err != nil {
 		glog.V(gpuparams.GpuLogLevel).Infof("Error trying to pull NFD operator "+
 			"deployment is: %v", err)
@@ -165,7 +160,6 @@ func CheckNFDOperatorDeployed(apiClient *clients.Settings, waitTime time.Duratio
 
 	nfdCurrentCSVFromSub, err := get.CurrentCSVFromSubscription(apiClient, nfdSubscriptionName,
 		nfdSubscriptionNamespace)
-
 	if err != nil {
 		glog.V(gpuparams.GpuLogLevel).Infof("error pulling NFD currentCSV from cluster:  %v", err)
 
@@ -202,7 +196,6 @@ func CheckNFDOperatorDeployed(apiClient *clients.Settings, waitTime time.Duratio
 	glog.V(gpuparams.GpuLogLevel).Infof("Pull existing CSV in NFD Operator Namespace")
 
 	clusterNfdCSV, err := olm.PullClusterServiceVersion(apiClient, nfdCurrentCSVFromSub, hwaccelparams.NFDNamespace)
-
 	if err != nil {
 		glog.V(gpuparams.GpuLogLevel).Infof("error pulling CSV %v from cluster:  %v",
 			nfdCurrentCSVFromSub, err)
@@ -234,7 +227,6 @@ func DeployCRInstance(apiClient *clients.Settings) error {
 
 	nfdCurrentCSVFromSub, err := get.CurrentCSVFromSubscription(apiClient, nfdSubscriptionName,
 		nfdSubscriptionNamespace)
-
 	if err != nil {
 		glog.V(gpuparams.GpuLogLevel).Infof("Error from getting CurrentCSVFromSubscription:  %v ", err)
 
@@ -244,7 +236,6 @@ func DeployCRInstance(apiClient *clients.Settings) error {
 	glog.V(gpuparams.GpuLogLevel).Infof("Pull existing CSV in NFD Operator Namespace")
 
 	clusterNfdCSV, err := olm.PullClusterServiceVersion(apiClient, nfdCurrentCSVFromSub, hwaccelparams.NFDNamespace)
-
 	if err != nil {
 		glog.V(gpuparams.GpuLogLevel).Infof("Error from PullClusterServiceVersion:  %v ", err)
 
@@ -252,7 +243,6 @@ func DeployCRInstance(apiClient *clients.Settings) error {
 	}
 
 	almExamples, err := clusterNfdCSV.GetAlmExamples()
-
 	if err != nil {
 		glog.V(gpuparams.GpuLogLevel).Infof("Error from pulling almExamples from NFD CSV:  %v ", err)
 
@@ -266,7 +256,6 @@ func DeployCRInstance(apiClient *clients.Settings) error {
 	nodeFeatureDiscoveryBuilder := nfd.NewBuilderFromObjectString(apiClient, almExamples)
 
 	_, err = nodeFeatureDiscoveryBuilder.Create()
-
 	if err != nil {
 		glog.V(gpuparams.GpuLogLevel).Infof("Error Creating NodeFeatureDiscovery instance from CSV "+
 			"almExamples  %v ", err)
@@ -288,7 +277,6 @@ func DeployCRInstance(apiClient *clients.Settings) error {
 	glog.V(gpuparams.GpuLogLevel).Infof("Check if the NFD CR deployment is ready")
 
 	nfdCRDeployment, err := deployment.Pull(apiClient, nfdCRDeploymentName, hwaccelparams.NFDNamespace)
-
 	if err != nil {
 		glog.V(gpuparams.GpuLogLevel).Infof("Error pulling NFD CR deployment  %v ", err)
 
@@ -314,7 +302,6 @@ func GetNFDCRJson(apiClient *clients.Settings, nfdCRName string, nfdNamespace st
 		"with updated fields")
 
 	pulledNodeFeatureDiscovery, err := nfd.Pull(apiClient, nfdCRName, nfdNamespace)
-
 	if err != nil {
 		glog.V(gpuparams.GpuLogLevel).Infof("error pulling NodeFeatureDiscovery %s from "+
 			"cluster: %v ", nfdCRName, err)
@@ -323,7 +310,6 @@ func GetNFDCRJson(apiClient *clients.Settings, nfdCRName string, nfdNamespace st
 	}
 
 	nfdCRJson, err := json.MarshalIndent(pulledNodeFeatureDiscovery, "", " ")
-
 	if err == nil {
 		glog.V(gpuparams.GpuLogLevel).Infof("The NodeFeatureDiscovery just created has name:  %v",
 			pulledNodeFeatureDiscovery.Definition.Name)
@@ -344,7 +330,6 @@ func NFDCRDeleteAndWait(apiClient *clients.Settings, nfdCRName string, nfdCRName
 	return wait.PollUntilContextTimeout(
 		context.TODO(), pollInterval, timeout, false, func(ctx context.Context) (bool, error) {
 			nfdCR, err := nfd.Pull(apiClient, nfdCRName, nfdCRNamespace)
-
 			if err != nil {
 				glog.V(gpuparams.GpuLogLevel).Infof("NodeFeatureDiscovery pull from cluster error: %s\n", err)
 
@@ -376,7 +361,6 @@ func DeleteNFDNamespace(apiClient *clients.Settings) error {
 	glog.V(gpuparams.GpuLogLevel).Infof("Deleting NFD namespace '%s'", hwaccelparams.NFDNamespace)
 
 	pulledNFDNsBuilder, err := namespace.Pull(apiClient, hwaccelparams.NFDNamespace)
-
 	if err != nil {
 		glog.V(gpuparams.GpuLogLevel).Infof("error pulling NFD namespace '%s' :  %v ",
 			hwaccelparams.NFDNamespace, err)
@@ -431,7 +415,6 @@ func DeleteNFDCSV(apiClient *clients.Settings) error {
 
 	nfdCurrentCSVFromSub, err := get.CurrentCSVFromSubscription(apiClient, nfdSubscriptionName,
 		nfdSubscriptionNamespace)
-
 	if err != nil {
 		return fmt.Errorf("error trying to get current NFD CSV from subscription '%w'", err)
 	}
@@ -441,7 +424,6 @@ func DeleteNFDCSV(apiClient *clients.Settings) error {
 	}
 
 	clusterNfdCSV, err := olm.PullClusterServiceVersion(apiClient, nfdCurrentCSVFromSub, hwaccelparams.NFDNamespace)
-
 	if err != nil {
 		return fmt.Errorf("error pulling CSV %v from cluster:  %w", nfdCurrentCSVFromSub, err)
 	}

--- a/tests/hw-accel/nvidiagpu/internal/get/get.go
+++ b/tests/hw-accel/nvidiagpu/internal/get/get.go
@@ -18,7 +18,6 @@ import (
 func InstalledCSVFromSubscription(apiClient *clients.Settings, gpuSubscriptionName,
 	gpuSubscriptionNamespace string) (string, error) {
 	subPulled, err := olm.PullSubscription(apiClient, gpuSubscriptionName, gpuSubscriptionNamespace)
-
 	if err != nil {
 		glog.V(gpuparams.GpuLogLevel).Infof(
 			"error pulling Subscription %s from cluster in namespace %s", gpuSubscriptionName,
@@ -38,7 +37,6 @@ func InstalledCSVFromSubscription(apiClient *clients.Settings, gpuSubscriptionNa
 func CurrentCSVFromSubscription(apiClient *clients.Settings, gpuSubscriptionName,
 	gpuSubscriptionNamespace string) (string, error) {
 	subPulled, err := olm.PullSubscription(apiClient, gpuSubscriptionName, gpuSubscriptionNamespace)
-
 	if err != nil {
 		glog.V(gpuparams.GpuLogLevel).Infof(
 			"error pulling Subscription %s from cluster in namespace %s", gpuSubscriptionName,

--- a/tests/hw-accel/nvidiagpu/internal/gpu-burn/gpu-burn.go
+++ b/tests/hw-accel/nvidiagpu/internal/gpu-burn/gpu-burn.go
@@ -39,7 +39,6 @@ func CreateGPUBurnConfigMap(apiClient *clients.Settings,
 	configMapBuilderWithData := configMapBuilder.WithData(gpuBurnConfigMapData)
 
 	createdConfigMapBuilderWithData, err := configMapBuilderWithData.Create()
-
 	if err != nil {
 		glog.V(gpuparams.GpuLogLevel).Infof(
 			"error creating ConfigMap with Data named %s and for namespace %s",

--- a/tests/hw-accel/nvidiagpu/internal/wait/wait.go
+++ b/tests/hw-accel/nvidiagpu/internal/wait/wait.go
@@ -19,7 +19,6 @@ func ClusterPolicyReady(apiClient *clients.Settings, clusterPolicyName string, p
 	return wait.PollUntilContextTimeout(
 		context.TODO(), pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
 			clusterPolicy, err := nvidiagpu.Pull(apiClient, clusterPolicyName)
-
 			if err != nil {
 				glog.V(gpuparams.GpuLogLevel).Infof("ClusterPolicy pull from cluster error: %s\n", err)
 
@@ -47,7 +46,6 @@ func CSVSucceeded(apiClient *clients.Settings, csvName, csvNamespace string, pol
 	return wait.PollUntilContextTimeout(
 		context.TODO(), pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
 			csvPulled, err := olm.PullClusterServiceVersion(apiClient, csvName, csvNamespace)
-
 			if err != nil {
 				glog.V(gpuparams.GpuLogLevel).Infof("ClusterServiceVersion pull from cluster error: %s\n", err)
 
@@ -77,8 +75,8 @@ func DeploymentCreated(apiClient *clients.Settings, deploymentName, deploymentNa
 	err := wait.PollUntilContextTimeout(
 		context.TODO(), pollInterval, timeout, false, func(ctx context.Context) (bool, error) {
 			var err error
-			deploymentPulled, err := deployment.Pull(apiClient, deploymentName, deploymentNamespace)
 
+			deploymentPulled, err := deployment.Pull(apiClient, deploymentName, deploymentNamespace)
 			if err != nil {
 				glog.V(gpuparams.GpuLogLevel).Infof("Deployment '%s' pull from cluster namespace '%s' error:"+
 					" %v", deploymentName, deploymentNamespace, err)

--- a/tests/internal/cluster/cluster.go
+++ b/tests/internal/cluster/cluster.go
@@ -29,7 +29,6 @@ func PullTestImageOnNodes(apiClient *clients.Settings, nodeSelector, image strin
 		apiClient,
 		metav1.ListOptions{LabelSelector: labels.Set(map[string]string{nodeSelector: ""}).String()},
 	)
-
 	if err != nil {
 		return err
 	}
@@ -38,9 +37,9 @@ func PullTestImageOnNodes(apiClient *clients.Settings, nodeSelector, image strin
 		glog.V(90).Infof("Pulling image %s to node %s", image, node.Object.Name)
 		podBuilder := pod.NewBuilder(
 			apiClient, fmt.Sprintf("pullpod-%s", node.Object.Name), "default", image)
+
 		err := podBuilder.PullImage(time.Duration(pullTimeout)*time.Second, []string{
 			"/bin/sh", "-c", "echo image Pulled && exit 0"})
-
 		if err != nil {
 			return err
 		}
@@ -81,8 +80,8 @@ func ExecCmd(apiClient *clients.Settings, nodeSelector string, shellCmd string) 
 			cmdToExec := []string{"sh", "-c", fmt.Sprintf("nsenter --mount=/proc/1/ns/mnt -- sh -c '%s'", shellCmd)}
 
 			glog.V(90).Infof("Exec cmd %v on pod %s", cmdToExec, mcPod.Definition.Name)
-			buf, err := mcPod.ExecCommand(cmdToExec)
 
+			buf, err := mcPod.ExecCommand(cmdToExec)
 			if err != nil {
 				return fmt.Errorf("%w\n%s", err, buf.String())
 			}
@@ -128,7 +127,6 @@ func ExecCmdWithStdout(
 		apiClient,
 		passedOptions,
 	)
-
 	if err != nil {
 		return nil, err
 	}
@@ -155,8 +153,8 @@ func ExecCmdWithStdout(
 			}
 
 			hostnameCmd := []string{"sh", "-c", "nsenter --mount=/proc/1/ns/mnt -- sh -c 'printf $(hostname)'"}
-			hostnameBuf, err := mcPod.ExecCommand(hostnameCmd)
 
+			hostnameBuf, err := mcPod.ExecCommand(hostnameCmd)
 			if err != nil {
 				return nil, fmt.Errorf("failed gathering node hostname: %w", err)
 			}
@@ -164,8 +162,8 @@ func ExecCmdWithStdout(
 			cmdToExec := []string{"sh", "-c", fmt.Sprintf("nsenter --mount=/proc/1/ns/mnt -- sh -c '%s'", shellCmd)}
 
 			glog.V(90).Infof("Exec cmd %v on pod %s", cmdToExec, mcPod.Definition.Name)
-			commandBuf, err := mcPod.ExecCommand(cmdToExec)
 
+			commandBuf, err := mcPod.ExecCommand(cmdToExec)
 			if err != nil {
 				return nil, fmt.Errorf("failed executing command '%s' on node %s: %w", shellCmd, hostnameBuf.String(), err)
 			}
@@ -271,8 +269,8 @@ func ExecCommandOnSNOWithRetries(client *clients.Settings, retries uint,
 // WaitForRecover waits up to timeout for all pods in namespaces on a provided node to recover.
 func WaitForRecover(client *clients.Settings, namespaces []string, timeout time.Duration) error {
 	glog.V(90).Infof("Wait for cluster to recover for namespaces: %v timeout: %v", namespaces, timeout)
-	err := waitForReachable(client, timeout)
 
+	err := waitForReachable(client, timeout)
 	if err != nil {
 		return err
 	}

--- a/tests/internal/cluster/config.go
+++ b/tests/internal/cluster/config.go
@@ -64,7 +64,6 @@ func GetOCPNetworkOperatorConfig(clusterObj APIClientGetter) (*network.OperatorB
 	glog.V(90).Infof("Gathering OCP network from cluster at %s", apiClient.KubeconfigPath)
 
 	clusterNetwork, err := network.PullOperator(apiClient)
-
 	if err != nil {
 		return nil, err
 	}

--- a/tests/internal/config/config.go
+++ b/tests/internal/config/config.go
@@ -50,8 +50,8 @@ func NewConfig() *GeneralConfig {
 	_, filename, _, _ := runtime.Caller(0)
 	baseDir := filepath.Dir(filename)
 	confFile := filepath.Join(baseDir, PathToDefaultParamsFile)
-	err := readFile(&conf, confFile)
 
+	err := readFile(&conf, confFile)
 	if err != nil {
 		log.Printf("Error to read config file %s", confFile)
 
@@ -59,7 +59,6 @@ func NewConfig() *GeneralConfig {
 	}
 
 	err = readEnv(&conf)
-
 	if err != nil {
 		log.Print("Error to read environment variables")
 
@@ -67,7 +66,6 @@ func NewConfig() *GeneralConfig {
 	}
 
 	err = deployReportDir(conf.ReportsDirAbsPath)
-
 	if err != nil {
 		log.Printf("Error to deploy report directory %s due to %s", conf.ReportsDirAbsPath, err.Error())
 
@@ -124,8 +122,8 @@ func readFile(cfg *GeneralConfig, cfgFile string) error {
 	}()
 
 	decoder := yaml.NewDecoder(openedCfgFile)
-	err = decoder.Decode(&cfg)
 
+	err = decoder.Decode(&cfg)
 	if err != nil {
 		return err
 	}
@@ -149,7 +147,6 @@ func readEnv(cfg *GeneralConfig) error {
 
 func deployReportDir(dirName string) error {
 	_, err := os.Stat(dirName)
-
 	if os.IsNotExist(err) {
 		return os.MkdirAll(dirName, 0777)
 	}

--- a/tests/internal/reporter/reporter.go
+++ b/tests/internal/reporter/reporter.go
@@ -39,7 +39,6 @@ func newReporter(
 	}
 
 	res, err := k8sreporter.New(kubeconfig, apiScheme, nsToDumpFilter, reportPath, cRDs...)
-
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +71,6 @@ func ReportIfFailedOnCluster(
 
 	if dumpDir != "" {
 		reporter, err := newReporter(dumpDir, kubeconfig, nSpaces, setReporterSchemes, cRDs)
-
 		if err != nil {
 			glog.Fatalf("Failed to create log reporter due to %s", err)
 		}
@@ -84,7 +82,6 @@ func ReportIfFailedOnCluster(
 
 		err = moveFile(
 			pathToPodExecLogs, path.Join(GeneralConfig.ReportsDirAbsPath, tcReportFolderName, podExecLogsFName))
-
 		if err != nil {
 			glog.Fatalf("Failed to move pod exec logs %s to report folder: %s", pathToPodExecLogs, err)
 		}
@@ -103,7 +100,6 @@ func moveFile(sourcePath, destPath string) error {
 	}
 
 	inputFile, err := os.Open(sourcePath)
-
 	if err != nil {
 		return fmt.Errorf("couldn't open source file: %w", err)
 	}
@@ -122,7 +118,6 @@ func moveFile(sourcePath, destPath string) error {
 	}()
 
 	_, err = io.Copy(outputFile, inputFile)
-
 	if err != nil {
 		return fmt.Errorf("writing to output file failed: %w", err)
 	}

--- a/tests/internal/url/url.go
+++ b/tests/internal/url/url.go
@@ -47,7 +47,6 @@ func Fetch(url, method string, skipCertVerify bool) (string, int, error) {
 	defer res.Body.Close()
 
 	body, err := io.ReadAll(res.Body)
-
 	if err != nil {
 		glog.Warning(fmt.Sprintf("Error reading reply: %v\n", err))
 

--- a/tests/lca/imagebasedinstall/internal/ibiconfig/config.go
+++ b/tests/lca/imagebasedinstall/internal/ibiconfig/config.go
@@ -16,6 +16,7 @@ func NewIBIConfig() *IBIConfig {
 	glog.V(ibiparams.IBILogLevel).Info("Creating new IBIConfig struct")
 
 	var ibiConfig IBIConfig
+
 	ibiConfig.LCAConfig = lcaconfig.NewLCAConfig()
 
 	return &ibiConfig

--- a/tests/lca/imagebasedinstall/mgmt/internal/mgmtconfig/config.go
+++ b/tests/lca/imagebasedinstall/mgmt/internal/mgmtconfig/config.go
@@ -90,6 +90,7 @@ func NewMGMTConfig() *MGMTConfig {
 	glog.V(mgmtparams.MGMTLogLevel).Info("Creating new MGMTConfig struct")
 
 	var mgmtConfig MGMTConfig
+
 	mgmtConfig.IBIConfig = ibiconfig.NewIBIConfig()
 
 	err := envconfig.Process("eco_lca_ibi_mgmt_", &mgmtConfig)

--- a/tests/lca/imagebasedupgrade/cnf/internal/cnfclusterinfo/cnfclusterinfo.go
+++ b/tests/lca/imagebasedupgrade/cnf/internal/cnfclusterinfo/cnfclusterinfo.go
@@ -63,7 +63,6 @@ type ClusterStruct struct {
 //nolint:funlen
 func (upgradeVar *ClusterStruct) SaveClusterInfo() error {
 	clusterVersion, err := cluster.GetOCPClusterVersion(cnfinittools.TargetSNOAPIClient)
-
 	if err != nil {
 		glog.V(cnfparams.CNFLogLevel).Infof("Could not retrieve cluster version")
 
@@ -71,7 +70,6 @@ func (upgradeVar *ClusterStruct) SaveClusterInfo() error {
 	}
 
 	targetSnoClusterName, err := cluster.GetOCPClusterName(cnfinittools.TargetSNOAPIClient)
-
 	if err != nil {
 		glog.V(cnfparams.CNFLogLevel).Infof("Could not retrieve target sno cluster name")
 
@@ -79,7 +77,6 @@ func (upgradeVar *ClusterStruct) SaveClusterInfo() error {
 	}
 
 	csvList, err := olm.ListClusterServiceVersionInAllNamespaces(cnfinittools.TargetSNOAPIClient)
-
 	if err != nil {
 		glog.V(cnfparams.CNFLogLevel).Infof("Could not retrieve csv list")
 
@@ -99,7 +96,6 @@ func (upgradeVar *ClusterStruct) SaveClusterInfo() error {
 	}
 
 	node, err := nodes.List(cnfinittools.TargetSNOAPIClient)
-
 	if err != nil {
 		glog.V(cnfparams.CNFLogLevel).Infof("Could not retrieve node list")
 
@@ -183,8 +179,8 @@ func (upgradeVar *ClusterStruct) getWorkloadInfo() error {
 	}
 
 	cmd := []string{"bash", "-c", "md5sum " + cnfinittools.CNFConfig.IbuWorkloadPVFilePath + " ||true"}
-	getDigest, err := workloadPod.ExecCommand(cmd)
 
+	getDigest, err := workloadPod.ExecCommand(cmd)
 	if err != nil {
 		return err
 	}

--- a/tests/lca/imagebasedupgrade/cnf/internal/cnfconfig/config.go
+++ b/tests/lca/imagebasedupgrade/cnf/internal/cnfconfig/config.go
@@ -41,6 +41,7 @@ func NewCNFConfig() *CNFConfig {
 	glog.V(cnfparams.CNFLogLevel).Info("Creating new CNFConfig struct")
 
 	var cnfConfig CNFConfig
+
 	cnfConfig.IBUConfig = ibuconfig.NewIBUConfig()
 
 	_, filename, _, _ := runtime.Caller(0)

--- a/tests/lca/imagebasedupgrade/internal/ibuconfig/config.go
+++ b/tests/lca/imagebasedupgrade/internal/ibuconfig/config.go
@@ -16,6 +16,7 @@ func NewIBUConfig() *IBUConfig {
 	glog.V(ibuparams.IBULogLevel).Info("Creating new IBUConfig struct")
 
 	var ibuConfig IBUConfig
+
 	ibuConfig.LCAConfig = lcaconfig.NewLCAConfig()
 
 	return &ibuConfig

--- a/tests/lca/imagebasedupgrade/internal/nodestate/nodestate.go
+++ b/tests/lca/imagebasedupgrade/internal/nodestate/nodestate.go
@@ -21,7 +21,6 @@ func WaitForNodeToBeUnreachable(host, port string, timeout time.Duration) (bool,
 			return !CheckIfNodeReachableOnPort(host, port), nil
 		},
 	)
-
 	if err != nil {
 		return false, err
 	}
@@ -38,7 +37,6 @@ func WaitForNodeToBeReachable(host, port string, timeout time.Duration) (bool, e
 			return CheckIfNodeReachableOnPort(host, port), nil
 		},
 	)
-
 	if err != nil {
 		return false, err
 	}
@@ -74,7 +72,6 @@ func WaitForIBUToBeAvailable(
 			var err error
 
 			ibu.Object, err = ibu.Get()
-
 			if err != nil {
 				return false, nil
 			}

--- a/tests/lca/imagebasedupgrade/internal/safeapirequest/safeapirequest.go
+++ b/tests/lca/imagebasedupgrade/internal/safeapirequest/safeapirequest.go
@@ -18,7 +18,6 @@ func Do(req Request) error {
 	var err error
 	for attempt := 0; attempt < retries; attempt++ {
 		err := req()
-
 		if err == nil {
 			return nil
 		}

--- a/tests/lca/imagebasedupgrade/mgmt/internal/mgmtconfig/config.go
+++ b/tests/lca/imagebasedupgrade/mgmt/internal/mgmtconfig/config.go
@@ -27,6 +27,7 @@ func NewMGMTConfig() *MGMTConfig {
 	glog.V(mgmtparams.MGMTLogLevel).Info("Creating new MGMTConfig struct")
 
 	var mgmtConfig MGMTConfig
+
 	mgmtConfig.IBUConfig = ibuconfig.NewIBUConfig()
 
 	err := envconfig.Process("eco_lca_ibu_mgmt_", &mgmtConfig)

--- a/tests/lca/internal/lcaconfig/config.go
+++ b/tests/lca/internal/lcaconfig/config.go
@@ -16,6 +16,7 @@ func NewLCAConfig() *LCAConfig {
 	log.Print("Creating new LCAConfig struct")
 
 	var lcaConfig LCAConfig
+
 	lcaConfig.GeneralConfig = config.NewConfig()
 
 	return &lcaConfig

--- a/tests/lca/internal/seedimage/seedimage.go
+++ b/tests/lca/internal/seedimage/seedimage.go
@@ -112,7 +112,6 @@ func GetContent(apiClient *clients.Settings, seedImageLocation string) (*SeedIma
 			apiClient, fmt.Sprintf("sudo tar xzf %s/etc.tgz -O etc/mco/proxy.env", mountedFilePath), metav1.ListOptions{
 				FieldSelector: fmt.Sprintf("metadata.name=%s", seedNode),
 			})
-
 		if err != nil {
 			return nil, err
 		}
@@ -141,7 +140,6 @@ func GetContent(apiClient *clients.Settings, seedImageLocation string) (*SeedIma
 		mirrorConfigOutput, err := cluster.ExecCmdWithStdout(
 			apiClient, fmt.Sprintf("sudo tar xzf %s/etc.tgz -O etc/containers/registries.conf",
 				mountedFilePath), metav1.ListOptions{FieldSelector: fmt.Sprintf("metadata.name=%s", seedNode)})
-
 		if err != nil {
 			return nil, err
 		}
@@ -225,7 +223,6 @@ func pullAndMountImage(apiClient *clients.Settings, node, pullCommand, image str
 		apiClient, fmt.Sprintf("%s %s", pullCommand, image), metav1.ListOptions{
 			FieldSelector: fmt.Sprintf("metadata.name=%s", node),
 		})
-
 	if err != nil {
 		return "", nil, err
 	}
@@ -234,7 +231,6 @@ func pullAndMountImage(apiClient *clients.Settings, node, pullCommand, image str
 		apiClient, fmt.Sprintf("sudo podman image mount %s", image), metav1.ListOptions{
 			FieldSelector: fmt.Sprintf("metadata.name=%s", node),
 		})
-
 	if err != nil {
 		return "", nil, err
 	}
@@ -246,7 +242,6 @@ func pullAndMountImage(apiClient *clients.Settings, node, pullCommand, image str
 			apiClient, fmt.Sprintf("sudo podman image unmount %s", image), metav1.ListOptions{
 				FieldSelector: fmt.Sprintf("metadata.name=%s", node),
 			})
-
 		if err != nil {
 			glog.V(100).Info("Error occurred while unmounting image")
 		}

--- a/tests/rhwa/internal/rhwaconfig/rhwaconfig.go
+++ b/tests/rhwa/internal/rhwaconfig/rhwaconfig.go
@@ -26,13 +26,14 @@ func NewRHWAConfig() *RHWAConfig {
 	log.Print("Creating new RHWAConfig struct")
 
 	var rhwaConf RHWAConfig
+
 	rhwaConf.GeneralConfig = config.NewConfig()
 
 	_, filename, _, _ := runtime.Caller(0)
 	baseDir := filepath.Dir(filename)
 	confFile := filepath.Join(baseDir, PathToDefaultRhwaParamsFile)
-	err := readFile(&rhwaConf, confFile)
 
+	err := readFile(&rhwaConf, confFile)
 	if err != nil {
 		log.Printf("Error to read config file %s", confFile)
 
@@ -40,7 +41,6 @@ func NewRHWAConfig() *RHWAConfig {
 	}
 
 	err = readEnv(&rhwaConf)
-
 	if err != nil {
 		log.Print("Error to read environment variables")
 
@@ -61,8 +61,8 @@ func readFile(rhwaConfig *RHWAConfig, cfgFile string) error {
 	}()
 
 	decoder := yaml.NewDecoder(openedCfgFile)
-	err = decoder.Decode(&rhwaConfig)
 
+	err = decoder.Decode(&rhwaConfig)
 	if err != nil {
 		return err
 	}

--- a/tests/system-tests/diskencryption/internal/config/config.go
+++ b/tests/system-tests/diskencryption/internal/config/config.go
@@ -42,8 +42,8 @@ func NewDiskEncryptionConfig() *DiskEncrptionConfig {
 	_, filename, _, _ := runtime.Caller(0)
 	baseDir := filepath.Dir(filename)
 	confFile := filepath.Join(baseDir, PathToDefaultDiskEncryptionParamsFile)
-	err := readFile(&diskEncryptionConf, confFile)
 
+	err := readFile(&diskEncryptionConf, confFile)
 	if err != nil {
 		log.Printf("Error reading config file %s", confFile)
 
@@ -51,7 +51,6 @@ func NewDiskEncryptionConfig() *DiskEncrptionConfig {
 	}
 
 	err = readEnv(&diskEncryptionConf)
-
 	if err != nil {
 		log.Print("Error reading environment variables")
 
@@ -86,8 +85,8 @@ func readFile(diskEncrptionConfig *DiskEncrptionConfig, cfgFile string) error {
 	}()
 
 	decoder := yaml.NewDecoder(openedCfgFile)
-	err = decoder.Decode(&diskEncrptionConfig)
 
+	err = decoder.Decode(&diskEncrptionConfig)
 	if err != nil {
 		return err
 	}

--- a/tests/system-tests/diskencryption/internal/helper/helper.go
+++ b/tests/system-tests/diskencryption/internal/helper/helper.go
@@ -36,7 +36,6 @@ func GetClevisLuksListOutput() (string, error) {
 // getRootDisk returns the name of the encrypted root disk in the form /dev/sdaX.
 func getRootDisk() (string, error) {
 	lsblkoutput, err := getAllDriveListOutput()
-
 	if err != nil {
 		return "", err
 	}
@@ -45,8 +44,8 @@ func getRootDisk() (string, error) {
 
 	for _, name := range driveList {
 		var mounts string
-		mounts, err = getLSBLKMounts(DiskPrefix + name)
 
+		mounts, err = getLSBLKMounts(DiskPrefix + name)
 		if err != nil {
 			return "", err
 		}
@@ -63,9 +62,9 @@ func getRootDisk() (string, error) {
 // false otherwise.
 func IsTTYConsole() (bool, error) {
 	cmdToExec := "sudo cat /proc/cmdline"
+
 	output, err := cluster.ExecCommandOnSNOWithRetries(APIClient, tsparams.RetryCount,
 		tsparams.RetryInterval, cmdToExec)
-
 	if err != nil {
 		return false, fmt.Errorf("error getting kernel command line, err: %w", err)
 	}

--- a/tests/system-tests/diskencryption/tests/tpm2.go
+++ b/tests/system-tests/diskencryption/tests/tpm2.go
@@ -489,6 +489,7 @@ func swapFirstSecondBootItems() {
 	By(fmt.Sprintf("listing current boot Order: %s", bootRefs))
 	// Creates a boot override swapping first and second boot references
 	var bootOverride []string
+
 	bootOverride, err = helper.SwapFirstAndSecondSliceItems(bootRefs)
 	Expect(err).ToNot(HaveOccurred(), "SwapFirstAndSecondSliceItems should not fail")
 	By(fmt.Sprintf("setting new boot Order: %s", bootOverride))

--- a/tests/system-tests/internal/apiobjectshelper/apiobjectshelper.go
+++ b/tests/system-tests/internal/apiobjectshelper/apiobjectshelper.go
@@ -37,7 +37,6 @@ func VerifyNamespaceExists(apiClient *clients.Settings, nsname string, timeout t
 
 			return true, nil
 		})
-
 	if err != nil {
 		return fmt.Errorf("failed to pull in %s namespace", nsname)
 	}
@@ -56,19 +55,16 @@ func VerifyOperatorDeployment(apiClient *clients.Settings,
 
 	if subscriptionName != "" {
 		csvName, err := csv.GetCurrentCSVNameFromSubscription(apiClient, subscriptionName, nsname)
-
 		if err != nil {
 			return fmt.Errorf("csv %s not found in namespace %s", csvName, nsname)
 		}
 
 		csvObj, err := olm.PullClusterServiceVersion(apiClient, csvName, nsname)
-
 		if err != nil {
 			return fmt.Errorf("failed to pull %q csv from the %s namespace", csvName, nsname)
 		}
 
 		isSuccessful, err := csvObj.IsSuccessful()
-
 		if err != nil {
 			return fmt.Errorf("failed to verify csv %s in the namespace %s status", csvName, nsname)
 		}
@@ -82,7 +78,6 @@ func VerifyOperatorDeployment(apiClient *clients.Settings,
 	glog.V(90).Infof("Confirm that operator %s is running in namespace %s", deploymentName, nsname)
 
 	err := await.WaitUntilDeploymentReady(apiClient, deploymentName, nsname, timeout)
-
 	if err != nil {
 		return fmt.Errorf("deployment %s not found in %s namespace; %w", deploymentName, nsname, err)
 	}
@@ -105,7 +100,6 @@ func CreateServiceAccount(apiClient *clients.Settings, saName, nsName string) er
 		true,
 		func(ctx context.Context) (bool, error) {
 			deploySa, err := deploySa.Create()
-
 			if err != nil {
 				glog.V(100).Infof("Error creating SA %q in %q namespace: %v", saName, nsName, err)
 
@@ -117,7 +111,6 @@ func CreateServiceAccount(apiClient *clients.Settings, saName, nsName string) er
 
 			return true, nil
 		})
-
 	if err != nil {
 		return fmt.Errorf("failed to create ServiceAccount %q in %q namespace", saName, nsName)
 	}
@@ -161,7 +154,6 @@ func CreateClusterRBAC(
 
 			return true, nil
 		})
-
 	if err != nil {
 		return fmt.Errorf("failed to create ClusterRoleBinding '%s' during timeout %v; %w",
 			rbacName, time.Minute, err)
@@ -186,7 +178,6 @@ func DeleteService(apiClient *clients.Settings, svcName, nsName string) error {
 			true,
 			func(ctx context.Context) (bool, error) {
 				err := svcObj.Delete()
-
 				if err != nil {
 					glog.V(100).Infof("Error deleting service %q in %q nsname: %v",
 						svcName, nsName, err)
@@ -198,7 +189,6 @@ func DeleteService(apiClient *clients.Settings, svcName, nsName string) error {
 
 				return true, nil
 			})
-
 		if err != nil {
 			return fmt.Errorf("failed to delete service %q from %q ns", svcName, nsName)
 		}
@@ -216,7 +206,6 @@ func DeleteClusterRBAC(apiClient *clients.Settings, rbacName string) error {
 	glog.V(100).Infof("Assert ClusterRoleBinding %q exists", rbacName)
 
 	crbSa, err := rbac.PullClusterRoleBinding(apiClient, rbacName)
-
 	if err != nil {
 		glog.V(100).Infof("ClusterRoleBinding %q not found; %v", rbacName, err)
 
@@ -232,7 +221,6 @@ func DeleteClusterRBAC(apiClient *clients.Settings, rbacName string) error {
 		true,
 		func(ctx context.Context) (bool, error) {
 			err = crbSa.Delete()
-
 			if err != nil {
 				glog.V(100).Infof("Error deleting ClusterRoleBinding %q : %v", rbacName, err)
 
@@ -243,7 +231,6 @@ func DeleteClusterRBAC(apiClient *clients.Settings, rbacName string) error {
 
 			return true, nil
 		})
-
 	if err != nil {
 		return fmt.Errorf("failed to delete Cluster RBAC %q", rbacName)
 	}
@@ -268,7 +255,6 @@ func DeleteServiceAccount(apiClient *clients.Settings, saName, nsName string) er
 			true,
 			func(ctx context.Context) (bool, error) {
 				err := deploySa.Delete()
-
 				if err != nil {
 					glog.V(100).Infof("Error deleting ServiceAccount %q in %q namespace: %v",
 						saName, nsName, err)
@@ -280,7 +266,6 @@ func DeleteServiceAccount(apiClient *clients.Settings, saName, nsName string) er
 
 				return true, nil
 			})
-
 		if err != nil {
 			return fmt.Errorf("failed to delete ServiceAccount %q from %q ns", saName, nsName)
 		}
@@ -301,7 +286,6 @@ func DeleteDeployment(
 		glog.V(100).Infof("Deleting deployment %q from %q namespace", deploymentName, nsName)
 
 		err = deploymentObj.DeleteAndWait(300 * time.Second)
-
 		if err != nil {
 			glog.V(100).Infof("Error deleting deployment %q from %q namespace: %v",
 				deploymentName, nsName, err)
@@ -333,7 +317,6 @@ func EnsureAllPodsRemoved(
 
 			return len(oldPods) == 0, nil
 		})
-
 	if err != nil {
 		return fmt.Errorf("pods matching label(%q) still present in namespace %q",
 			podLabel, nsName)

--- a/tests/system-tests/internal/await/await.go
+++ b/tests/system-tests/internal/await/await.go
@@ -27,7 +27,6 @@ import (
 // in the namespace reach the Ready condition.
 func WaitUntilAllDeploymentsReady(apiClient *clients.Settings, nsname string, timeout time.Duration) (bool, error) {
 	deployments, err := deployment.List(apiClient, nsname, metav1.ListOptions{})
-
 	if err != nil {
 		glog.V(100).Infof("deployment list error: %s", err)
 
@@ -54,7 +53,6 @@ func WaitUntilDeploymentReady(apiClient *clients.Settings, name, nsname string, 
 		true,
 		func(ctx context.Context) (bool, error) {
 			irDeployment, err := deployment.Pull(apiClient, name, nsname)
-
 			if err != nil {
 				return false, nil
 			}
@@ -67,10 +65,8 @@ func WaitUntilDeploymentReady(apiClient *clients.Settings, name, nsname string, 
 
 			return false, nil
 		})
-
 	if err != nil {
 		irDeployment, err := deployment.Pull(apiClient, name, nsname)
-
 		if err != nil {
 			glog.V(100).Infof("deployment %s in namespace %s not exists; %w", name, nsname, err)
 
@@ -92,7 +88,6 @@ func WaitUntilDeploymentReady(apiClient *clients.Settings, name, nsname string, 
 // in the namespace reach the Ready condition.
 func WaitUntilAllStatefulSetsReady(apiClient *clients.Settings, nsname string, timeout time.Duration) (bool, error) {
 	statefulsets, err := statefulset.List(apiClient, nsname, metav1.ListOptions{})
-
 	if err != nil {
 		glog.V(100).Infof("statefulsets list error: %s", err)
 
@@ -113,7 +108,6 @@ func WaitUntilAllStatefulSetsReady(apiClient *clients.Settings, nsname string, t
 // in the namespace reach the Ready condition.
 func WaitUntilAllPodsReady(apiClient *clients.Settings, nsname string, timeout time.Duration) (bool, error) {
 	pods, err := pod.List(apiClient, nsname, metav1.ListOptions{})
-
 	if err != nil {
 		glog.V(100).Infof("pods list error: %s", err)
 
@@ -155,8 +149,8 @@ func WaitUntilNodeIsUnreachable(hostname string, timeout time.Duration) error {
 		// Ping the node's IPv4 address
 		if !ip4Unreachable {
 			cmd := exec.Command("ping", "-c", "1", ipv4Addr.String())
-			_, err := cmd.CombinedOutput()
 
+			_, err := cmd.CombinedOutput()
 			if err != nil {
 				ip4Unreachable = true
 			}
@@ -165,8 +159,8 @@ func WaitUntilNodeIsUnreachable(hostname string, timeout time.Duration) error {
 		// Ping the node's IPv6 address
 		if !ip6Unreachable {
 			cmd := exec.Command("ping", "-c", "1", ipv6Addr.String())
-			_, err = cmd.CombinedOutput()
 
+			_, err = cmd.CombinedOutput()
 			if err != nil {
 				ip6Unreachable = true
 			}
@@ -211,7 +205,6 @@ func WaitUntilDaemonSetIsRunning(apiClient *clients.Settings, name, nsname strin
 
 			return true, nil
 		})
-
 	if err != nil {
 		return err
 	}
@@ -240,7 +233,6 @@ func WaitUntilDaemonSetDeleted(apiClient *clients.Settings, name, nsname string,
 
 			return true, nil
 		})
-
 	if err == nil {
 		return nil
 	}
@@ -263,7 +255,6 @@ func WaitUntilConfigMapCreated(apiClient *clients.Settings, name, nsname string,
 
 			return true, nil
 		})
-
 	if err != nil {
 		return fmt.Errorf("configMap %s in namespace %s is not created during timeout %v; %w",
 			name, nsname, timeout, err)
@@ -308,7 +299,6 @@ func WaitForThePodReplicasCountInNamespace(
 
 			return true, nil
 		})
-
 	if err != nil {
 		return false, err
 	}
@@ -341,7 +331,6 @@ func WaitUntilPersistentVolumeCreated(apiClient *clients.Settings,
 
 			return true, nil
 		})
-
 	if err != nil {
 		return fmt.Errorf("persistentVolumes with option %v were not found or count is not as expected %d; %w",
 			options, timeout, err)
@@ -376,7 +365,6 @@ func WaitUntilPersistentVolumeClaimCreated(apiClient *clients.Settings,
 
 			return true, nil
 		})
-
 	if err != nil {
 		return fmt.Errorf("persistentVolumeClaims with option %v were not found or count is not as expected %d; %w",
 			options, timeout, err)
@@ -410,7 +398,6 @@ func WaitUntilLVDIsDiscovering(apiClient *clients.Settings,
 
 			return true, nil
 		})
-
 	if err != nil {
 		return fmt.Errorf("localVolumeDiscovery %s in namespace %s phase not as expected after %v; %w",
 			lvdName, nsname, timeout, err)

--- a/tests/system-tests/internal/cgroup/cgroup.go
+++ b/tests/system-tests/internal/cgroup/cgroup.go
@@ -20,7 +20,6 @@ var nodesConfigResourceName = "cluster"
 // GetNodeLinuxCGroupVersion returns node Linux cgroup version value.
 func GetNodeLinuxCGroupVersion(apiClient *clients.Settings, nodeName string) (configv1.CgroupMode, error) {
 	node, err := nodes.Pull(apiClient, nodeName)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to get node %s resource due to %v",
 			nodeName, err.Error())
@@ -31,7 +30,6 @@ func GetNodeLinuxCGroupVersion(apiClient *clients.Settings, nodeName string) (co
 	cmdToExecute := []string{"/bin/sh", "-c", "stat -c %T -f /sys/fs/cgroup"}
 
 	output, err := remote.ExecuteOnNodeWithDebugPod(cmdToExecute, node.Object.Name)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to execute command %s on the node %s due to %v",
 			cmdToExecute, nodeName, err.Error())
@@ -67,7 +65,6 @@ func GetNodeLinuxCGroupVersion(apiClient *clients.Settings, nodeName string) (co
 //nolint:funlen
 func SetLinuxCGroupVersion(apiClient *clients.Settings, expectedCGroupMode configv1.CgroupMode) error {
 	nodesConfigObj, err := nodesconfig.Pull(apiClient, nodesConfigResourceName)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to get nodes.config %s resource due to %v",
 			nodesConfigResourceName, err.Error())
@@ -79,7 +76,6 @@ func SetLinuxCGroupVersion(apiClient *clients.Settings, expectedCGroupMode confi
 		expectedCGroupMode, nodesConfigObj.Definition.Name)
 
 	currentCGroupMode, err := nodesConfigObj.GetCGroupMode()
-
 	if err != nil {
 		glog.V(100).Infof("Failed to get current cgroup configuration from the nodes.config %s due to %v",
 			nodesConfigObj.Definition.Name, err.Error())
@@ -89,7 +85,6 @@ func SetLinuxCGroupVersion(apiClient *clients.Settings, expectedCGroupMode confi
 
 	if currentCGroupMode == configv1.CgroupModeEmpty {
 		nodesList, err := nodes.List(apiClient)
-
 		if err != nil {
 			return err
 		}
@@ -98,7 +93,6 @@ func SetLinuxCGroupVersion(apiClient *clients.Settings, expectedCGroupMode confi
 			nodesList[0].Definition.Name)
 
 		currentCGroupMode, err = GetNodeLinuxCGroupVersion(apiClient, nodesList[0].Definition.Name)
-
 		if err != nil {
 			return err
 		}
@@ -109,7 +103,6 @@ func SetLinuxCGroupVersion(apiClient *clients.Settings, expectedCGroupMode confi
 			currentCGroupMode, expectedCGroupMode)
 
 		nodesConfigObj, err := nodesConfigObj.WithCGroupMode(expectedCGroupMode).Update()
-
 		if err != nil {
 			glog.V(100).Infof("Failed to make change to the nodesConfig cgroup due to %v",
 				err)
@@ -118,7 +111,6 @@ func SetLinuxCGroupVersion(apiClient *clients.Settings, expectedCGroupMode confi
 		}
 
 		newCGroupMode, err := nodesConfigObj.GetCGroupMode()
-
 		if err != nil {
 			glog.V(100).Infof("Failed to get current cgroup configuration from the nodes.config %s due to %v",
 				nodesConfigObj.Definition.Name, err.Error())
@@ -132,7 +124,6 @@ func SetLinuxCGroupVersion(apiClient *clients.Settings, expectedCGroupMode confi
 		}
 
 		_, err = nodes.WaitForAllNodesToReboot(apiClient, 30*time.Minute)
-
 		if err != nil {
 			glog.V(100).Infof("Nodes failed to reboot after setting new cgroup mode %v config; %v",
 				expectedCGroupMode, err)
@@ -142,13 +133,11 @@ func SetLinuxCGroupVersion(apiClient *clients.Settings, expectedCGroupMode confi
 		}
 
 		_, err = clusteroperator.WaitForAllClusteroperatorsAvailable(apiClient, 5*time.Minute)
-
 		if err != nil {
 			return fmt.Errorf("not all clusteroperators are available; %w", err)
 		}
 
 		allNodesList, err := nodes.List(apiClient)
-
 		if err != nil {
 			glog.V(100).Infof("Failed to get cluster nodes list due to: %v", err)
 
@@ -157,7 +146,6 @@ func SetLinuxCGroupVersion(apiClient *clients.Settings, expectedCGroupMode confi
 
 		for _, node := range allNodesList {
 			currentNodeCGroup, err := GetNodeLinuxCGroupVersion(apiClient, node.Definition.Name)
-
 			if err != nil {
 				glog.V(100).Infof("Failed to get cGroup version from the node %s due to: %v",
 					node.Definition.Name, err)

--- a/tests/system-tests/internal/csv/csv.go
+++ b/tests/system-tests/internal/csv/csv.go
@@ -13,7 +13,6 @@ func GetCurrentCSVNameFromSubscription(apiClient *clients.Settings,
 		subscriptionName, subscriptionNamespace)
 
 	subscriptionObj, err := olm.PullSubscription(apiClient, subscriptionName, subscriptionNamespace)
-
 	if err != nil {
 		glog.V(100).Infof("error pulling subscription %s from cluster in namespace %s",
 			subscriptionName, subscriptionNamespace)

--- a/tests/system-tests/internal/file/file.go
+++ b/tests/system-tests/internal/file/file.go
@@ -17,8 +17,8 @@ func TouchFile(path string) error {
 // DeleteFile deletes the file passed in parameter.
 func DeleteFile(path string) error {
 	cmdToExec := fmt.Sprintf("sudo rm -f %s", path)
-	err := cluster.ExecCmd(APIClient, SystemTestsTestConfig.ControlPlaneLabel, cmdToExec)
 
+	err := cluster.ExecCmd(APIClient, SystemTestsTestConfig.ControlPlaneLabel, cmdToExec)
 	if err != nil {
 		return fmt.Errorf("error deleting file %s, err=%w", path, err)
 	}

--- a/tests/system-tests/internal/files/files.go
+++ b/tests/system-tests/internal/files/files.go
@@ -25,7 +25,6 @@ func DownloadFile(fileURL, fileName, targetFolder string) error {
 		glog.V(100).Info("Build fileName from the fullPath")
 
 		fileURL, err := url.Parse(fileURL)
-
 		if err != nil {
 			return fmt.Errorf("failed to parse URL %s due to: %w", fileURL, err)
 		}
@@ -44,8 +43,8 @@ func DownloadFile(fileURL, fileName, targetFolder string) error {
 
 	// Create the file
 	filePath := filepath.Join(targetFolder, fileName)
-	out, err := os.Create(filePath)
 
+	out, err := os.Create(filePath)
 	if err != nil {
 		return fmt.Errorf("failed to create file %s at folder %s due to: %w", fileName, targetFolder, err)
 	}

--- a/tests/system-tests/internal/imageregistryconfig/imageregistryconfig.go
+++ b/tests/system-tests/internal/imageregistryconfig/imageregistryconfig.go
@@ -23,7 +23,6 @@ var imageRegistryDeploymentName = "image-registry"
 // SetManagementState returns true when succeeded to change imageRegistry operator management state.
 func SetManagementState(apiClient *clients.Settings, expectedManagementState operatorv1.ManagementState) error {
 	irConfigObj, err := imageregistry.Pull(apiClient, imageRegistryObjName)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to get imageRegistry operator due to %v",
 			err.Error())
@@ -35,7 +34,6 @@ func SetManagementState(apiClient *clients.Settings, expectedManagementState ope
 		irConfigObj.Definition.Name, expectedManagementState)
 
 	currentManagementState, err := irConfigObj.GetManagementState()
-
 	if err != nil {
 		glog.V(100).Infof("Failed to get current imageRegistry operator management state value due to %v",
 			err.Error())
@@ -48,7 +46,6 @@ func SetManagementState(apiClient *clients.Settings, expectedManagementState ope
 			irConfigObj.Definition.Name, currentManagementState, expectedManagementState)
 
 		irConfig, err := irConfigObj.WithManagementState(expectedManagementState).Update()
-
 		if err != nil {
 			glog.V(100).Infof("Failed to make change to the imageRegistry operator managementState due to %v", err)
 
@@ -56,7 +53,6 @@ func SetManagementState(apiClient *clients.Settings, expectedManagementState ope
 		}
 
 		newManagementState, err := irConfig.GetManagementState()
-
 		if err != nil {
 			glog.V(100).Infof("Failed to get current imageRegistry operator managementState value due to %v", err)
 
@@ -77,7 +73,6 @@ func SetManagementState(apiClient *clients.Settings, expectedManagementState ope
 // SetStorageToTheEmptyDir sets the imageRegistry storage to an empty directory.
 func SetStorageToTheEmptyDir(apiClient *clients.Settings) error {
 	irClusterOperator, err := clusteroperator.Pull(apiClient, imageRegistryCoName)
-
 	if err != nil {
 		return err
 	}
@@ -88,7 +83,6 @@ func SetStorageToTheEmptyDir(apiClient *clients.Settings) error {
 			imageRegistryDeploymentName,
 			imageRegistryNamespace,
 			time.Second*2)
-
 		if err == nil {
 			return nil
 		}
@@ -97,7 +91,6 @@ func SetStorageToTheEmptyDir(apiClient *clients.Settings) error {
 	glog.V(100).Infof("Setting up imageRegistry storage to the EmptyDir")
 
 	imageRegistryObj, err := imageregistry.Pull(apiClient, imageRegistryObjName)
-
 	if err != nil {
 		return err
 	}
@@ -108,7 +101,6 @@ func SetStorageToTheEmptyDir(apiClient *clients.Settings) error {
 	}
 
 	irConfig, err := imageRegistryObj.WithStorage(emptyDirStorage).Update()
-
 	if err != nil {
 		glog.V(100).Infof("Failed to change an imageRegistryObj config and setup storage to the EmptyDir")
 
@@ -116,7 +108,6 @@ func SetStorageToTheEmptyDir(apiClient *clients.Settings) error {
 	}
 
 	newStorageConfig, err := irConfig.GetStorageConfig()
-
 	if err != nil {
 		glog.V(100).Infof("Failed to get current imageRegistry Storage configuration due to %v", err)
 
@@ -129,7 +120,6 @@ func SetStorageToTheEmptyDir(apiClient *clients.Settings) error {
 	}
 
 	err = WaitForAPIServersUpdate(apiClient)
-
 	if err != nil {
 		return err
 	}
@@ -141,7 +131,6 @@ func SetStorageToTheEmptyDir(apiClient *clients.Settings) error {
 		imageRegistryDeploymentName,
 		imageRegistryNamespace,
 		time.Minute*5)
-
 	if err != nil {
 		glog.V(100).Infof("image-registry deployment failure due to %s", err.Error())
 
@@ -149,7 +138,6 @@ func SetStorageToTheEmptyDir(apiClient *clients.Settings) error {
 	}
 
 	err = WaitForImageregistryCoIsAvailable(apiClient)
-
 	if err != nil {
 		return err
 	}
@@ -163,13 +151,11 @@ func WaitForAPIServersUpdate(apiClient *clients.Settings) error {
 		"pods have to be updated to the latest generation")
 
 	oasBuilder, err := apiservers.PullOpenshiftAPIServer(apiClient)
-
 	if err != nil {
 		return err
 	}
 
 	err = oasBuilder.WaitAllPodsAtTheLatestGeneration(time.Minute * 10)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to update openshiftapiserver due to: %v", err)
 
@@ -180,13 +166,11 @@ func WaitForAPIServersUpdate(apiClient *clients.Settings) error {
 		"nodes have to be updated to the latest revision")
 
 	kasBuilder, err := apiservers.PullKubeAPIServer(apiClient)
-
 	if err != nil {
 		return err
 	}
 
 	err = kasBuilder.WaitAllNodesAtTheLatestRevision(time.Minute * 15)
-
 	if err != nil {
 		return err
 	}
@@ -199,7 +183,6 @@ func WaitForImageregistryCoIsAvailable(apiClient *clients.Settings) error {
 	glog.V(100).Infof("Asserting clusteroperators availability")
 
 	imageRegistryCo, err := clusteroperator.Pull(apiClient, imageRegistryCoName)
-
 	if err != nil {
 		return err
 	}
@@ -209,7 +192,6 @@ func WaitForImageregistryCoIsAvailable(apiClient *clients.Settings) error {
 	}
 
 	err = imageRegistryCo.WaitUntilAvailable(time.Minute * 2)
-
 	if err != nil {
 		return err
 	}

--- a/tests/system-tests/internal/mirroring/mirror-images.go
+++ b/tests/system-tests/internal/mirroring/mirror-images.go
@@ -39,8 +39,8 @@ func MirrorImageToTheLocalRegistry(
 	}
 
 	originalImageURL := fmt.Sprintf("%s/%s", originServerURL, imageName)
-	isDisconnected, err := platform.IsDisconnectedDeployment(apiClient)
 
+	isDisconnected, err := platform.IsDisconnectedDeployment(apiClient)
 	if err != nil {
 		return "", "", err
 	}
@@ -52,7 +52,6 @@ func MirrorImageToTheLocalRegistry(
 	}
 
 	localRegistryURL, err := platform.GetLocalMirrorRegistryURL(apiClient)
-
 	if err != nil {
 		return "", "", err
 	}
@@ -63,8 +62,8 @@ func MirrorImageToTheLocalRegistry(
 
 	imageMirrorCmd := fmt.Sprintf("oc --kubeconfig %s image mirror --insecure=true %s:%s %s:%s",
 		kubeconfigPath, originalImageURL, imageTag, localImageURL, imageTag)
-	_, err = remote.ExecCmdOnHost(host, user, pass, imageMirrorCmd)
 
+	_, err = remote.ExecCmdOnHost(host, user, pass, imageMirrorCmd)
 	if err != nil {
 		glog.Infof("failed to execute %s command due to %s", imageMirrorCmd, err)
 

--- a/tests/system-tests/internal/platform/platform.go
+++ b/tests/system-tests/internal/platform/platform.go
@@ -138,8 +138,8 @@ func getMirrorRegistryMap(apiClient *clients.Settings) (map[string]interface{}, 
 	}
 
 	dataMap := make(map[string]interface{})
-	err = json.Unmarshal(data, &dataMap)
 
+	err = json.Unmarshal(data, &dataMap)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/system-tests/internal/reboot/reboot.go
+++ b/tests/system-tests/internal/reboot/reboot.go
@@ -97,8 +97,8 @@ func prepareRebootResources(nodeName, nsName string) ([]*pod.Builder, error) {
 		FieldSelector: fields.SelectorFromSet(fields.Set{"spec.nodeName": nodeName}).String(),
 		LabelSelector: labels.SelectorFromSet(labels.Set{"test": "hardreboot"}).String(),
 	}
-	ipmiPods, err := pod.List(APIClient, nsName, listOptions)
 
+	ipmiPods, err := pod.List(APIClient, nsName, listOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -206,7 +206,6 @@ func waitForNodeReady(nodeName string) error {
 
 			return false, nil
 		})
-
 	if err != nil {
 		return fmt.Errorf("node %s did not become Ready within timeout: %w", nodeName, err)
 	}
@@ -250,8 +249,8 @@ func KernelCrashKdump(nodeName string) error {
 	cmdToExec := []string{"chroot", "/rootfs", "/bin/sh", "-c", "rm -rf /var/crash/*"}
 
 	glog.V(90).Infof("Remove any existing crash dumps. Exec cmd %v", cmdToExec)
-	_, err := remote.ExecuteOnNodeWithDebugPod(cmdToExec, nodeName)
 
+	_, err := remote.ExecuteOnNodeWithDebugPod(cmdToExec, nodeName)
 	if err != nil {
 		return err
 	}
@@ -259,8 +258,8 @@ func KernelCrashKdump(nodeName string) error {
 	cmdToExec = []string{"/bin/sh", "-c", "echo c > /proc/sysrq-trigger"}
 
 	glog.V(90).Infof("Trigerring kernel crash. Exec cmd %v", cmdToExec)
-	_, err = remote.ExecuteOnNodeWithDebugPod(cmdToExec, nodeName)
 
+	_, err = remote.ExecuteOnNodeWithDebugPod(cmdToExec, nodeName)
 	if err != nil {
 		return err
 	}
@@ -273,7 +272,6 @@ func SoftRebootNode(nodeName string) error {
 	cmdToExec := []string{"chroot", "/rootfs", "systemctl", "reboot"}
 
 	_, err := remote.ExecuteOnNodeWithDebugPod(cmdToExec, nodeName)
-
 	if err != nil {
 		return err
 	}

--- a/tests/system-tests/internal/remote/cmd.go
+++ b/tests/system-tests/internal/remote/cmd.go
@@ -30,8 +30,8 @@ func ExecuteOnNodeWithDebugPod(cmdToExec []string, nodeName string) (string, err
 	}
 
 	glog.V(90).Infof("Exec cmd %v on pod %s", cmdToExec, mcPodList[0].Definition.Name)
-	buf, err := mcPodList[0].ExecCommand(cmdToExec)
 
+	buf, err := mcPodList[0].ExecCommand(cmdToExec)
 	if err != nil {
 		return "", fmt.Errorf("%w\n%s", err, buf.String())
 	}
@@ -61,7 +61,6 @@ func ExecuteOnNodeWithPrivilegedDebugPod(apiClient *clients.Settings,
 		func(context.Context) (bool, error) {
 			oldPods, err := pod.List(apiClient, SystemTestsTestConfig.MCONamespace,
 				metav1.ListOptions{LabelSelector: podSelector})
-
 			if err != nil {
 				glog.V(90).Infof("Error listing pods: %v", err)
 
@@ -73,7 +72,6 @@ func ExecuteOnNodeWithPrivilegedDebugPod(apiClient *clients.Settings,
 					_pod.Definition.Name, _pod.Definition.Namespace)
 
 				_, delErr := _pod.DeleteAndWait(15 * time.Second)
-
 				if delErr != nil {
 					glog.V(90).Infof("Failed to delete pod %q in %q namespace: %v",
 						_pod.Definition.Name, _pod.Definition.Namespace, delErr)
@@ -84,7 +82,6 @@ func ExecuteOnNodeWithPrivilegedDebugPod(apiClient *clients.Settings,
 
 			return true, nil
 		})
-
 	if err != nil {
 		glog.V(90).Infof("Failed to assert if previous %q pod exists", debugPodName)
 
@@ -96,13 +93,11 @@ func ExecuteOnNodeWithPrivilegedDebugPod(apiClient *clients.Settings,
 		WithLabel(debugPodLabel, nodeName).
 		WithNodeSelector(map[string]string{"kubernetes.io/hostname": nodeName}).
 		CreateAndWaitUntilRunning(1 * time.Minute)
-
 	if err != nil {
 		return "", err
 	}
 
 	buf, err := debugPod.ExecCommand(cmd)
-
 	if err != nil {
 		return "", err
 	}
@@ -137,7 +132,6 @@ func ExecCmdOnHost(remoteHostname, remoteHostUsername, remoteHostPass, cmd strin
 	glog.V(100).Infof("Dial SSH to the host %s", remoteHostname)
 
 	scpClient, err := ssh.NewClient(remoteHostname, sshConf, &ssh.ClientOption{})
-
 	if err != nil {
 		glog.V(100).Infof("Failed to build new ssh client due to: %v", err)
 
@@ -148,7 +142,6 @@ func ExecCmdOnHost(remoteHostname, remoteHostUsername, remoteHostPass, cmd strin
 	defer ss.Close()
 
 	out, err := ss.CombinedOutput(cmd)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to run cmd %s on the host %s due to: %v",
 			cmd, remoteHostname, err)

--- a/tests/system-tests/internal/remote/scp.go
+++ b/tests/system-tests/internal/remote/scp.go
@@ -54,7 +54,6 @@ func ScpFileFrom(source, destination, remoteHostname, remoteHostUsername, remote
 	glog.V(100).Infof("Dial SSH to %s", remoteHostname)
 
 	scpClient, err := ssh.NewClient(remoteHostname, sshConf, &ssh.ClientOption{})
-
 	if err != nil {
 		return err
 	}
@@ -62,7 +61,6 @@ func ScpFileFrom(source, destination, remoteHostname, remoteHostUsername, remote
 	glog.V(100).Infof("Transfer file %s to %s", source, destination)
 
 	err = scpClient.CopyFileFromRemote(source, destination, &ssh.FileTransferOption{})
-
 	if err != nil {
 		return err
 	}
@@ -122,7 +120,6 @@ func ScpFileTo(source, destination, remoteHostname, remoteHostUsername, remoteHo
 	glog.V(100).Infof("Dial SSH to %s", remoteHostname)
 
 	scpClient, err := ssh.NewClient(remoteHostname, sshConf, &ssh.ClientOption{})
-
 	if err != nil {
 		return err
 	}
@@ -164,7 +161,6 @@ func ScpDirectoryFrom(source, destination, remoteHostname, remoteHostUsername, r
 	glog.V(100).Infof("Create local directory %s if not exists", destination)
 
 	err := os.Mkdir(destination, 0755)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to create directory %s, it is already exists", destination)
 	}
@@ -176,7 +172,6 @@ func ScpDirectoryFrom(source, destination, remoteHostname, remoteHostUsername, r
 	glog.V(100).Infof("Dial SSH to %s", remoteHostname)
 
 	scpClient, err := ssh.NewClient(remoteHostname, sshConf, &ssh.ClientOption{})
-
 	if err != nil {
 		return err
 	}
@@ -184,7 +179,6 @@ func ScpDirectoryFrom(source, destination, remoteHostname, remoteHostUsername, r
 	glog.V(100).Infof("recursively copy from remote directory %s to the %s", source, destination)
 
 	err = scpClient.CopyDirFromRemote(source, destination, &ssh.DirTransferOption{})
-
 	if err != nil {
 		return err
 	}
@@ -233,7 +227,6 @@ func ScpDirectoryTo(source, destination, remoteHostname, remoteHostUsername, rem
 	glog.V(100).Infof("Dial SSH to %s", remoteHostname)
 
 	scpClient, err := ssh.NewClient(remoteHostname, sshConf, &ssh.ClientOption{})
-
 	if err != nil {
 		return err
 	}
@@ -241,7 +234,6 @@ func ScpDirectoryTo(source, destination, remoteHostname, remoteHostUsername, rem
 	glog.V(100).Infof("recursively copy from directory %s to the %s", source, destination)
 
 	err = scpClient.CopyDirToRemote(source, destination, &ssh.DirTransferOption{})
-
 	if err != nil {
 		return err
 	}

--- a/tests/system-tests/internal/scc/scc.go
+++ b/tests/system-tests/internal/scc/scc.go
@@ -11,8 +11,8 @@ import (
 func AddPrivilegedSCCtoDefaultSA(nsName string) error {
 	privSCCRequired := true
 	sccUser := fmt.Sprintf("system:serviceaccount:%s:default", nsName)
-	privSCC, err := scc.Pull(APIClient, "privileged")
 
+	privSCC, err := scc.Pull(APIClient, "privileged")
 	if err != nil {
 		return err
 	}

--- a/tests/system-tests/internal/shell/shell.go
+++ b/tests/system-tests/internal/shell/shell.go
@@ -7,8 +7,8 @@ import (
 // ExecuteCmd function executes a shell command.
 func ExecuteCmd(command string) ([]byte, error) {
 	cmd := exec.Command("bash", "-c", command)
-	output, err := cmd.Output()
 
+	output, err := cmd.Output()
 	if err != nil {
 		return nil, err
 	}

--- a/tests/system-tests/internal/sriov/list.go
+++ b/tests/system-tests/internal/sriov/list.go
@@ -24,8 +24,8 @@ func ListNetworksByDeviceType(
 
 	operatornsname := "openshift-sriov-network-operator"
 	options := client.ListOptions{}
-	sriovPolicies, err := sriov.ListPolicy(apiClient, operatornsname, options)
 
+	sriovPolicies, err := sriov.ListPolicy(apiClient, operatornsname, options)
 	if err != nil {
 		glog.V(100).Infof("Failed to list sriov policies in namespace: %s", operatornsname)
 
@@ -33,7 +33,6 @@ func ListNetworksByDeviceType(
 	}
 
 	sriovNetworks, err := sriov.List(apiClient, operatornsname, options)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to list sriov networks in namespace: %s", operatornsname)
 

--- a/tests/system-tests/internal/supporttools/tcpdump.go
+++ b/tests/system-tests/internal/supporttools/tcpdump.go
@@ -70,7 +70,6 @@ func CreateTCPDumpDeployment(
 		captureScript,
 		scheduleOnHosts,
 	)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to create tcpdump deployment %s in namespace %s due to %v",
 			stDeploymentName, tdNamespace, err)
@@ -79,7 +78,6 @@ func CreateTCPDumpDeployment(
 	}
 
 	err = await.WaitUntilDeploymentReady(apiClient, stDeploymentName, tdNamespace, time.Minute)
-
 	if err != nil {
 		glog.V(100).Infof("deployment %s in namespace %s failed to reach ready state due to %v",
 			stDeploymentName, tdNamespace, err)
@@ -111,7 +109,6 @@ func createTCPDumpDeployment(
 		stDeploymentName, stNamespace)
 
 	err = apiobjectshelper.DeleteDeployment(apiClient, stDeploymentName, stNamespace)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to delete deployment %s from namespace %s; %v",
 			stDeploymentName, stNamespace, err)
@@ -126,7 +123,6 @@ func createTCPDumpDeployment(
 	glog.V(100).Infof("Removing ServiceAccount %s from namespace %s", supportToolsDeploySAName, stNamespace)
 
 	err = apiobjectshelper.DeleteServiceAccount(apiClient, supportToolsDeploySAName, stNamespace)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to remove serviceAccount %q from namespace %q; %v",
 			supportToolsDeploySAName, stNamespace, err)
@@ -138,7 +134,6 @@ func createTCPDumpDeployment(
 	glog.V(100).Infof("Creating ServiceAccount %s in namespace %s", supportToolsDeploySAName, stNamespace)
 
 	err = apiobjectshelper.CreateServiceAccount(apiClient, supportToolsDeploySAName, stNamespace)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to create serviceAccount %q in namespace %q; %v",
 			supportToolsDeploySAName, stNamespace, err)
@@ -150,7 +145,6 @@ func createTCPDumpDeployment(
 	glog.V(100).Infof("Removing Cluster RBAC %q", supportToolsDeployRBACName)
 
 	err = apiobjectshelper.DeleteClusterRBAC(apiClient, supportToolsDeployRBACName)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to delete supporttools RBAC %q; %v", supportToolsDeployRBACName, err)
 
@@ -161,7 +155,6 @@ func createTCPDumpDeployment(
 
 	err = apiobjectshelper.CreateClusterRBAC(apiClient, supportToolsDeployRBACName, supportToolsRBACRole,
 		supportToolsDeploySAName, stNamespace)
-
 	if err != nil {
 		glog.V(100).Infof("failed to create supporttools RBAC %q in namespace %s; %v",
 			supportToolsDeployRBACName, stNamespace, err)
@@ -292,6 +285,7 @@ func SendTrafficCheckTCPDumpLogs(
 	targetHost,
 	targetPort string) error {
 	timeout := 3 * time.Minute
+
 	err := wait.PollUntilContextTimeout(
 		context.TODO(),
 		3*time.Second,
@@ -307,14 +301,12 @@ func SendTrafficCheckTCPDumpLogs(
 				tcpdumpPodSelectorLabel,
 				targetHost,
 				targetPort)
-
 			if err == nil && result {
 				return true, nil
 			}
 
 			return false, nil
 		})
-
 	if err != nil {
 		glog.V(100).Infof("Expected request was not found in the packet sniffer logs; %v", err)
 
@@ -365,7 +357,6 @@ func sendProbeAndCheckTCPDumpLogs(
 			tcpdumpPodSelectorLabel,
 			searchString,
 			timeStart)
-
 		if err != nil {
 			errMsg = err
 		} else if numberFound >= 1 {
@@ -436,7 +427,6 @@ func ScanTCPDumpPodLogs(
 			}
 
 			tcpdumpLog, err = tcpdumpPodObj.GetLog(logStartTimestamp, tcpdumpPodObj.Definition.Spec.Containers[0].Name)
-
 			if err != nil {
 				glog.V(100).Infof("Failed to get tcpdumpLog from pod %q, log %s: %v",
 					tcpdumpPodObj.Definition.Name, tcpdumpLog, err)
@@ -455,8 +445,8 @@ func ScanTCPDumpPodLogs(
 			glog.V(100).Infof("len(tcpdumpLog) = %d", len(tcpdumpLog))
 
 			buf := new(bytes.Buffer)
-			_, err = buf.WriteString(tcpdumpLog)
 
+			_, err = buf.WriteString(tcpdumpLog)
 			if err != nil {
 				glog.V(100).Infof("error in copying info from pod tcpdumpLog to buffer: %v", err)
 
@@ -494,7 +484,6 @@ func ScanTCPDumpPodLogs(
 
 			return false, nil
 		})
-
 	if err != nil {
 		glog.V(100).Infof("Error processing logs: %v", err)
 
@@ -522,6 +511,7 @@ func sendProbeToHostPort(
 	var errorMsg error
 
 	timeout := time.Minute * 3
+
 	err := wait.PollUntilContextTimeout(
 		context.TODO(),
 		time.Second*15,
@@ -529,7 +519,6 @@ func sendProbeToHostPort(
 		true,
 		func(ctx context.Context) (bool, error) {
 			output, err := proberPod.ExecCommand(cmdToRun, proberPod.Object.Spec.Containers[0].Name)
-
 			if err != nil {
 				glog.V(100).Infof("query failed. Request: %s, Output: %q, Error: %v", request, output, err)
 
@@ -546,7 +535,6 @@ func sendProbeToHostPort(
 
 			return true, nil
 		})
-
 	if err != nil {
 		return "", fmt.Errorf("failed to execute the command '%s' during timeout %v; %w", cmdToRun, timeout, err)
 	}

--- a/tests/system-tests/internal/supporttools/traceroute.go
+++ b/tests/system-tests/internal/supporttools/traceroute.go
@@ -57,7 +57,6 @@ func CreateTraceRouteDeployment(
 		stDeploymentLabel,
 		scheduleOnNodes,
 	)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to create traceroute deployment %s in namespace %s due to %v",
 			tracerouteDeploymentName, stNamespace, err)
@@ -93,7 +92,6 @@ func ensureNamespaceExists(apiClient *clients.Settings, nsName string) error {
 
 	if createNs.Exists() {
 		err := createNs.Delete()
-
 		if err != nil {
 			glog.V(100).Infof("Failed to delete namespace %q: %v", nsName, err)
 
@@ -116,7 +114,6 @@ func ensureNamespaceExists(apiClient *clients.Settings, nsName string) error {
 
 				return true, nil
 			})
-
 		if err != nil {
 			glog.V(100).Infof("Failed to delete namespace %s due to %v", nsName, err)
 
@@ -125,7 +122,6 @@ func ensureNamespaceExists(apiClient *clients.Settings, nsName string) error {
 	}
 
 	_, err := createNs.Create()
-
 	if err != nil {
 		glog.V(100).Infof("Error creating namespace %q: %v", nsName, err)
 
@@ -148,7 +144,6 @@ func ensureNamespaceExists(apiClient *clients.Settings, nsName string) error {
 
 			return true, nil
 		})
-
 	if err != nil {
 		glog.V(100).Infof("support-tools namespace %q not found created: %v", nsName, err)
 
@@ -176,7 +171,6 @@ func createTraceRouteDeployment(
 		stDeploymentName, stNamespace)
 
 	err = apiobjectshelper.DeleteDeployment(apiClient, stDeploymentName, stNamespace)
-
 	if err != nil {
 		glog.V(100).Infof("failed to delete deployment %s from namespace %s due to %v",
 			stDeploymentName, stNamespace, err)
@@ -191,7 +185,6 @@ func createTraceRouteDeployment(
 	glog.V(100).Infof("Removing ServiceAccount %s from namespace %s", stDeploymentName, stNamespace)
 
 	err = apiobjectshelper.DeleteServiceAccount(apiClient, supportToolsDeploySAName, stNamespace)
-
 	if err != nil {
 		glog.V(100).Infof("failed to remove serviceAccount %q from namespace %q due to %v",
 			supportToolsDeploySAName, stNamespace, err)
@@ -203,7 +196,6 @@ func createTraceRouteDeployment(
 	glog.V(100).Infof("Creating ServiceAccount %s in namespace %s", stDeploymentName, stNamespace)
 
 	err = apiobjectshelper.CreateServiceAccount(apiClient, supportToolsDeploySAName, stNamespace)
-
 	if err != nil {
 		glog.V(100).Infof("failed to create serviceAccount %q in namespace %q due to %v",
 			supportToolsDeploySAName, stNamespace, err)
@@ -215,7 +207,6 @@ func createTraceRouteDeployment(
 	glog.V(100).Infof("Removing Cluster RBAC %s", supportToolsDeployRBACName)
 
 	err = apiobjectshelper.DeleteClusterRBAC(apiClient, supportToolsDeployRBACName)
-
 	if err != nil {
 		glog.V(100).Infof("failed to delete supporttools RBAC %q due to %v",
 			supportToolsDeployRBACName, err)
@@ -228,7 +219,6 @@ func createTraceRouteDeployment(
 
 	err = apiobjectshelper.CreateClusterRBAC(apiClient, supportToolsDeployRBACName, supportToolsRBACRole,
 		supportToolsDeploySAName, stNamespace)
-
 	if err != nil {
 		glog.V(100).Infof("failed to create supporttools RBAC %q in namespace %s due to %v",
 			supportToolsDeployRBACName, stNamespace, err)
@@ -300,6 +290,7 @@ func sendProbesAndCheckOutput(
 	var err error
 
 	timeout := time.Minute
+
 	err = wait.PollUntilContextTimeout(
 		context.TODO(),
 		time.Second*15,
@@ -307,7 +298,6 @@ func sendProbesAndCheckOutput(
 		true,
 		func(ctx context.Context) (bool, error) {
 			output, err = trPod.ExecCommand(cmdToRun, trPod.Object.Spec.Containers[0].Name)
-
 			if err != nil {
 				glog.V(100).Infof("query failed. Request: %s, Output: %q, Error: %v",
 					targetIP, output, err)
@@ -335,7 +325,6 @@ func sendProbesAndCheckOutput(
 
 			return true, nil
 		})
-
 	if err != nil {
 		glog.V(100).Infof("expected string %s not found in traceroute output: %q; %v",
 			searchString, output.String(), err)
@@ -355,6 +344,7 @@ func SendTrafficFindExpectedString(
 	targetPort,
 	searchString string) error {
 	timeout := 3 * time.Minute
+
 	err := wait.PollUntilContextTimeout(
 		context.TODO(),
 		3*time.Second,
@@ -366,14 +356,12 @@ func SendTrafficFindExpectedString(
 				targetIP,
 				targetPort,
 				searchString)
-
 			if err == nil && result {
 				return true, nil
 			}
 
 			return false, nil
 		})
-
 	if err != nil {
 		glog.V(100).Infof("expected string was not found in the traceroute output; %v", err)
 

--- a/tests/system-tests/internal/systemtestsconfig/systemtestsconfig.go
+++ b/tests/system-tests/internal/systemtestsconfig/systemtestsconfig.go
@@ -32,13 +32,14 @@ func NewSystemTestsConfig() *SystemTestsConfig {
 	log.Print("Creating new SystemTestsConfig struct")
 
 	var systemConf SystemTestsConfig
+
 	systemConf.GeneralConfig = config.NewConfig()
 
 	_, filename, _, _ := runtime.Caller(0)
 	baseDir := filepath.Dir(filename)
 	confFile := filepath.Join(baseDir, PathToDefaultSystemTestsParamsFile)
-	err := readFile(&systemConf, confFile)
 
+	err := readFile(&systemConf, confFile)
 	if err != nil {
 		log.Printf("Error to read config file %s", confFile)
 
@@ -46,7 +47,6 @@ func NewSystemTestsConfig() *SystemTestsConfig {
 	}
 
 	err = readEnv(&systemConf)
-
 	if err != nil {
 		log.Print("Error to read environment variables")
 
@@ -67,8 +67,8 @@ func readFile(systemtestsConfig *SystemTestsConfig, cfgFile string) error {
 	}()
 
 	decoder := yaml.NewDecoder(openedCfgFile)
-	err = decoder.Decode(&systemtestsConfig)
 
+	err = decoder.Decode(&systemtestsConfig)
 	if err != nil {
 		return err
 	}

--- a/tests/system-tests/internal/template/template.go
+++ b/tests/system-tests/internal/template/template.go
@@ -29,7 +29,6 @@ func SaveTemplate(
 	}
 
 	tmpl, err := template.ParseFiles(source)
-
 	if err != nil {
 		glog.V(100).Infof("Error to read config file %s", source)
 
@@ -47,7 +46,6 @@ func SaveTemplate(
 	glog.V(100).Infof("apply the template %s to the vars map and write the result to file", destination)
 
 	err = tmpl.Execute(file, variablesToReplace)
-
 	if err != nil {
 		glog.V(100).Infof("Error to apply the template to the vars map and write the result to file %s",
 			destination)
@@ -56,7 +54,6 @@ func SaveTemplate(
 	}
 
 	err = os.Chmod(destination, 0755)
-
 	if err != nil {
 		glog.V(100).Infof("Error to chmod file %s", destination)
 

--- a/tests/system-tests/ipsec/internal/iperf3workload/iperf3workload.go
+++ b/tests/system-tests/ipsec/internal/iperf3workload/iperf3workload.go
@@ -34,7 +34,6 @@ func CreateService(apiClient *clients.Settings,
 		nodePort,
 		nodePort,
 		corev1.Protocol("TCP"))
-
 	if err != nil {
 		glog.V(ipsecparams.IpsecLogLevel).Infof("Error defining ServicePort: %v", err)
 
@@ -54,7 +53,6 @@ func CreateService(apiClient *clients.Settings,
 	svcDemo.Definition.Spec.Ports[0].NodePort = nodePort
 
 	svcDemo, err = svcDemo.Create()
-
 	if err != nil {
 		glog.V(ipsecparams.IpsecLogLevel).Infof("Error creating service: %v", err)
 
@@ -74,7 +72,6 @@ func DeleteService(apiClient *clients.Settings, serviceName string) error {
 		serviceName, ipsecparams.TestNamespaceName)
 
 	svcDemo, err := service.Pull(apiClient, serviceName, ipsecparams.TestNamespaceName)
-
 	if err != nil && svcDemo == nil {
 		glog.V(ipsecparams.IpsecLogLevel).Infof("Service %q not found in %q namespace",
 			serviceName, ipsecparams.TestNamespaceName)
@@ -170,7 +167,6 @@ func DeleteWorkload(apiClient *clients.Settings, deploymentName string, workload
 	for continueLooping {
 		oldPods, err = pod.List(apiClient, ipsecparams.TestNamespaceName,
 			metav1.ListOptions{LabelSelector: workloadLabels})
-
 		if err == nil {
 			pollSuccess = true
 			continueLooping = false
@@ -251,7 +247,6 @@ func LaunchIperf3Command(apiClient *clients.Settings,
 		appPods, err = pod.List(apiClient,
 			ipsecparams.TestNamespaceName,
 			metav1.ListOptions{LabelSelector: containerLabels})
-
 		if err == nil {
 			pollSuccess = true
 			continueLooping = false
@@ -281,7 +276,6 @@ func LaunchIperf3Command(apiClient *clients.Settings,
 			cmdIperf3, _pod.Definition.Name, _pod.Definition.ObjectMeta.Labels)
 
 		output, err = _pod.ExecCommand(cmdIperf3, deploymentName)
-
 		if err != nil {
 			glog.V(ipsecparams.IpsecLogLevel).Infof(
 				"Error running iperf3 lookup from within pod, output: [%s], err [%s]",

--- a/tests/system-tests/ipsec/internal/ipsecconfig/config.go
+++ b/tests/system-tests/ipsec/internal/ipsecconfig/config.go
@@ -44,13 +44,14 @@ func NewIpsecConfig() *IpsecConfig {
 	log.Print("Creating new IpsecConfig struct")
 
 	var ipsecConf IpsecConfig
+
 	ipsecConf.SystemTestsConfig = systemtestsconfig.NewSystemTestsConfig()
 
 	_, filename, _, _ := runtime.Caller(0)
 	baseDir := filepath.Dir(filename)
 	confFile := filepath.Join(baseDir, PathToDefaultIpsecParamsFile)
-	err := readFile(&ipsecConf, confFile)
 
+	err := readFile(&ipsecConf, confFile)
 	if err != nil {
 		log.Printf("Error reading config file %s", confFile)
 
@@ -58,7 +59,6 @@ func NewIpsecConfig() *IpsecConfig {
 	}
 
 	err = readEnv(&ipsecConf)
-
 	if err != nil {
 		log.Print("Error reading environment variables")
 
@@ -79,8 +79,8 @@ func readFile(ipsecConfig *IpsecConfig, cfgFile string) error {
 	}()
 
 	decoder := yaml.NewDecoder(openedCfgFile)
-	err = decoder.Decode(&ipsecConfig)
 
+	err = decoder.Decode(&ipsecConfig)
 	if err != nil {
 		return err
 	}

--- a/tests/system-tests/ipsec/internal/ipsectunnel/ipsectunnel.go
+++ b/tests/system-tests/ipsec/internal/ipsectunnel/ipsectunnel.go
@@ -91,8 +91,8 @@ func TunnelPackets(nodeName string) *IpsecTunnelPackets {
 	}
 
 	tunnelPackets := &IpsecTunnelPackets{}
-	tunnelPackets.InBytes, err = strconv.Atoi(ipsecOutput[startIndex+len(inBytesStr) : startIndex+endIndex])
 
+	tunnelPackets.InBytes, err = strconv.Atoi(ipsecOutput[startIndex+len(inBytesStr) : startIndex+endIndex])
 	if err != nil {
 		glog.V(ipsecparams.IpsecLogLevel).Infof("Error Cannot parse IPSec traffic status inBytes value: %v", ipsecOutput)
 

--- a/tests/system-tests/o-cloud/internal/ocloudcommon/sno-provisioning-ibi.go
+++ b/tests/system-tests/o-cloud/internal/ocloudcommon/sno-provisioning-ibi.go
@@ -206,7 +206,6 @@ func generateBaseImage(ctx SpecContext) {
 	By("Detaching the seed SNO from the hub")
 
 	cluster, err := ocm.PullManagedCluster(HubAPIClient, OCloudConfig.ClusterName1)
-
 	if err == nil {
 		err = cluster.DeleteAndWait(time.Minute * 10)
 		Expect(err).NotTo(HaveOccurred(),
@@ -268,6 +267,7 @@ func generateBaseImage(ctx SpecContext) {
 	}
 
 	var rendered bytes.Buffer
+
 	err = tmpl.Execute(&rendered, imageBasedConfigData)
 	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Error executing template file: %v", err))
 

--- a/tests/system-tests/o-cloud/internal/ocloudconfig/config.go
+++ b/tests/system-tests/o-cloud/internal/ocloudconfig/config.go
@@ -130,13 +130,14 @@ func NewOCloudConfig() *OCloudConfig {
 	log.Print("Creating new OCloudConfig struct")
 
 	var ocloudConf OCloudConfig
+
 	ocloudConf.SystemTestsConfig = systemtestsconfig.NewSystemTestsConfig()
 
 	_, filename, _, _ := runtime.Caller(0)
 	baseDir := filepath.Dir(filename)
 	confFile := filepath.Join(baseDir, PathToDefaultOCloudParamsFile)
-	err := readFile(&ocloudConf, confFile)
 
+	err := readFile(&ocloudConf, confFile)
 	if err != nil {
 		log.Printf("Error to read config file %s", confFile)
 
@@ -144,7 +145,6 @@ func NewOCloudConfig() *OCloudConfig {
 	}
 
 	err = readEnv(&ocloudConf)
-
 	if err != nil {
 		log.Print("Error to read environment variables")
 
@@ -175,8 +175,8 @@ func readFile(ocloudConfig *OCloudConfig, cfgFile string) error {
 	}()
 
 	decoder := yaml.NewDecoder(openedCfgFile)
-	err = decoder.Decode(&ocloudConfig)
 
+	err = decoder.Decode(&ocloudConfig)
 	if err != nil {
 		return err
 	}

--- a/tests/system-tests/ran-du/internal/randuconfig/config.go
+++ b/tests/system-tests/ran-du/internal/randuconfig/config.go
@@ -43,13 +43,14 @@ func NewRanDuConfig() *RanDuConfig {
 	log.Print("Creating new RanDuConfig struct")
 
 	var randuConf RanDuConfig
+
 	randuConf.SystemTestsConfig = systemtestsconfig.NewSystemTestsConfig()
 
 	_, filename, _, _ := runtime.Caller(0)
 	baseDir := filepath.Dir(filename)
 	confFile := filepath.Join(baseDir, PathToDefaultRanDuParamsFile)
-	err := readFile(&randuConf, confFile)
 
+	err := readFile(&randuConf, confFile)
 	if err != nil {
 		log.Printf("Error to read config file %s", confFile)
 
@@ -57,7 +58,6 @@ func NewRanDuConfig() *RanDuConfig {
 	}
 
 	err = readEnv(&randuConf)
-
 	if err != nil {
 		log.Print("Error to read environment variables")
 
@@ -78,8 +78,8 @@ func readFile(randuConfig *RanDuConfig, cfgFile string) error {
 	}()
 
 	decoder := yaml.NewDecoder(openedCfgFile)
-	err = decoder.Decode(&randuConfig)
 
+	err = decoder.Decode(&randuConfig)
 	if err != nil {
 		return err
 	}

--- a/tests/system-tests/ran-du/internal/randutestworkload/randutestworkload.go
+++ b/tests/system-tests/ran-du/internal/randutestworkload/randutestworkload.go
@@ -16,7 +16,6 @@ import (
 func CleanNameSpace(cleanTimeout time.Duration, nsname string) error {
 	err := namespace.NewBuilder(APIClient, nsname).
 		CleanObjects(cleanTimeout, deployment.GetGVR(), statefulset.GetGVR())
-
 	if err != nil {
 		glog.V(100).Infof("Failed to clean up objects in namespace: %s", nsname)
 

--- a/tests/system-tests/rdscore/internal/rdscorecommon/egress-ip.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/egress-ip.go
@@ -83,7 +83,6 @@ func createAgnhostRBAC(
 	glog.V(100).Infof("Removing ServiceAccount")
 
 	err = apiobjectshelper.DeleteServiceAccount(apiClient, deploySAName, egressIPNamespace)
-
 	if err != nil {
 		return "", fmt.Errorf("failed to remove serviceAccount %q from egressIPNamespace %q",
 			deploySAName, egressIPNamespace)
@@ -92,7 +91,6 @@ func createAgnhostRBAC(
 	glog.V(100).Infof("Creating ServiceAccount")
 
 	err = apiobjectshelper.CreateServiceAccount(apiClient, deploySAName, egressIPNamespace)
-
 	if err != nil {
 		return "", fmt.Errorf("failed to create serviceAccount %q in egressIPNamespace %q",
 			deploySAName, egressIPNamespace)
@@ -101,7 +99,6 @@ func createAgnhostRBAC(
 	glog.V(100).Infof("Removing Cluster RBAC")
 
 	err = apiobjectshelper.DeleteClusterRBAC(apiClient, deployRBACName)
-
 	if err != nil {
 		return "", fmt.Errorf("failed to delete deployment RBAC %q", deployRBACName)
 	}
@@ -110,7 +107,6 @@ func createAgnhostRBAC(
 
 	err = apiobjectshelper.CreateClusterRBAC(apiClient, deployRBACName, deployRBACRole,
 		deploySAName, egressIPNamespace)
-
 	if err != nil {
 		return "", fmt.Errorf("failed to create deployment RBAC %q in egressIPNamespace %s",
 			deployRBACName, egressIPNamespace)
@@ -127,7 +123,6 @@ func cleanUpDeployments(apiClient *clients.Settings) error {
 
 	for _, nsName := range namespacesList {
 		deploymentsList, err := deployment.List(APIClient, nsName)
-
 		if err != nil {
 			glog.V(100).Infof("Error listing deployments in the namespace %s, %v", nsName, err)
 
@@ -142,7 +137,6 @@ func cleanUpDeployments(apiClient *clients.Settings) error {
 				apiClient,
 				deploy.Definition.Name,
 				nsName)
-
 			if err != nil {
 				return fmt.Errorf("failed to delete deploy %s from nsname %s",
 					deploy.Definition.Name, nsName)
@@ -151,7 +145,6 @@ func cleanUpDeployments(apiClient *clients.Settings) error {
 
 		for _, label := range podLabelsList {
 			err = apiobjectshelper.EnsureAllPodsRemoved(APIClient, nsName, label)
-
 			if err != nil {
 				return fmt.Errorf("failed to delete pods in namespace %s: %w", nsName, err)
 			}
@@ -350,7 +343,6 @@ func sendTrafficCheckIP(clientPods []*pod.Builder, isIPv6 bool, expectedIPs []st
 			true,
 			func(ctx context.Context) (bool, error) {
 				result, err := clientPod.ExecCommand(cmdToRun, clientPod.Object.Spec.Containers[0].Name)
-
 				if err != nil {
 					glog.V(100).Infof("Error running command from within a pod %q: %v",
 						clientPod.Object.Name, err)
@@ -363,7 +355,6 @@ func sendTrafficCheckIP(clientPods []*pod.Builder, isIPv6 bool, expectedIPs []st
 				glog.V(100).Infof("Command's output:\n\t%v", result.String())
 
 				parsedIP, _, err = net.SplitHostPort(result.String())
-
 				if err != nil {
 					glog.V(100).Infof("Failed to parse %q for host/port pair", result.String())
 
@@ -373,7 +364,6 @@ func sendTrafficCheckIP(clientPods []*pod.Builder, isIPv6 bool, expectedIPs []st
 				glog.V(100).Infof("Verify IP version type correctness")
 
 				myIP, err := netip.ParseAddr(parsedIP)
-
 				if err != nil {
 					glog.V(100).Infof("Failed to parse used ip address %q", parsedIP)
 
@@ -398,7 +388,6 @@ func sendTrafficCheckIP(clientPods []*pod.Builder, isIPv6 bool, expectedIPs []st
 
 				return false, nil
 			})
-
 		if err != nil {
 			return fmt.Errorf("failed to run command from within pod %s: %w", clientPod.Object.Name, err)
 		}
@@ -411,7 +400,6 @@ func getEgressIPMap() (map[string]string, error) {
 	By("Getting a map of source nodes and assigned Egress IPs for these nodes")
 
 	egressIPObj, err := egressip.Pull(APIClient, RDSCoreConfig.EgressIPName)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to pull egressIP %q object: %v", RDSCoreConfig.EgressIPName, err)
 
@@ -419,7 +407,6 @@ func getEgressIPMap() (map[string]string, error) {
 	}
 
 	egressIPMap, err := egressIPObj.GetAssignedEgressIPMap()
-
 	if err != nil {
 		glog.V(100).Infof("Failed to retrieve egressIP %s assigned egressIPs map: %v",
 			RDSCoreConfig.EgressIPName, err)
@@ -442,7 +429,6 @@ func getEgressIPList() ([]string, error) {
 	var eIPList []string
 
 	egressIPMap, err := getEgressIPMap()
-
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve EgressIP map due to %w", err)
 	}
@@ -518,7 +504,6 @@ func gracefulNodeReboot(nodeName string) error {
 	By("Execute graceful node reboot")
 
 	nodeObj, err := nodes.Pull(APIClient, nodeName)
-
 	if err != nil {
 		return fmt.Errorf("failed to retrieve node %s object due to: %w", nodeName, err)
 	}
@@ -526,7 +511,6 @@ func gracefulNodeReboot(nodeName string) error {
 	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Cordoning node %q", nodeName)
 
 	err = nodeObj.Cordon()
-
 	if err != nil {
 		glog.V(100).Infof("Failed to cordon node %q due to %v", nodeName, err)
 
@@ -538,7 +522,6 @@ func gracefulNodeReboot(nodeName string) error {
 	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Draining node %q", nodeName)
 
 	err = nodeObj.Drain()
-
 	if err != nil {
 		glog.V(100).Infof("Failed to drain node %q due to %v", nodeName, err)
 
@@ -581,7 +564,6 @@ func gracefulNodeReboot(nodeName string) error {
 
 			return true, nil
 		})
-
 	if err != nil {
 		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to reboot node %s", nodeName)
 
@@ -616,7 +598,6 @@ func gracefulNodeReboot(nodeName string) error {
 
 			return false, nil
 		})
-
 	if err != nil {
 		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("The node %s hasn't reached notReady state", nodeName)
 
@@ -651,7 +632,6 @@ func gracefulNodeReboot(nodeName string) error {
 
 			return false, nil
 		})
-
 	if err != nil {
 		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("The node %s hasn't reached Ready state", nodeName)
 
@@ -661,7 +641,6 @@ func gracefulNodeReboot(nodeName string) error {
 	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Uncordoning node %q", nodeName)
 
 	err = nodeObj.Uncordon()
-
 	if err != nil {
 		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to uncordon %q due to %v", nodeName, err)
 
@@ -677,7 +656,6 @@ func getNodeForReboot(isIPv6 bool) (string, string, error) {
 	By("Find cluster node name to reboot")
 
 	egressIPMap, err := getEgressIPMap()
-
 	if err != nil {
 		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to retrieve egressIP map due to %w", err)
 
@@ -688,7 +666,6 @@ func getNodeForReboot(isIPv6 bool) (string, string, error) {
 		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("IP %q is assigned to %q", egressIPValue, egressIPNode)
 
 		myIP, err := netip.ParseAddr(egressIPValue)
-
 		if err != nil {
 			glog.V(100).Infof("Failed to parse used ip address %q", egressIPValue)
 

--- a/tests/system-tests/rdscore/internal/rdscorecommon/metallb-graceful-restart.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/metallb-graceful-restart.go
@@ -55,7 +55,6 @@ func mTCPConnect(addr *net.TCPAddr, timeOut int) (*net.TCPConn, error) {
 			time.Now().UnixMilli())
 
 		tConn, err := net.DialTCP(network, laddr, addr)
-
 		if err != nil {
 			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to connect to %q due to: %v",
 				raddr.String(), err)
@@ -116,7 +115,6 @@ func verifySingleTCPConnection(loadBalancerIP string, servicePort int32,
 			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Resolving TCP endpoint %q", endPoint)
 
 			addr, err = net.ResolveTCPAddr("tcp", endPoint)
-
 			if err != nil {
 				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed resolve TCP address %q : %v", endPoint, err)
 
@@ -127,7 +125,6 @@ func verifySingleTCPConnection(loadBalancerIP string, servicePort int32,
 
 			return true, nil
 		})
-
 	if err != nil {
 		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed resolve TCP address %q : %v", endPoint, err)
 
@@ -151,7 +148,6 @@ func verifySingleTCPConnection(loadBalancerIP string, servicePort int32,
 	err = wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute, true,
 		func(context.Context) (bool, error) {
 			lbConnection, err = mTCPConnect(addr, int(1000))
-
 			if err != nil {
 				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed dailing to %q : %v", endPoint, err)
 
@@ -162,7 +158,6 @@ func verifySingleTCPConnection(loadBalancerIP string, servicePort int32,
 
 			return true, nil
 		})
-
 	if err != nil {
 		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed dailing to %q : %v", endPoint, err)
 
@@ -211,7 +206,6 @@ func verifySingleTCPConnection(loadBalancerIP string, servicePort int32,
 			glog.V(110).Infof("Writing to the TCP connection at %v", time.Now().UnixMilli())
 
 			nSent, err := lbConnection.Write(getHTTPMsg)
-
 			if err != nil || nSent == 0 {
 				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to write to connection: %v", err)
 
@@ -229,7 +223,6 @@ func verifySingleTCPConnection(loadBalancerIP string, servicePort int32,
 			}
 
 			err = lbConnection.SetReadDeadline(time.Now().Add(300 * time.Millisecond))
-
 			if err != nil {
 				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed set ReadDeadline: %v", err)
 
@@ -247,7 +240,6 @@ func verifySingleTCPConnection(loadBalancerIP string, servicePort int32,
 			msgReply := make([]byte, 1024)
 
 			bRead, err := lbConnection.Read(msgReply)
-
 			if err != nil {
 				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to read reply(%v): %v",
 					time.Now().UnixMilli(), err)
@@ -316,7 +308,6 @@ func verifyMultipleTCPConnections(loadBalancerIP string, servicePort int32,
 			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Resolving TCP endpoint %q", endPoint)
 
 			addr, err = net.ResolveTCPAddr("tcp", endPoint)
-
 			if err != nil {
 				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed resolve TCP address %q : %v", endPoint, err)
 
@@ -327,7 +318,6 @@ func verifyMultipleTCPConnections(loadBalancerIP string, servicePort int32,
 
 			return true, nil
 		})
-
 	if err != nil {
 		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed resolve TCP address %q : %v", endPoint, err)
 
@@ -360,7 +350,6 @@ func verifyMultipleTCPConnections(loadBalancerIP string, servicePort int32,
 			glog.V(110).Infof("Dialing to the TCP endpoint %q", endPoint)
 
 			lbConnection, err := mTCPConnect(addr, int(300))
-
 			if err != nil {
 				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed dailing to %q : %v", endPoint, err)
 
@@ -383,7 +372,6 @@ func verifyMultipleTCPConnections(loadBalancerIP string, servicePort int32,
 			glog.V(110).Infof("Writing to the TCP connection at %v", time.Now().UnixMilli())
 
 			nSent, err := lbConnection.Write(getHTTPMsg)
-
 			if err != nil || nSent == 0 {
 				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to write to connection: %v", err)
 
@@ -401,7 +389,6 @@ func verifyMultipleTCPConnections(loadBalancerIP string, servicePort int32,
 			}
 
 			err = lbConnection.SetReadDeadline(time.Now().Add(300 * time.Millisecond))
-
 			if err != nil {
 				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed set ReadDeadline: %v", err)
 
@@ -419,7 +406,6 @@ func verifyMultipleTCPConnections(loadBalancerIP string, servicePort int32,
 			msgReply := make([]byte, 1024)
 
 			bRead, err := lbConnection.Read(msgReply)
-
 			if err != nil {
 				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to read reply(%v): %v",
 					time.Now().UnixMilli(), err)
@@ -479,7 +465,6 @@ func restartMetallbFRRPod(node string, metallbFRRRestartFailed *bool, start, fin
 			func(context.Context) (bool, error) {
 				mPodList, err = pod.List(APIClient, RDSCoreConfig.MetalLBFRRNamespace,
 					metav1.ListOptions{LabelSelector: rdscoreparams.MetalLBFRRPodSelector})
-
 				if err != nil {
 					glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to list pods due to: %v", err)
 
@@ -527,7 +512,6 @@ func restartMetallbFRRPod(node string, metallbFRRRestartFailed *bool, start, fin
 		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Deleting pod %q", prevPod.Definition.Name)
 
 		prevPod, err = prevPod.DeleteAndWait(15 * time.Second)
-
 		if err != nil {
 			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to delete pod %q: %v",
 				prevPod.Definition.Name, err)
@@ -547,7 +531,6 @@ func restartMetallbFRRPod(node string, metallbFRRRestartFailed *bool, start, fin
 			func(context.Context) (bool, error) {
 				mPodList, err = pod.List(APIClient, RDSCoreConfig.MetalLBFRRNamespace,
 					metav1.ListOptions{LabelSelector: "app=frr-k8s"})
-
 				if err != nil {
 					glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to list pods due to %v", err)
 
@@ -591,7 +574,6 @@ func restartMetallbFRRPod(node string, metallbFRRRestartFailed *bool, start, fin
 
 				return true, nil
 			})
-
 		if err != nil || newPod == nil {
 			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("No new frr-k8s pod found on %q node", node)
 
@@ -606,7 +588,6 @@ func restartMetallbFRRPod(node string, metallbFRRRestartFailed *bool, start, fin
 			newPod.Definition.Name)
 
 		err = newPod.WaitUntilReady(3 * time.Minute)
-
 		if err != nil {
 			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Pod %q hasn't reached Ready state",
 				newPod.Definition.Name)

--- a/tests/system-tests/rdscore/internal/rdscorecommon/metallb-traffic-segregation.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/metallb-traffic-segregation.go
@@ -622,7 +622,6 @@ func verifyIPRouteBGP(host, user, pass, containerName, lbIP string) error {
 	glog.V(100).Infof("IP: %s", parsedIP)
 
 	myIP, err := netip.ParseAddr(parsedIP)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to parse provided loadbalancer ip address %q; %v", parsedIP, err)
 
@@ -647,7 +646,6 @@ func verifyIPRouteBGP(host, user, pass, containerName, lbIP string) error {
 		true,
 		func(ctx context.Context) (bool, error) {
 			result, err = remote.ExecCmdOnHost(host, user, pass, showIPRouteBGPOnFRRContainerCmd)
-
 			if err != nil {
 				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to run command due to: %v", err)
 
@@ -659,7 +657,6 @@ func verifyIPRouteBGP(host, user, pass, containerName, lbIP string) error {
 
 			return true, nil
 		})
-
 	if err != nil {
 		glog.V(100).Infof("Failed to verify BGP routes in the FRR container %s: %v", containerName, err)
 
@@ -693,7 +690,6 @@ func verifyAppIsReachableFromFRRContainer(host, user, pass, containerName, appUR
 		true,
 		func(ctx context.Context) (bool, error) {
 			netNs, err = remote.ExecCmdOnHost(host, user, pass, getContainerNetNsCmd)
-
 			if err != nil {
 				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to run command due to: %v", err)
 
@@ -708,7 +704,6 @@ func verifyAppIsReachableFromFRRContainer(host, user, pass, containerName, appUR
 
 			return true, nil
 		})
-
 	if err != nil {
 		glog.V(100).Infof("Failed to retrieve netns for the FRR container %s: %v", containerName, err)
 
@@ -734,7 +729,6 @@ func verifyAppIsReachableFromFRRContainer(host, user, pass, containerName, appUR
 		true,
 		func(ctx context.Context) (bool, error) {
 			output, err = remote.ExecCmdOnHost(host, user, pass, verifyAppIsReachableCmd)
-
 			if err != nil {
 				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to run command due to: %v", err)
 
@@ -745,7 +739,6 @@ func verifyAppIsReachableFromFRRContainer(host, user, pass, containerName, appUR
 
 			return true, nil
 		})
-
 	if err != nil {
 		glog.V(100).Infof("URL %s is not reachable from the netns %s of the container %s; %v",
 			appURL, netNs, containerName, err)
@@ -818,7 +811,6 @@ func getNodesNamesList(apiClient *clients.Settings, options metav1.ListOptions) 
 	var nodeNamesList []string
 
 	nodesList, err := nodes.List(apiClient, options)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to retrieve %q nodes list; %v", options.String(), err)
 
@@ -849,7 +841,6 @@ func scanTroughPodsList(podsList []*pod.Builder, searchString string, timeStart 
 			stDeploymentLabel,
 			searchString,
 			timeStart)
-
 		if err != nil {
 			errorMsg = err
 		}

--- a/tests/system-tests/rdscore/internal/rdscorecommon/mount_namespace.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/mount_namespace.go
@@ -71,7 +71,6 @@ func mountNamespaceEncapsulation(nodeLabel string) {
 		err = wait.PollUntilContextTimeout(context.TODO(), 3*time.Second, time.Minute, true,
 			func(context.Context) (bool, error) {
 				kubeletMountNsOutput, err := remote.ExecuteOnNodeWithDebugPod(kubeletMountNsCmd, nodeName)
-
 				if err != nil {
 					glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to run command %s on node %s due to %v",
 						kubeletMountNsCmd, nodeName, err)
@@ -89,7 +88,6 @@ func mountNamespaceEncapsulation(nodeLabel string) {
 
 				return true, nil
 			})
-
 		if err != nil {
 			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to check kubelet mount namespace")
 
@@ -105,7 +103,6 @@ func mountNamespaceEncapsulation(nodeLabel string) {
 		err = wait.PollUntilContextTimeout(context.TODO(), 3*time.Second, time.Minute, true,
 			func(context.Context) (bool, error) {
 				crioMountNsOutput, err := remote.ExecuteOnNodeWithDebugPod(crioMountNsCmd, nodeName)
-
 				if err != nil {
 					glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to execute %s cmd on the node %s due to %v",
 						crioMountNsCmd, nodeName, err)
@@ -123,7 +120,6 @@ func mountNamespaceEncapsulation(nodeLabel string) {
 
 				return true, nil
 			})
-
 		if err != nil {
 			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to check CRI-O mount namespace")
 

--- a/tests/system-tests/rdscore/internal/rdscorecommon/sriov-pod-level-bond.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/sriov-pod-level-bond.go
@@ -160,7 +160,6 @@ func createPrivilegedPodLevelBondDeployment(
 
 func cleanUpPodLevelBondDeployment(apiClient *clients.Settings, deploymentName, nsName, podLabel string) error {
 	_, err := deployment.Pull(apiClient, deploymentName, nsName)
-
 	if err != nil {
 		glog.V(100).Infof("Deployment %s not found in namespace %s, %v", deploymentName, nsName, err)
 	}
@@ -168,7 +167,6 @@ func cleanUpPodLevelBondDeployment(apiClient *clients.Settings, deploymentName, 
 	glog.V(100).Infof("Ensure %s deployment does not exist in namespace %s", deploymentName, nsName)
 
 	err = apiobjectshelper.DeleteDeployment(apiClient, deploymentName, nsName)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to delete deployment %s from nsname %s due to %v",
 			deploymentName, nsName, err)
@@ -178,7 +176,6 @@ func cleanUpPodLevelBondDeployment(apiClient *clients.Settings, deploymentName, 
 	}
 
 	err = apiobjectshelper.EnsureAllPodsRemoved(apiClient, nsName, podLabel)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to delete pods in namespace %s with the label %s: %w", nsName, podLabel, err)
 
@@ -327,7 +324,6 @@ func generateTCPTraffic(
 		clientPod.Definition.Name, clientPod.Definition.Namespace)
 
 	err := clientPod.WaitUntilReady(5 * time.Second)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to wait for pod %q in namespace %q to become Ready: %v",
 			clientPod.Definition.Name, clientPod.Definition.Namespace, err)
@@ -351,7 +347,6 @@ func generateTCPTraffic(
 		true,
 		func(ctx context.Context) (bool, error) {
 			result, err := clientPod.ExecCommand(cmdToRun, clientPod.Object.Spec.Containers[0].Name)
-
 			if err != nil {
 				glog.V(100).Infof("Error running command from within a pod %q: %v",
 					clientPod.Object.Name, err)
@@ -367,7 +362,6 @@ func generateTCPTraffic(
 
 			return true, nil
 		})
-
 	if err != nil {
 		return "", fmt.Errorf("failed to run command from within pod %s: %w", clientPod.Object.Name, err)
 	}
@@ -387,8 +381,8 @@ func findInCmdExecOutput(cmdExecOutput, stringToFind string) (bool, error) {
 	}
 
 	buf := new(bytes.Buffer)
-	_, err = buf.WriteString(cmdExecOutput)
 
+	_, err = buf.WriteString(cmdExecOutput)
 	if err != nil {
 		glog.V(100).Infof("error in copying info from the cmdExecOutput to buffer: %v", err)
 
@@ -396,7 +390,6 @@ func findInCmdExecOutput(cmdExecOutput, stringToFind string) (bool, error) {
 	}
 
 	stringToFindRegex, err := regexp.Compile(stringToFind)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to compile stringToFind %s: %v", stringToFind, err)
 
@@ -427,7 +420,6 @@ func scanClientPodTrafficOutput(clientPodOutput string) (bool, error) {
 	glog.V(100).Infof("client pod output: %s", clientPodOutput)
 
 	isFound, err := findInCmdExecOutput(clientPodOutput, tcpTestPassedMsg)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to parse clientPodOutput due to %v", err)
 
@@ -464,7 +456,6 @@ func getBondActiveInterface(clientPod *pod.Builder) (string, error) {
 		true,
 		func(ctx context.Context) (bool, error) {
 			output, err = clientPod.ExecCommand(cmdToRun, clientPod.Object.Spec.Containers[0].Name)
-
 			if err != nil {
 				glog.V(100).Infof("Error running command from within a pod %q in namespace %q: %v",
 					clientPod.Definition.Name, clientPod.Definition.Namespace, err)
@@ -481,7 +472,6 @@ func getBondActiveInterface(clientPod *pod.Builder) (string, error) {
 
 			return true, nil
 		})
-
 	if err != nil {
 		glog.V(100).Infof("Failed to run command from within pod %q in namespace %q: %v",
 			clientPod.Definition.Name, clientPod.Definition.Namespace, err)
@@ -509,7 +499,6 @@ func disableBondActiveVFInterface(clientPod *pod.Builder) error {
 	}
 
 	err = changeInterfaceState(clientPod, interfaceName, true)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to disable interface %s for the pod %q in namespace %q: %v",
 			interfaceName, clientPod.Definition.Name, clientPod.Definition.Namespace, err)
@@ -576,7 +565,6 @@ func changeInterfaceState(clientPod *pod.Builder, interfaceName string, toDisabl
 		true,
 		func(ctx context.Context) (bool, error) {
 			output, err = clientPod.ExecCommand(cmdToRun, clientPod.Object.Spec.Containers[0].Name)
-
 			if err != nil {
 				glog.V(100).Infof("Error running command from within a pod %q in namespace %q: %v",
 					clientPod.Definition.Name, clientPod.Definition.Namespace, err)
@@ -593,7 +581,6 @@ func changeInterfaceState(clientPod *pod.Builder, interfaceName string, toDisabl
 
 			return true, nil
 		})
-
 	if err != nil {
 		glog.V(100).Infof("Failed to run command from within pod %q in namespace %q: %v",
 			clientPod.Definition.Name, clientPod.Definition.Namespace, err)
@@ -616,7 +603,6 @@ func changeInterfaceState(clientPod *pod.Builder, interfaceName string, toDisabl
 		true,
 		func(ctx context.Context) (bool, error) {
 			output, err = clientPod.ExecCommand(cmdToRun, clientPod.Object.Spec.Containers[0].Name)
-
 			if err != nil {
 				glog.V(100).Infof("Error running command from within a pod %q in namespace %q: %v",
 					clientPod.Definition.Name, clientPod.Definition.Namespace, err)
@@ -645,7 +631,6 @@ func changeInterfaceState(clientPod *pod.Builder, interfaceName string, toDisabl
 
 			return true, nil
 		})
-
 	if err != nil {
 		glog.V(100).Infof("Failed to run command from within pod %q in namespace %q: %v",
 			clientPod.Definition.Name, clientPod.Definition.Namespace, err)
@@ -674,7 +659,6 @@ func inspectPodLevelBondedInterfaceConfig(podObj *pod.Builder, ipv4Addr, ipv6Add
 		true,
 		func(ctx context.Context) (bool, error) {
 			result, err := podObj.ExecCommand(cmdToRun, podObj.Object.Spec.Containers[0].Name)
-
 			if err != nil {
 				glog.V(100).Infof("Error running command from within a pod %q: %v",
 					podObj.Object.Name, err)
@@ -697,7 +681,6 @@ func inspectPodLevelBondedInterfaceConfig(podObj *pod.Builder, ipv4Addr, ipv6Add
 
 			return true, nil
 		})
-
 	if err != nil {
 		return false, fmt.Errorf("failed to run command from within pod %s: %w", podObj.Object.Name, err)
 	}
@@ -706,7 +689,6 @@ func inspectPodLevelBondedInterfaceConfig(podObj *pod.Builder, ipv4Addr, ipv6Add
 		glog.V(100).Infof("Ensure IPv4 %s address defined as expected", ipv4Addr)
 
 		ipv4Found, err := findInCmdExecOutput(output, ipv4Addr)
-
 		if err != nil {
 			glog.V(100).Infof("Failed to parse output due to %v", err)
 
@@ -728,7 +710,6 @@ func inspectPodLevelBondedInterfaceConfig(podObj *pod.Builder, ipv4Addr, ipv6Add
 		glog.V(100).Infof("Ensure IPv6 %s address defined as expected", ipv6Addr)
 
 		ipv6Found, err := findInCmdExecOutput(output, ipv6Addr)
-
 		if err != nil {
 			glog.V(100).Infof("Failed to parse output due to %v", err)
 
@@ -786,7 +767,6 @@ func getPodObjectByNamePattern(apiClient *clients.Settings, podNamePattern, podN
 
 			return true, nil
 		})
-
 	if err != nil {
 		glog.V(100).Infof("Failed to retrieve pod %q in namespace %q: %v",
 			podNamePattern, podNamespace, err)
@@ -811,7 +791,6 @@ func getBondActiveInterfaceSrIovNetworkName(podObj *pod.Builder) (string, error)
 	podNetAnnotation := podObj.Object.Annotations["k8s.v1.cni.cncf.io/network-status"]
 
 	activeInterfaceName, err := getBondActiveInterface(podObj)
-
 	if err != nil {
 		glog.V(100).Infof("No active interface found for the pod %s in namespace %s: %v",
 			podObj.Definition.Name, podObj.Definition.Namespace, err)
@@ -821,8 +800,8 @@ func getBondActiveInterfaceSrIovNetworkName(podObj *pod.Builder) (string, error)
 	}
 
 	var podNetworkStatusType []podNetworkAnnotation
-	err = json.Unmarshal([]byte(podNetAnnotation), &podNetworkStatusType)
 
+	err = json.Unmarshal([]byte(podNetAnnotation), &podNetworkStatusType)
 	if err != nil {
 		glog.V(100).Infof("Error unmarshalling pod network status annotation %q: %v", podNetAnnotation, err)
 
@@ -974,7 +953,6 @@ func prepareSecondPodLevelBondDeployment(sameNode, samePF bool) {
 		APIClient,
 		RDSCoreConfig.PodLevelBondDeploymentOneName,
 		RDSCoreConfig.PodLevelBondNamespace)
-
 	if err != nil || clientPod == nil {
 		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Pod-Level Bond client deployment not found")
 

--- a/tests/system-tests/rdscore/internal/rdscorecommon/sriov-rootless-dpdk.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/sriov-rootless-dpdk.go
@@ -123,7 +123,6 @@ func createRootlessDPDKServerDeployment(
 		defineTestServerPmdCmd(clientMac, fmt.Sprintf("${PCIDEVICE_OPENSHIFT_IO_%s}",
 			strings.ToUpper(sriovNodePolicyName)), txIPs),
 		serverDeploymentLabelMap)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to create server deployment %s in namespace %s: %v",
 			serverDPDKDeploymentName, deploymentNamespace, err)
@@ -163,12 +162,10 @@ func cleanUpRootlessDPDKDeployment(
 	}
 
 	_, err := deployment.Pull(apiClient, deploymentName, nsName)
-
 	if err == nil {
 		glog.V(100).Infof("Ensure %s deployment does not exist in namespace %s", deploymentName, nsName)
 
 		err = apiobjectshelper.DeleteDeployment(apiClient, deploymentName, nsName)
-
 		if err != nil {
 			glog.V(100).Infof("Failed to delete deployment %s from nsname %s due to %v",
 				deploymentName, nsName, err)
@@ -179,7 +176,6 @@ func cleanUpRootlessDPDKDeployment(
 	}
 
 	err = apiobjectshelper.EnsureAllPodsRemoved(apiClient, nsName, podLabel)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to delete pods in namespace %s with the label %s: %v", nsName, podLabel, err)
 
@@ -205,7 +201,6 @@ func defineAndCreateDPDKDeployment(
 	nodeSelector := map[string]string{"kubernetes.io/hostname": scheduleOnHost}
 
 	dpdkContainerCfg, err := defineDPDKContainer(deploymentName, containerCmd, securityContext)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to set DPDK container %s due to %v", deploymentName, err)
 
@@ -229,7 +224,6 @@ func defineAndCreateDPDKDeployment(
 	}
 
 	_, err = dpdkDeployment.CreateAndWaitUntilReady(waitTimeout)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to create DPDK deployment %s in namespace %s due to %v",
 			deploymentName, deploymentNamespace, err)
@@ -242,7 +236,6 @@ func defineAndCreateDPDKDeployment(
 		deploymentName, deploymentNamespace)
 
 	_pod, err := getDPDKPod(apiClient, deploymentName, deploymentNamespace)
-
 	if err != nil || _pod == nil {
 		glog.V(100).Infof("no running pods found for the deployment %s in namespace %s: %v",
 			deploymentName, deploymentNamespace, err)
@@ -267,7 +260,6 @@ func defineDPDKContainer(
 		WithResourceLimit(hugePages, memory, cpu).
 		WithResourceRequest(hugePages, memory, cpu).WithEnvVar("RUN_TYPE", "testcmd").
 		GetContainerCfg()
-
 	if err != nil {
 		glog.V(100).Infof("Failed to define server container %s due to %v", cName, err)
 
@@ -281,7 +273,6 @@ func retrieveClientDPDKPod(apiClient *clients.Settings, podNamePattern, podNames
 	glog.V(100).Infof("Retrieve client DPDK pod %s in namespace %s", podNamePattern, podNamespace)
 
 	podObj, err := getDPDKPod(apiClient, podNamePattern, podNamespace)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to retrieve client pod %q in namespace %q: %v",
 			podNamePattern, podNamespace, err)
@@ -340,7 +331,6 @@ func getDPDKPod(apiClient *clients.Settings, podNamePattern, podNamespace string
 
 			return true, nil
 		})
-
 	if err != nil {
 		glog.V(100).Infof("Failed to retrieve pod %q in namespace %q: %v",
 			podNamePattern, podNamespace, err)
@@ -369,7 +359,6 @@ func rxTrafficOnClientPod(clientPod *pod.Builder, clientRxCmd string) error {
 		false,
 		func(ctx context.Context) (bool, error) {
 			clientOut, err = clientPod.ExecCommand([]string{"/bin/bash", "-c", clientRxCmd})
-
 			if err != nil {
 				if err.Error() != timeoutError {
 					glog.V(100).Infof("Failed to run the dpdk-pmd command %s; %v", clientRxCmd, err)
@@ -380,7 +369,6 @@ func rxTrafficOnClientPod(clientPod *pod.Builder, clientRxCmd string) error {
 
 			return true, nil
 		})
-
 	if err != nil {
 		if err.Error() != timeoutError {
 			glog.V(100).Infof("Failed to run the dpdk-pmd command %s on the client pod %s in namespace %s; %v",
@@ -431,7 +419,6 @@ func getCurrentLinkRx(runningPod *pod.Builder) (map[string]int, error) {
 
 			return true, nil
 		})
-
 	if err != nil {
 		glog.V(100).Infof("Failed to get links info from pod %s in namespace %s with error %v",
 			runningPod.Definition.Name, runningPod.Definition.Namespace, err)
@@ -498,7 +485,6 @@ func getNumberOfPackets(line, firstFieldSubstr string) int {
 	}
 
 	numberOfPackets, err := strconv.Atoi(splitLine[1])
-
 	if err != nil {
 		glog.V(90).Infof("failed to convert string to integer %s", err)
 
@@ -586,7 +572,6 @@ func getLinkRx(runningPod *pod.Builder, linkName string) (int, error) {
 
 			return true, nil
 		})
-
 	if err != nil {
 		glog.V(100).Infof("Failed to get link %s info from pod %s in namespace %s with error %v",
 			linkName, runningPod.Definition.Name, runningPod.Definition.Namespace, err)
@@ -609,8 +594,8 @@ func getLinkRx(runningPod *pod.Builder, linkName string) (int, error) {
 
 func getPCIAddressListFromSrIovNetworkName(podNetworkStatus, networkName string) ([]string, error) {
 	var podNetworkStatusType []podNetworkAnnotation
-	err := json.Unmarshal([]byte(podNetworkStatus), &podNetworkStatusType)
 
+	err := json.Unmarshal([]byte(podNetworkStatus), &podNetworkStatusType)
 	if err != nil {
 		glog.V(100).Infof("Failed to unmarshal pod network status %s with error %v", podNetworkStatus, err)
 
@@ -651,7 +636,6 @@ func isPCIAddressAvailable(clientPod *pod.Builder) bool {
 	var err error
 
 	pciAddressList, err := getPCIAddressListFromSrIovNetworkName(podNetAnnotation, dpdkNetworkOne)
-
 	if err != nil {
 		glog.V(100).Infof("Failed to get PCI address list from pod %s in namespace %s with error %v",
 			clientPod.Definition.Name, clientPod.Definition.Namespace, err)

--- a/tests/system-tests/rdscore/internal/rdscorecommon/sriov-validation.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/sriov-validation.go
@@ -96,7 +96,6 @@ func getSRIOVOperatorConfig() (*srIovV1.SriovOperatorConfig, error) {
 			var getErr error
 
 			sriovConfig, getErr = sriovConfigBuiler.Get()
-
 			if getErr != nil {
 				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Error retrieving SR-IOV Operator config: %v", getErr)
 
@@ -107,7 +106,6 @@ func getSRIOVOperatorConfig() (*srIovV1.SriovOperatorConfig, error) {
 
 			return true, nil
 		})
-
 	if err != nil {
 		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Error retrieving SR-IOV Operator config: %v", err)
 

--- a/tests/system-tests/rdscore/internal/rdscoreconfig/config.go
+++ b/tests/system-tests/rdscore/internal/rdscoreconfig/config.go
@@ -54,6 +54,7 @@ func (tl *TolerationList) Decode(value string) error {
 				parsedToleration.Operator = corev1.TolerationOperator(strings.Split(parsedRecord, "=")[1])
 			}
 		}
+
 		tmpTolerationList = append(tmpTolerationList, parsedToleration)
 	}
 
@@ -536,6 +537,7 @@ func NewCoreConfig() *CoreConfig {
 	log.Print("Creating new CoreConfig struct")
 
 	var rdsCoreConf CoreConfig
+
 	rdsCoreConf.GeneralConfig = config.NewConfig()
 
 	var confFile string
@@ -558,7 +560,6 @@ func NewCoreConfig() *CoreConfig {
 	}
 
 	err = readEnv(&rdsCoreConf)
-
 	if err != nil {
 		log.Print("Error to read environment variables")
 
@@ -579,8 +580,8 @@ func readFile(rdsConfig *CoreConfig, cfgFile string) error {
 	}()
 
 	decoder := yaml.NewDecoder(openedCfgFile)
-	err = decoder.Decode(&rdsConfig)
 
+	err = decoder.Decode(&rdsConfig)
 	if err != nil {
 		return err
 	}

--- a/tests/system-tests/spk/internal/spkcommon/setup-workloads.go
+++ b/tests/system-tests/spk/internal/spkcommon/setup-workloads.go
@@ -210,7 +210,6 @@ func deleteSVC(svcName, svcNS string) {
 		svcName, svcNS)
 
 	svcDemo, err := service.Pull(APIClient, svcName, svcNS)
-
 	if err != nil && svcDemo == nil {
 		glog.V(spkparams.SPKLogLevel).Infof("Service %q not found in %q namespace",
 			svcName, svcNS)

--- a/tests/system-tests/spk/internal/spkconfig/config.go
+++ b/tests/system-tests/spk/internal/spkconfig/config.go
@@ -106,7 +106,6 @@ func NewSPKConfig() *SPKConfig {
 	log.Printf("Open config file %s", confFile)
 
 	err := readFile(&spkConf, confFile)
-
 	if err != nil {
 		log.Printf("Error to read config file %s", confFile)
 
@@ -114,7 +113,6 @@ func NewSPKConfig() *SPKConfig {
 	}
 
 	err = readEnv(&spkConf)
-
 	if err != nil {
 		log.Print("Error to read environment variables")
 
@@ -135,8 +133,8 @@ func readFile(spkConfig *SPKConfig, cfgFile string) error {
 	}()
 
 	decoder := yaml.NewDecoder(openedCfgFile)
-	err = decoder.Decode(&spkConfig)
 
+	err = decoder.Decode(&spkConfig)
 	if err != nil {
 		return err
 	}

--- a/tests/system-tests/vcore/internal/ocpcli/ocpcli.go
+++ b/tests/system-tests/vcore/internal/ocpcli/ocpcli.go
@@ -31,7 +31,6 @@ func DownloadAndExtractOcBinaryArchive(apiClient *clients.Settings) error {
 		glog.V(100).Info("oc binary was found, need to be deleted")
 
 		err = os.Remove(ocPath)
-
 		if err != nil {
 			return fmt.Errorf("failed to remove %s", ocPath)
 		}
@@ -40,7 +39,6 @@ func DownloadAndExtractOcBinaryArchive(apiClient *clients.Settings) error {
 	glog.V(100).Info("install oc binary")
 
 	clusterVersion, err := platform.GetOCPVersion(apiClient)
-
 	if err != nil {
 		return err
 	}
@@ -49,28 +47,27 @@ func DownloadAndExtractOcBinaryArchive(apiClient *clients.Settings) error {
 		ocBinaryMirror, clusterVersion, clusterVersion)
 
 	err = files.DownloadFile(ocBinaryURL, localTarArchiveName, tempDir)
-
 	if err != nil {
 		return err
 	}
 
 	tarArchiveLocation := filepath.Join(tempDir, localTarArchiveName)
-	err = targz.Extract(tarArchiveLocation, tempDir)
 
+	err = targz.Extract(tarArchiveLocation, tempDir)
 	if err != nil {
 		return err
 	}
 
 	execCmd := fmt.Sprintf("sudo -u root -i cp %s /usr/local/bin/oc", ocPath)
-	output, err := shell.ExecuteCmd(execCmd)
 
+	output, err := shell.ExecuteCmd(execCmd)
 	if err != nil {
 		return fmt.Errorf("failed to execute %s command due to: %w. \noutput: %v", execCmd, err, output)
 	}
 
 	chmodCmd := "sudo -u root -i chmod 755 /usr/local/bin/oc"
-	_, err = shell.ExecuteCmd(chmodCmd)
 
+	_, err = shell.ExecuteCmd(chmodCmd)
 	if err != nil {
 		return fmt.Errorf("failed to execute %s command due to: %w", chmodCmd, err)
 	}
@@ -84,13 +81,11 @@ func ApplyConfig(
 	pathToConfigFile string,
 	variablesToReplace map[string]interface{}) error {
 	err := template.SaveTemplate(pathToTemplate, pathToConfigFile, variablesToReplace)
-
 	if err != nil {
 		return err
 	}
 
 	err = remote.ScpFileTo(pathToConfigFile, pathToConfigFile, VCoreConfig.Host, VCoreConfig.User, VCoreConfig.Pass)
-
 	if err != nil {
 		return fmt.Errorf("failed to transfer file %s to the %s/%s due to: %w",
 			pathToConfigFile, VCoreConfig.Host, pathToConfigFile, err)
@@ -98,8 +93,8 @@ func ApplyConfig(
 
 	applyCmd := fmt.Sprintf("oc apply -f %s --kubeconfig=%s",
 		pathToConfigFile, VCoreConfig.KubeconfigPath)
-	_, err = remote.ExecCmdOnHost(VCoreConfig.Host, VCoreConfig.User, VCoreConfig.Pass, applyCmd)
 
+	_, err = remote.ExecCmdOnHost(VCoreConfig.Host, VCoreConfig.User, VCoreConfig.Pass, applyCmd)
 	if err != nil {
 		return fmt.Errorf("failed to execute %s command due to: %w", applyCmd, err)
 	}
@@ -113,21 +108,19 @@ func CreateConfig(
 	pathToConfigFile string,
 	variablesToReplace map[string]interface{}) error {
 	err := template.SaveTemplate(pathToTemplate, pathToConfigFile, variablesToReplace)
-
 	if err != nil {
 		return err
 	}
 
 	err = remote.ScpFileTo(pathToConfigFile, pathToConfigFile, VCoreConfig.Host, VCoreConfig.User, VCoreConfig.Pass)
-
 	if err != nil {
 		return fmt.Errorf("failed to transfer file %s to the %s/%s due to: %w",
 			pathToConfigFile, VCoreConfig.Host, pathToConfigFile, err)
 	}
 
 	createCmd := fmt.Sprintf("oc create -f %s --kubeconfig=%s", pathToConfigFile, VCoreConfig.KubeconfigPath)
-	_, err = remote.ExecCmdOnHost(VCoreConfig.Host, VCoreConfig.User, VCoreConfig.Pass, createCmd)
 
+	_, err = remote.ExecCmdOnHost(VCoreConfig.Host, VCoreConfig.User, VCoreConfig.Pass, createCmd)
 	if err != nil {
 		return fmt.Errorf("failed to execute %s command due to: %w", createCmd, err)
 	}

--- a/tests/system-tests/vcore/internal/vcorecommon/helper.go
+++ b/tests/system-tests/vcore/internal/vcorecommon/helper.go
@@ -19,7 +19,6 @@ func getImageURL(repository, name, tag string) (string, error) {
 	imageURL := fmt.Sprintf("%s/%s", repository, name)
 
 	isDisconnected, err := platform.IsDisconnectedDeployment(APIClient)
-
 	if err != nil {
 		return "", err
 	}
@@ -40,7 +39,6 @@ func getImageURL(repository, name, tag string) (string, error) {
 			VCoreConfig.Pass,
 			VCoreConfig.RegistryRepository,
 			VCoreConfig.KubeconfigPath)
-
 		if err != nil {
 			return "", fmt.Errorf("failed to mirror image %s:%s locally due to %w",
 				name, tag, err)
@@ -87,7 +85,6 @@ func ensureNamespaceExists(nsName string) bool {
 
 	if !createNs.Exists() {
 		createNs, err := createNs.Create()
-
 		if err != nil {
 			glog.V(vcoreparams.VCoreLogLevel).Infof("Error creating namespace %q: %v", nsName, err)
 
@@ -110,7 +107,6 @@ func ensureNamespaceExists(nsName string) bool {
 
 				return true, nil
 			})
-
 		if err != nil {
 			return false
 		}

--- a/tests/system-tests/vcore/internal/vcorecommon/initial-platform-deployment.go
+++ b/tests/system-tests/vcore/internal/vcorecommon/initial-platform-deployment.go
@@ -74,6 +74,7 @@ func VerifyHealthyClusterStatus(ctx SpecContext) {
 	glog.V(vcoreparams.VCoreLogLevel).Infof("Checking if all BareMetalHosts in good OperationalState")
 
 	var bmhList []*bmh.BmhBuilder
+
 	bmhList, err = bmh.List(APIClient, vcoreparams.OpenshiftMachineAPINamespace)
 	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Error getting BareMetaHosts list: %v", err))
 	Expect(len(bmhList)).ToNot(Equal(0), "Empty bareMetalHosts list received")
@@ -87,6 +88,7 @@ func VerifyHealthyClusterStatus(ctx SpecContext) {
 	glog.V(vcoreparams.VCoreLogLevel).Infof("Checking available control-plane nodes count")
 
 	var nodesList []*nodes.Builder
+
 	nodesList, err = nodes.List(APIClient, VCoreConfig.ControlPlaneLabelListOption)
 	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Failed to get master nodes list; %v", err))
 
@@ -97,6 +99,7 @@ func VerifyHealthyClusterStatus(ctx SpecContext) {
 	glog.V(vcoreparams.VCoreLogLevel).Infof("Checking all master nodes are Ready")
 
 	var isReady bool
+
 	isReady, err = nodes.WaitForAllNodesAreReady(
 		APIClient,
 		5*time.Second,
@@ -113,6 +116,7 @@ func VerifyHealthyClusterStatus(ctx SpecContext) {
 	glog.V(vcoreparams.VCoreLogLevel).Infof("Asserting clusteroperators availability")
 
 	var coBuilder []*clusteroperator.Builder
+
 	coBuilder, err = clusteroperator.List(APIClient)
 	Expect(err).To(BeNil(), fmt.Sprintf("ClusterOperator List not found: %v", err))
 	Expect(len(coBuilder)).ToNot(Equal(0), "Empty clusterOperators list received")

--- a/tests/system-tests/vcore/internal/vcorecommon/node-tuning-operator.go
+++ b/tests/system-tests/vcore/internal/vcorecommon/node-tuning-operator.go
@@ -405,6 +405,7 @@ func unmarshalRaw[T any](raw []byte) T {
 	Expect(err).ToNot(HaveOccurred(), "Failed to unmarshal JSON into unstructured")
 
 	var typed T
+
 	err = runtime.DefaultUnstructuredConverter.FromUnstructured(untyped.UnstructuredContent(), &typed)
 	Expect(err).ToNot(HaveOccurred(), "Failed to convert unstructed to structured")
 

--- a/tests/system-tests/vcore/internal/vcorecommon/numa-operator.go
+++ b/tests/system-tests/vcore/internal/vcorecommon/numa-operator.go
@@ -58,7 +58,6 @@ func VerifyNROPSuite() {
 				workloadDeployment, err := deployment.Pull(APIClient,
 					vcoreparams.NumaWorkloadName,
 					vcoreparams.NROPNamespace)
-
 				if err == nil {
 					err = workloadDeployment.DeleteAndWait(time.Minute * 2)
 					Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Failed to delete deployment due to %v", err))

--- a/tests/system-tests/vcore/internal/vcorecommon/post-deployment-config.go
+++ b/tests/system-tests/vcore/internal/vcorecommon/post-deployment-config.go
@@ -234,6 +234,7 @@ func SetSystemReservedMemoryForMasterNodes(ctx SpecContext) {
 		glog.V(vcoreparams.VCoreLogLevel).Infof("Checking all master nodes are Ready")
 
 		var isReady bool
+
 		isReady, err = nodes.WaitForAllNodesAreReady(
 			APIClient,
 			30*time.Second,
@@ -250,6 +251,7 @@ func SetSystemReservedMemoryForMasterNodes(ctx SpecContext) {
 		glog.V(vcoreparams.VCoreLogLevel).Infof("Asserting clusteroperators availability")
 
 		var coBuilder []*clusteroperator.Builder
+
 		coBuilder, err = clusteroperator.List(APIClient)
 		Expect(err).To(BeNil(), fmt.Sprintf("ClusterOperator List not found: %v", err))
 		Expect(len(coBuilder)).ToNot(Equal(0), "Empty clusterOperators list received")

--- a/tests/system-tests/vcore/internal/vcorecommon/redis.go
+++ b/tests/system-tests/vcore/internal/vcorecommon/redis.go
@@ -57,7 +57,6 @@ func VerifyRedisDeploymentProcedure(ctx SpecContext) {
 	glog.V(vcoreparams.VCoreLogLevel).Info("Check if redis already installed")
 
 	redisStatefulset, err := statefulset.Pull(APIClient, redisStatefulsetName, redisNamespace)
-
 	if err == nil && redisStatefulset.IsReady(time.Second) {
 		glog.V(vcoreparams.VCoreLogLevel).Infof("redis statefulset %s in namespace %s exists and ready",
 			redisStatefulsetName, redisNamespace)
@@ -93,7 +92,6 @@ func VerifyRedisDeploymentProcedure(ctx SpecContext) {
 		glog.V(100).Infof("Ensure local directory %s exists", vcoreparams.ConfigurationFolderPath)
 
 		err = os.Mkdir(vcoreparams.ConfigurationFolderPath, 0755)
-
 		if err != nil {
 			glog.V(100).Infof("Failed to create directory %s, it is already exists",
 				vcoreparams.ConfigurationFolderPath)

--- a/tests/system-tests/vcore/internal/vcoreconfig/config.go
+++ b/tests/system-tests/vcore/internal/vcoreconfig/config.go
@@ -55,13 +55,14 @@ func NewVCoreConfig() *VCoreConfig {
 	log.Print("Creating new VCoreConfig struct")
 
 	var vcoreConf VCoreConfig
+
 	vcoreConf.SystemTestsConfig = systemtestsconfig.NewSystemTestsConfig()
 
 	_, filename, _, _ := runtime.Caller(0)
 	baseDir := filepath.Dir(filename)
 	confFile := filepath.Join(baseDir, PathToDefaultVCoreParamsFile)
-	err := readFile(&vcoreConf, confFile)
 
+	err := readFile(&vcoreConf, confFile)
 	if err != nil {
 		log.Printf("Error to read config file %s", confFile)
 
@@ -69,7 +70,6 @@ func NewVCoreConfig() *VCoreConfig {
 	}
 
 	err = readEnv(&vcoreConf)
-
 	if err != nil {
 		log.Print("Error to read environment variables")
 
@@ -90,8 +90,8 @@ func readFile(vcoreConfig *VCoreConfig, cfgFile string) error {
 	}()
 
 	decoder := yaml.NewDecoder(openedCfgFile)
-	err = decoder.Decode(&vcoreConfig)
 
+	err = decoder.Decode(&vcoreConfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR updates to v5 of the wsl linter. Since there are a number of changes, this PR runs `golangci-lint run --fix` to correct them.