### PR TITLE
cnf network: fix multiple test issues

### DIFF
--- a/tests/cnf/core/network/day1day2/internal/tsparams/day1day2vars.go
+++ b/tests/cnf/core/network/day1day2/internal/tsparams/day1day2vars.go
@@ -29,5 +29,6 @@ var (
 	ReporterNamespacesToDump = map[string]string{
 		NetConfig.NMStateOperatorNamespace: NetConfig.NMStateOperatorNamespace,
 		TestNamespaceName:                  "other",
+		"openshift-nmstate":                "nmstate operator",
 	}
 )

--- a/tests/cnf/core/network/metallb/internal/tsparams/mlbvars.go
+++ b/tests/cnf/core/network/metallb/internal/tsparams/mlbvars.go
@@ -22,6 +22,7 @@ var (
 		"openshift-performance-addon-operator": "performance",
 		NetConfig.MlbOperatorNamespace:         "metallb-system",
 		TestNamespaceName:                      "other",
+		"openshift-nmstate":                    "nmstate operator",
 	}
 
 	// ReporterCRDsToDump tells to the reporter what CRs to dump.

--- a/tests/cnf/core/network/metallb/tests/layer2-test.go
+++ b/tests/cnf/core/network/metallb/tests/layer2-test.go
@@ -206,9 +206,15 @@ func getLBServiceAnnouncingNodeName() string {
 	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Failed to get events in namespace %s", tsparams.TestNamespaceName))
 
 	var allEvents []string
-
+	//nolint:varnamelen
 	sort.Slice(serviceEvents, func(i int, j int) bool {
-		return serviceEvents[i].Object.FirstTimestamp.Before(&serviceEvents[j].Object.FirstTimestamp)
+		// Primary sort: LastTimestamp
+		if serviceEvents[i].Object.LastTimestamp.Time.Equal(serviceEvents[j].Object.LastTimestamp.Time) {
+			// Secondary sort: FirstTimestamp
+			return serviceEvents[i].Object.FirstTimestamp.Time.Before(serviceEvents[j].Object.FirstTimestamp.Time)
+		}
+
+		return serviceEvents[i].Object.LastTimestamp.Time.Before(serviceEvents[j].Object.LastTimestamp.Time)
 	})
 	Expect(len(serviceEvents)).To(BeNumerically(">", 0), "No events were found")
 

--- a/tests/cnf/core/network/policy/tests/multinetpolicysriov.go
+++ b/tests/cnf/core/network/policy/tests/multinetpolicysriov.go
@@ -73,7 +73,7 @@ var _ = Describe("SRIOV", Ordered, Label("multinetworkpolicy"), ContinueOnFailur
 			"policysriov",
 			NetConfig.SriovOperatorNamespace,
 			"sriovpolicy",
-			5,
+			6,
 			srIovInterfacesUnderTest,
 			NetConfig.WorkerLabelMap).Create()
 		Expect(err).ToNot(HaveOccurred(), "Failed to create SR-IOV policy")

--- a/tests/cnf/core/network/sriov/internal/tsparams/sriovvars.go
+++ b/tests/cnf/core/network/sriov/internal/tsparams/sriovvars.go
@@ -38,6 +38,7 @@ var (
 	ReporterNamespacesToDump = map[string]string{
 		NetConfig.SriovOperatorNamespace: NetConfig.SriovOperatorNamespace,
 		TestNamespaceName:                "other",
+		"openshift-nmstate":              "nmstate operator",
 	}
 	// ClientIPv4IPAddress represents the full test client IPv4 address.
 	ClientIPv4IPAddress = "192.168.0.1/24"

--- a/tests/cnf/core/network/sriov/tests/allmulti.go
+++ b/tests/cnf/core/network/sriov/tests/allmulti.go
@@ -92,8 +92,8 @@ var _ = Describe("allmulti", Ordered, Label(tsparams.LabelSuite), ContinueOnFail
 			srIovPolicyNode1Name,
 			NetConfig.SriovOperatorNamespace,
 			srIovPolicyNode0ResName,
-			5,
-			[]string{fmt.Sprintf("%s#0-4", srIovInterfacesUnderTest[0])},
+			6,
+			[]string{fmt.Sprintf("%s#0-5", srIovInterfacesUnderTest[0])},
 			nodeSelectorWorker0).WithMTU(9000).WithVhostNet(true).Create()
 		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Failed to create an sriov policy on %s",
 			workerNodes[0].Definition.Name))
