### PR TITLE
system-tests: Whereabouts tests for terminated pods

### DIFF
--- a/tests/system-tests/rdscore/tests/00_validate_top_level.go
+++ b/tests/system-tests/rdscore/tests/00_validate_top_level.go
@@ -291,6 +291,16 @@ var _ = Describe(
 				reportxml.ID("82713"),
 				rdscorecommon.VerifyWhereaboutsInterDeploymentPodCommunicationOnDifferentNodes)
 
+			It("Verify Whereabouts Deployment on the same node after pod termination",
+				Label("whereabouts", "whereabouts-deployment-same-node-termination", "whereabouts-deployment"),
+				reportxml.ID("82741"),
+				rdscorecommon.VerifyWhereaboutsInterDeploymentPodCommunicationOnTheSameNodeAfterPodTermination)
+
+			It("Verify Whereabouts Deployment on the different nodes after pod termination",
+				Label("whereabouts", "whereabouts-deployment-different-nodes-termination", "whereabouts-deployment"),
+				reportxml.ID("82740"),
+				rdscorecommon.VerifyWhereaboutsInterDeploymentPodCommunicationOnDifferentNodesAfterPodTermination)
+
 			AfterEach(func(ctx SpecContext) {
 				By("Ensure rootless DPDK server deployment was deleted")
 				rdscorecommon.CleanupRootlessDPDKServerDeployment()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Expanded system tests to validate inter-deployment pod communication resilience after pod termination on same-node and cross-node scenarios.
  - Introduced randomized pod/deployment termination within tests to better simulate real-world failures.
  - Added polling intervals and timeout safeguards to improve test stability and reliability.
  - Enhanced test logging for clearer visibility into termination and recovery steps.
  - No user-facing behavior changes; these updates strengthen test coverage and confidence in stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->