### PR TITLE
Refined IBU post-upgrade validations

### DIFF
--- a/tests/lca/imagebasedupgrade/cnf/internal/validations/post_ibu_validations.go
+++ b/tests/lca/imagebasedupgrade/cnf/internal/validations/post_ibu_validations.go
@@ -96,6 +96,13 @@ func ValidateClusterVersionCSVs() {
 			})
 			By("Validate CSVs were upgraded", func() {
 				for _, preUpgradeOperator := range cnfclusterinfo.PreUpgradeClusterInfo.Operators {
+					// Skip cluster-logging operator as it is not OCP-aligned and not always upgraded
+					if strings.Contains(preUpgradeOperator, "cluster-logging") {
+						glog.V(100).Infof("Skipping cluster-logging operator validation: %s", preUpgradeOperator)
+
+						continue
+					}
+
 					for _, postUpgradeOperator := range cnfclusterinfo.PostUpgradeClusterInfo.Operators {
 						Expect(preUpgradeOperator).ToNot(Equal(postUpgradeOperator), "Operator %s was not upgraded", preUpgradeOperator)
 					}
@@ -214,7 +221,12 @@ func ValidateNetworkConfig() {
 func ValidateSeedHostnameRefLogs() {
 	It("Validate no seed hostname references in pod logs", reportxml.ID("71392"), Label("ValidateSeedRefPodLogs"), func() {
 		By("Validate no seed hostname references in pod logs", func() {
-			logCmd := "grep -Ri " + seedInfo.SNOHostname + " /var/log/pods | grep -v lifecycle-agent-controller-manager | wc -l"
+			// Seed refs from garbage-collector-controller are expected during IBU; exclude them from this check.
+			logCmd := fmt.Sprintf(
+				`grep -Ri %q /var/log/pods | `+
+					`grep -vE 'lifecycle-agent-controller-manager|garbage-collector-controller' | wc -l`,
+				seedInfo.SNOHostname,
+			)
 			logRes, err := cluster.ExecCmdWithStdout(TargetSNOAPIClient, logCmd)
 			Expect(err).ToNot(HaveOccurred(), "could not execute command: %s", err)
 
@@ -378,9 +390,16 @@ func ValidateSeedRefLogs() {
 				return true
 			}, 1*time.Minute, 5*time.Second).Should(BeTrue(), "Failed to get kcat logs")
 
-			Expect(kcatPodOut).ToNot(
-				ContainSubstring(seedInfo.SNOHostname),
-				"Seed cluster name references detected in kcat logs: %s", kcatPodOut)
+			failedLines := []string{}
+			logLines := strings.Split(kcatPodOut, "\n")
+
+			for _, line := range logLines {
+				if strings.Contains(line, seedInfo.SNOHostname) {
+					failedLines = append(failedLines, line)
+				}
+			}
+
+			Expect(failedLines).To(BeEmpty(), "Seed cluster name references detected in exported logs")
 		})
 	})
 }


### PR DESCRIPTION
This PR addresses two post-upgrade validation failures.

1. Exclude cluster-logging from operator upgrade check. This operator is not always upgraded as part of a cluster upgrade since it is not tied to OCP.

2. Exclude instances of seed cluster name appearing in garbage-collector-controller pod logs during check for seed hostname in target pod logs. 
These seed cluster references are normal. They are occurring as the authentication-operator changes from the seed cluster to the target cluster as IBU progresses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Exclude the cluster-logging operator from pre/post-upgrade CSV comparisons to avoid false positives.
  * Extend seed-hostname log exclusions to also ignore expected garbage-collector-controller references during upgrades.
  * Improve seed-ref log validation by gathering any offending log lines and reporting them (exported logs) for clearer failure messages and more reliable checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->