### PR TITLE
cnf:network fix issue with hardcoded node name

### DIFF
--- a/tests/cnf/core/network/metallb/tests/frrk8-tests.go
+++ b/tests/cnf/core/network/metallb/tests/frrk8-tests.go
@@ -246,7 +246,7 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelFRRTestCases), ContinueOnFa
 				Eventually(func() string {
 					// Get the routes
 					frrNodeState, err := metallb.ListFrrNodeState(APIClient, client.ListOptions{
-						FieldSelector: fields.SelectorFromSet(fields.Set{"metadata.name": "worker-0"})})
+						FieldSelector: fields.SelectorFromSet(fields.Set{"metadata.name": workerNodeList[0].Definition.Name})})
 					Expect(err).ToNot(HaveOccurred(), "Failed to verify BGP routes")
 
 					return frrNodeState[0].Object.Status.RunningConfig
@@ -266,7 +266,7 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelFRRTestCases), ContinueOnFa
 				Eventually(func() string {
 					// Get the routes
 					frrNodeState, err := metallb.ListFrrNodeState(APIClient, client.ListOptions{
-						FieldSelector: fields.SelectorFromSet(fields.Set{"metadata.name": "worker-1"})})
+						FieldSelector: fields.SelectorFromSet(fields.Set{"metadata.name": workerNodeList[1].Definition.Name})})
 					Expect(err).ToNot(HaveOccurred(), "Failed to verify BGP routes")
 
 					return frrNodeState[0].Object.Status.RunningConfig


### PR DESCRIPTION
Issue running on new cluster with node naming convention worker0 rather then worker-0.