### PR TITLE
report: switch remote URL to rh-ecosystem-edge

### DIFF
--- a/internal/report/README.md
+++ b/internal/report/README.md
@@ -2,7 +2,7 @@
 
 Generate HTML reports for the tree of Ginkgo specs. [Available on GitHub pages.]
 
-[Available on GitHub pages.]: https://openshift-kni.github.io/eco-gotests/report
+[Available on GitHub pages.]: https://rh-ecosystem-edge.github.io/eco-gotests/report
 
 ## Usage
 

--- a/internal/report/cache.go
+++ b/internal/report/cache.go
@@ -16,8 +16,7 @@ import (
 )
 
 const (
-	cacheDir  = "eco-gotests"
-	remoteURL = "https://github.com/openshift-kni/eco-gotests.git"
+	cacheDir = "eco-gotests"
 )
 
 var (
@@ -179,7 +178,7 @@ func (cache *Cache) GetRemotePatterns(patterns []string) (map[CacheKey]*SuiteTre
 		return nil, errCacheMiss
 	}
 
-	revisions, err := GetRemoteRevisions(cache.ctx, remoteURL, slices.Values(patterns))
+	revisions, err := GetRemoteRevisions(cache.ctx, RemoteURL, slices.Values(patterns))
 	if err != nil {
 		return nil, err
 	}
@@ -288,7 +287,7 @@ func (cache *Cache) Update() error {
 		cachedRevisions[key.Branch] = key.Revision
 	}
 
-	remoteRevisions, err := GetRemoteRevisions(cache.ctx, remoteURL, maps.Keys(cachedRevisions))
+	remoteRevisions, err := GetRemoteRevisions(cache.ctx, RemoteURL, maps.Keys(cachedRevisions))
 	if err != nil {
 		return err
 	}

--- a/internal/report/const.go
+++ b/internal/report/const.go
@@ -1,0 +1,6 @@
+package main
+
+const (
+	// RemoteURL is the URL of the remote repository. It should always point to the upstream eco-gotests repository.
+	RemoteURL = "https://github.com/rh-ecosystem-edge/eco-gotests.git"
+)

--- a/internal/report/main.go
+++ b/internal/report/main.go
@@ -187,7 +187,7 @@ func templateTreeMap(treeMap map[CacheKey]*SuiteTree, output string) error {
 			Generated:  time.Now(),
 			Branch:     key.Branch,
 			ActionURL:  template.URL(actionURL),
-			RepoURL:    "https://github.com/openshift-kni/eco-gotests",
+			RepoURL:    RemoteURL,
 			TimeFormat: time.RFC3339,
 		}
 		outputFileName := fmt.Sprintf("report_%s.html", key.Branch)
@@ -211,7 +211,7 @@ func templateTreeMap(treeMap map[CacheKey]*SuiteTree, output string) error {
 		BranchReports: branchReports,
 		Generated:     time.Now(),
 		ActionURL:     template.URL(actionURL),
-		RepoURL:       "https://github.com/openshift-kni/eco-gotests",
+		RepoURL:       RemoteURL,
 		TimeFormat:    time.RFC3339,
 	}
 	outputFilePath := filepath.Join(output, "report.html")
@@ -264,7 +264,7 @@ func getFromCacheOrClone(ctx context.Context, cache *Cache, patterns []string) (
 			continue
 		}
 
-		repoPath, err := CloneRepo(ctx, tempDir, remoteURL, key.Branch)
+		repoPath, err := CloneRepo(ctx, tempDir, RemoteURL, key.Branch)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This PR switches all the references of the openshift-kni/eco-gotests repository to be for rh-ecosystem-edge/eco-gotests within the report package. A slight refactoring has also been completed to move this URL to a single constant. These changes include the README which links to the generated report now using the rh-ecosystem-edge GitHub pages.

Since the reporter is setup to always run from the main branch, we do not need to backport these changes.

Assisted-by: Cursor