@@ -108,8 +108,8 @@ var _ = Describe("allmulti", Ordered, Label(tsparams.LabelSuite), ContinueOnFail
 			srIovPolicyNode2Name,
 			NetConfig.SriovOperatorNamespace,
 			srIovPolicyNode1ResName,
-			5,
-			[]string{fmt.Sprintf("%s#0-4", srIovInterfacesUnderTest[0])},
+			6,
+			[]string{fmt.Sprintf("%s#0-5", srIovInterfacesUnderTest[0])},
 			nodeSelectorWorker1).WithMTU(9000).WithVhostNet(true).Create()
 		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Failed to create an sriov policy on %s",
 			workerNodes[1].Definition.Name))

--- a/tests/cnf/core/network/sriov/tests/externalllymanaged.go
+++ b/tests/cnf/core/network/sriov/tests/externalllymanaged.go
@@ -371,7 +371,7 @@ var _ = Describe("ExternallyManaged", Ordered, Label(tsparams.LabelExternallyMan
 					sriovAndResourceNameExManagedTrue,
 					NetConfig.SriovOperatorNamespace,
 					sriovAndResourceNameExManagedTrue,
-					5, []string{fmt.Sprintf("%s#%d-%d", pfInterface, 2, 2)}, NetConfig.WorkerLabelMap).
+					6, []string{fmt.Sprintf("%s#%d-%d", pfInterface, 2, 2)}, NetConfig.WorkerLabelMap).
 					WithExternallyManaged(true)
 
 				err = sriovenv.CreateSriovPolicyAndWaitUntilItsApplied(sriovPolicy, tsparams.MCOWaitTimeout)

--- a/tests/cnf/core/network/sriov/tests/metricsExporter.go
+++ b/tests/cnf/core/network/sriov/tests/metricsExporter.go
@@ -281,19 +281,19 @@ func definePolicy(role, devType, nicVendor, pfName string, vfRange int) *sriov.P
 	switch devType {
 	case "netdevice":
 		policy = sriov.NewPolicyBuilder(APIClient,
-			role+devType, NetConfig.SriovOperatorNamespace, role+devType, 5, []string{pfName}, NetConfig.WorkerLabelMap).
+			role+devType, NetConfig.SriovOperatorNamespace, role+devType, 6, []string{pfName}, NetConfig.WorkerLabelMap).
 			WithDevType("netdevice").
 			WithVFRange(vfRange, vfRange)
 	case "vfiopci":
 		if nicVendor != netparam.MlxVendorID {
 			policy = sriov.NewPolicyBuilder(APIClient,
-				role+devType, NetConfig.SriovOperatorNamespace, role+devType, 5, []string{pfName}, NetConfig.WorkerLabelMap).
+				role+devType, NetConfig.SriovOperatorNamespace, role+devType, 6, []string{pfName}, NetConfig.WorkerLabelMap).
 				WithDevType("vfio-pci").
 				WithVFRange(vfRange, vfRange).
 				WithRDMA(false)
 		} else {
 			policy = sriov.NewPolicyBuilder(APIClient,
-				role+devType, NetConfig.SriovOperatorNamespace, role+devType, 5, []string{pfName}, NetConfig.WorkerLabelMap).
+				role+devType, NetConfig.SriovOperatorNamespace, role+devType, 6, []string{pfName}, NetConfig.WorkerLabelMap).
 				WithDevType("netdevice").
 				WithVFRange(vfRange, vfRange).
 				WithRDMA(true)

