### PR TITLE
global: update to Go 1.25.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi9/ubi:latest
 
-ARG GO_VER=go1.24.4
-ARG GINKGO_VER=ginkgo@v2.22.2
+ARG GO_VER=go1.25.0
+ARG GINKGO_VER=ginkgo@v2.23.4
 ARG CONTAINERUSER=testuser
 
 LABEL description="eco-gotests development image"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/rh-ecosystem-edge/eco-gotests
 
-go 1.24.5
+go 1.25
+
+toolchain go1.25.0
 
 require (
 	github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c

--- a/scripts/golangci-lint.sh
+++ b/scripts/golangci-lint.sh
@@ -4,7 +4,7 @@ set -e
 
 . "$(dirname "$0")"/common.sh
 
-GOLANGCI_LINT_VERSION="2.2.2"
+GOLANGCI_LINT_VERSION="2.4.0"
 
 # IsGoLangCiLintInstalled is used to check whether golangci-lint executable is on the $PATH.
 function IsGolangCiLintInstalled() {


### PR DESCRIPTION
This PR updates the project's Go version to 1.25, taking a new approach of specifying only minor versions with the `go` directive and leaving patch versions for the `toolchain` directive. This should allow developing in eco-gotests with misaligned patch versions as long as the minor versions are the same, giving greater flexibility.

golangci-lint has been updated to 2.4.0 to support Go 1.25.

Ginkgo in the Dockerfile has been updated to align with the version in the `go.mod`.

Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Go to 1.25 across build and container environments for improved performance and compatibility.
  * Updated development toolchain configuration to align with the new Go version.
  * Bumped linting tool to a newer release for more robust static analysis.

* **Tests**
  * Updated the test framework to a newer minor version to improve stability and compatibility with the updated toolchain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->