--- a/tests/cnf/core/network/sriov/tests/mlxSecureBoot.go
+++ b/tests/cnf/core/network/sriov/tests/mlxSecureBoot.go
@@ -116,7 +116,7 @@ var _ = Describe("Mellanox Secure Boot", Ordered, Label(tsparams.LabelMlxSecureB
 				sriovAndResourceNameSecureBoot,
 				NetConfig.SriovOperatorNamespace,
 				sriovAndResourceNameSecureBoot,
-				5,
+				6,
 				sriovInterfacesUnderTest[:1],
 				map[string]string{"kubernetes.io/hostname": workerNodeList[0].Definition.Name})
 

--- a/tests/cnf/core/network/sriov/tests/qinq.go
+++ b/tests/cnf/core/network/sriov/tests/qinq.go
@@ -1022,8 +1022,8 @@ func defineCreateSriovNetPolices(vfioPCIName, vfioPCIResName, sriovInterface,
 		vfioPCIName,
 		NetConfig.SriovOperatorNamespace,
 		vfioPCIResName,
-		5,
-		[]string{fmt.Sprintf("%s#0-4", sriovInterface)},
+		6,
+		[]string{fmt.Sprintf("%s#0-5", sriovInterface)},
 		NetConfig.WorkerLabelMap).WithVhostNet(true)
 
 	switch reqDriver {

--- a/tests/cnf/core/network/sriov/tests/rdmametricsapi.go
+++ b/tests/cnf/core/network/sriov/tests/rdmametricsapi.go
@@ -73,8 +73,8 @@ var _ = Describe("rdmaMetricsAPI", Ordered, Label(tsparams.LabelRdmaMetricsAPITe
 
 				By("Create Sriov Node Policy and Network")
 
-				tPol1 = defineAndCreateNodePolicy("rdmapolicy1", "sriovpf1", sriovInterfacesUnderTest[0], 5, 1)
-				tPol2 = defineAndCreateNodePolicy("rdmapolicy2", "sriovpf2", sriovInterfacesUnderTest[1], 5, 1)
+				tPol1 = defineAndCreateNodePolicy("rdmapolicy1", "sriovpf1", sriovInterfacesUnderTest[0], 6, 1)
+				tPol2 = defineAndCreateNodePolicy("rdmapolicy2", "sriovpf2", sriovInterfacesUnderTest[1], 6, 1)
 				tNet1 = defineAndCreateSriovNetworkWithRdma("sriovnet1", tPol1.Object.Spec.ResourceName, true)
 				tNet2 = defineAndCreateSriovNetworkWithRdma("sriovnet2", tPol2.Object.Spec.ResourceName, true)
 

--- a/tests/system-tests/vcore/internal/vcorecommon/sriov-validation.go
+++ b/tests/system-tests/vcore/internal/vcorecommon/sriov-validation.go
@@ -151,7 +151,7 @@ func VerifySRIOVConfig(ctx SpecContext) {
 		sriovNet1Name,
 		vcoreparams.SRIOVNamespace,
 		net1ResourceName,
-		5,
+		6,
 		snnpPfname1,
 		VCoreConfig.VCorePpLabelMap)
 	if !sriovNetworkNodePolicy1.Exists() {
@@ -171,7 +171,7 @@ func VerifySRIOVConfig(ctx SpecContext) {
 		sriovNet2Name,
 		vcoreparams.SRIOVNamespace,
 		net1ResourceName,
-		5,
+		6,
 		snnpPfname2,
 		VCoreConfig.VCorePpLabelMap)
 	if !sriovNetworkNodePolicy2.Exists() {


### PR DESCRIPTION
- Flaky issue where metallb speaker daemonset deletion check is skipped and old speaker daemonset is considered as new daemonset.
- Flaky issue where Events sorting needs to use both FirstTimestamp and LastTimestamp
- 6 VFs needed for test ID 67820. Updating VFs=6 all over the suite
- Dumping nmstate operator pods status when a test fails. This is to capture flaky issues of nmstate configuration.