### PR TITLE
cnf network: add acc100 tests

### DIFF
--- a/tests/cnf/core/network/acc/acc_suite_test.go
+++ b/tests/cnf/core/network/acc/acc_suite_test.go
@@ -1,0 +1,59 @@
+package acc
+
+import (
+	"runtime"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/namespace"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/acc/internal/accenv"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/acc/internal/tsparams"
+	_ "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/acc/tests"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netinittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/params"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/reporter"
+)
+
+var (
+	_, currentFile, _, _ = runtime.Caller(0)
+	testNS               = namespace.NewBuilder(APIClient, tsparams.TestNamespaceName)
+)
+
+func TestAcc(t *testing.T) {
+	_, reporterConfig := GinkgoConfiguration()
+	reporterConfig.JUnitReport = NetConfig.GetJunitReportPath(currentFile)
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "acc", Label(tsparams.Labels...), reporterConfig)
+}
+
+var _ = BeforeSuite(func() {
+	By("Creating privileged test namespace")
+	for key, value := range params.PrivilegedNSLabels {
+		testNS.WithLabel(key, value)
+	}
+
+	_, err := testNS.Create()
+	Expect(err).ToNot(HaveOccurred(), "error to create test namespace")
+
+	By("Verifying if accelerator tests can be executed on given cluster")
+	err = accenv.DoesClusterSupportAcceleratorTests(APIClient, NetConfig)
+	Expect(err).ToNot(HaveOccurred(), "Cluster doesn't support accelerator test cases")
+})
+
+var _ = AfterSuite(func() {
+	By("Deleting test namespace")
+	err := testNS.DeleteAndWait(tsparams.WaitTimeout)
+	Expect(err).ToNot(HaveOccurred(), "Fail to delete test namespace")
+})
+
+var _ = JustAfterEach(func() {
+	reporter.ReportIfFailed(
+		CurrentSpecReport(), currentFile, tsparams.ReporterNamespacesToDump, tsparams.ReporterCRDsToDump)
+})
+
+var _ = ReportAfterSuite("", func(report Report) {
+	reportxml.Create(report, NetConfig.GetReportPath(), NetConfig.TCPrefix)
+})

--- a/tests/cnf/core/network/acc/internal/accenv/accenv.go
+++ b/tests/cnf/core/network/acc/internal/accenv/accenv.go
@@ -1,0 +1,22 @@
+package accenv
+
+import (
+	"github.com/golang/glog"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netconfig"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netenv"
+)
+
+// DoesClusterSupportAcceleratorTests verifies if given cluster supports accelerator workload and test cases.
+func DoesClusterSupportAcceleratorTests(
+	apiClient *clients.Settings, netConfig *netconfig.NetworkConfig) error {
+	glog.V(90).Infof("Verifying if cluster supports accelerator tests")
+
+	err := netenv.DoesClusterHasEnoughNodes(apiClient, netConfig, 1, 2)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/tests/cnf/core/network/acc/internal/tsparams/accvars.go
+++ b/tests/cnf/core/network/acc/internal/tsparams/accvars.go
@@ -1,0 +1,42 @@
+package tsparams
+
+import (
+	"time"
+
+	"github.com/openshift-kni/k8sreporter"
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	performanceprofileV2 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v2"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netparam"
+)
+
+var (
+	// Labels represents the range of labels that can be used for test cases selection.
+	Labels = append(netparam.Labels, LabelSuite)
+	// WaitTimeout represents timeout for the most ginkgo Eventually functions.
+	WaitTimeout = 3 * time.Minute
+	// RetryInterval represents retry interval for the most ginkgo Eventually functions.
+	RetryInterval = 3 * time.Second
+	// MCOWaitTimeout represent timeout for mco operations.
+	MCOWaitTimeout = 60 * time.Minute
+	// ReporterCRDsToDump tells to the reporter what CRs to dump.
+	ReporterCRDsToDump = []k8sreporter.CRData{
+		{Cr: &performanceprofileV2.PerformanceProfileList{}},
+		{Cr: &mcfgv1.MachineConfigPoolList{}},
+	}
+	// OperatorNamespace represents the namespace of the fec operator.
+	OperatorNamespace = "vran-acceleration-operators"
+	// DaemonsetNames represents the names of the daemonsets to check for fec operator.
+	DaemonsetNames = []string{"accelerator-discovery", "sriov-device-plugin", "sriov-fec-daemonset"}
+	// ReporterNamespacesToDump tells to the reporter from where to collect logs.
+	ReporterNamespacesToDump = map[string]string{
+		"openshift-performance-addon-operator": "performance",
+		TestNamespaceName:                      "other",
+	}
+)
+
+// VFIOToken represents the vfiotoken struct.
+type VFIOToken struct {
+	Extra struct {
+		VfioToken string `json:"VFIO_TOKEN"`
+	} `json:"extra"`
+}

--- a/tests/cnf/core/network/acc/internal/tsparams/consts.go
+++ b/tests/cnf/core/network/acc/internal/tsparams/consts.go
@@ -1,0 +1,16 @@
+package tsparams
+
+const (
+	// LabelSuite represents acc label that can be used for test cases selection.
+	LabelSuite = "accelerator"
+	// TestNamespaceName acc namespace where all test cases are performed.
+	TestNamespaceName = "acc-tests"
+	// Acc100DeviceID represents the device id of the acc100.
+	Acc100DeviceID = "0d5c"
+	// Acc100ResourceName represents the resource name of the acc100.
+	Acc100ResourceName = "intel.com/intel_fec_acc100"
+	// TotalNumberBbdevTests represents the total number of bbdev tests.
+	TotalNumberBbdevTests = 31
+	// ExpectedNumberBbdevTestsPassed represents the expected number of bbdev tests passed.
+	ExpectedNumberBbdevTestsPassed = 27
+)

--- a/tests/cnf/core/network/acc/tests/accelerator.go
+++ b/tests/cnf/core/network/acc/tests/accelerator.go
@@ -1,0 +1,395 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nodes"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/fec/fectypes"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netenv"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/ptr"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/daemonset"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/deployment"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
+	sriovfec "github.com/rh-ecosystem-edge/eco-goinfra/pkg/sriov-fec"
+
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/acc/internal/tsparams"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netinittools"
+)
+
+var _ = Describe("Intel Accelerator 100", Ordered, Label(tsparams.LabelSuite), ContinueOnFailure, func() {
+
+	var (
+		sfnc        *sriovfec.NodeConfigBuilder
+		accelerator *fectypes.SriovAccelerator
+		secureBoot  bool
+	)
+
+	BeforeAll(func() {
+		By("Checking if operator is installed and has required resources")
+		fecDeploy, err := deployment.Pull(APIClient, "sriov-fec-controller-manager", tsparams.OperatorNamespace)
+		if err != nil && err.Error() == "no matches for kind \"SriovFecNodeConfig\" in version \"sriovfec.intel.com/v1\"" {
+			Skip("Cluster does not have operator installed")
+		}
+		Expect(err).ToNot(HaveOccurred(), "Failed to pull SriovFecOperator")
+		Expect(fecDeploy.IsReady(2*time.Minute)).To(BeTrue(), "SriovFecOperator is not ready")
+
+		By("Checking if node config exists")
+		sfncList, err := sriovfec.List(APIClient, tsparams.OperatorNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Failed to list SriovFecNodeConfig")
+		if len(sfncList) == 0 {
+			Skip("No SriovFecNodeConfig found")
+		}
+
+		By("Checking if all damensets are present and ready")
+		for _, dsName := range tsparams.DaemonsetNames {
+			ds, err := daemonset.Pull(APIClient, dsName, tsparams.OperatorNamespace)
+			Expect(err).ToNot(HaveOccurred(), "Failed to pull %s", dsName)
+			Expect(ds.IsReady(2*time.Minute)).To(BeTrue(), "%s is not ready", dsName)
+		}
+
+		secureBoot = isSecureBootEnabled()
+
+		By("Deploying PerformanceProfile if it's not installed")
+		err = netenv.DeployPerformanceProfile(
+			APIClient,
+			NetConfig,
+			"performance-profile-dpdk",
+			"1,3,5,7,9,11,13,15,17,19,21,23,25",
+			"0,2,4,6,8,10,12,14,16,18,20",
+			24)
+		Expect(err).ToNot(HaveOccurred(), "Fail to deploy PerformanceProfile")
+
+		By("Checking if the cluster has ACC100 cards")
+		sfnc, accelerator, err = getNodeConfigWithAccCard(tsparams.Acc100DeviceID)
+		if err != nil {
+			Skip(fmt.Sprintf("Cluster does not have ACC100 cards: %s", err.Error()))
+		}
+
+		By("Deleting SriovFecClusterConfig if any present in the cluster")
+		sfccList, err := sriovfec.ListClusterConfig(APIClient, tsparams.OperatorNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Failed to list SriovFecClusterConfig")
+		if len(sfccList) != 0 {
+			for _, sfcc := range sfccList {
+				_, err := sfcc.Delete()
+				Expect(err).ToNot(HaveOccurred(), "Failed to delete SriovFecClusterConfig")
+			}
+		}
+
+		By("Creating SriovFecClusterConfig")
+		_, err = defineFecClusterConfig(accelerator.PCIAddress, sfnc.Object.Name, secureBoot).Create()
+		Expect(err).ToNot(HaveOccurred(), "Failed to create SriovFecClusterConfig")
+
+		err = waitForNodeConfigToSucceed()
+		Expect(err).ToNot(HaveOccurred(), "SriovFecNodeConfig never succeeded")
+	})
+
+	AfterAll(func() {
+		By("Deleting SriovFecClusterConfig in the cluster")
+		sfccList, err := sriovfec.ListClusterConfig(APIClient, tsparams.OperatorNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Failed to list SriovFecClusterConfig")
+		if len(sfccList) != 0 {
+			for _, sfcc := range sfccList {
+				_, err := sfcc.Delete()
+				Expect(err).ToNot(HaveOccurred(), "Failed to delete SriovFecClusterConfig")
+			}
+		}
+	})
+
+	It("node should show acc100 resource", func() {
+		Eventually(getNodeResource, 10*time.Minute, time.Second).
+			WithArguments(sfnc.Object.Name, tsparams.Acc100ResourceName).To(BeNumerically(">", 0))
+	})
+
+	It("validation of acc100 resource", func() {
+		Eventually(getNodeResource, 10*time.Minute, time.Second).
+			WithArguments(sfnc.Object.Name, tsparams.Acc100ResourceName).To(BeNumerically(">", 0))
+
+		By("Creating bbdev test pod")
+		bbdevContainer, err := pod.NewContainerBuilder(
+			"bbdev", NetConfig.CnfNetTestContainer, []string{"bash", "-c", "sleep infinity"}).
+			WithSecurityContext(&corev1.SecurityContext{
+				Privileged:   ptr.To(false),
+				RunAsUser:    ptr.To(int64(0)),
+				Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"IPC_LOCK", "SYS_RESOURCE"}},
+			}).
+			WithCustomResourcesLimits(corev1.ResourceList{
+				"hugepages-1Gi":             resource.MustParse("1Gi"),
+				"memory":                    resource.MustParse("1Gi"),
+				"cpu":                       *resource.NewQuantity(4, resource.DecimalSI),
+				tsparams.Acc100ResourceName: resource.MustParse("1"),
+			}).
+			WithCustomResourcesRequests(corev1.ResourceList{
+				"hugepages-1Gi":             resource.MustParse("1Gi"),
+				"memory":                    resource.MustParse("1Gi"),
+				"cpu":                       *resource.NewQuantity(4, resource.DecimalSI),
+				tsparams.Acc100ResourceName: resource.MustParse("1"),
+			}).
+			GetContainerCfg()
+		Expect(err).ToNot(HaveOccurred(), "Failed to get container configuration")
+
+		bbdevPod, err := pod.NewBuilder(APIClient, "bbdev-test", tsparams.TestNamespaceName, NetConfig.CnfNetTestContainer).
+			RedefineDefaultContainer(*bbdevContainer).
+			DefineOnNode(sfnc.Object.Name).
+			WithHugePages().
+			CreateAndWaitUntilRunning(2 * time.Minute)
+		Expect(err).ToNot(HaveOccurred(), "Failed to create bbdev test pod")
+
+		By("Running bbdev tests")
+		bbdevTestsOutput := RunBbdevTests(bbdevPod, secureBoot)
+		Expect(bbdevTestsOutput).ToNot(BeEmpty(), "Failed to run bbdev tests")
+
+		By("Checking if bbdev tests executed")
+
+		countOfTests := countLinesByPatterns(bbdevTestsOutput, "Starting Test Suite :")
+		countOfPassed := countLinesByPatterns(bbdevTestsOutput, "Tests Passed", "1")
+
+		Expect(countOfTests).To(Equal(tsparams.TotalNumberBbdevTests), "Not all test have been executed")
+		Expect(countOfPassed).To(Equal(tsparams.ExpectedNumberBbdevTestsPassed), "Not all expected tests passed")
+
+		Expect(isBbdevFailedTests(bbdevTestsOutput)).To(BeFalse(),
+			fmt.Sprintf("There are failed tests.\n %s", bbdevTestsOutput))
+	})
+})
+
+func getNodeResource(nodeName, resName string) (int64, error) {
+	testNode, err := nodes.Pull(APIClient, nodeName)
+	if err != nil {
+		return 0, err
+	}
+
+	quantity, exists := testNode.Object.Status.Allocatable[corev1.ResourceName(resName)]
+
+	if !exists {
+		return 0, fmt.Errorf("resource %s is not available", resName)
+	}
+
+	quantityInt, _ := quantity.AsInt64()
+
+	return quantityInt, nil
+}
+
+func isSecureBootEnabled() bool {
+	workernodeList, err := nodes.List(APIClient, metav1.ListOptions{LabelSelector: NetConfig.WorkerLabel})
+	Expect(err).ToNot(HaveOccurred(), "Failed to list worker nodes")
+	Expect(len(workernodeList)).To(BeNumerically(">=", 1), "Worker node list length must be > 1")
+
+	By("Creating test pod")
+
+	testcontainer, err := pod.NewContainerBuilder(
+		"testcontainer", NetConfig.CnfNetTestContainer, []string{"sleep", "infinity"}).
+		WithVolumeMount(corev1.VolumeMount{Name: "host", MountPath: "/host", ReadOnly: false}).
+		WithSecurityContext(&corev1.SecurityContext{
+			Privileged:   ptr.To(true),
+			RunAsUser:    ptr.To(int64(0)),
+			Capabilities: &corev1.Capabilities{Add: []corev1.Capability{"IPC_LOCK", "SYS_RESOURCE", "SYS_ADMIN"}},
+		}).
+		GetContainerCfg()
+	Expect(err).ToNot(HaveOccurred(), "Failed to get container configuration")
+
+	testPod, err := pod.NewBuilder(
+		APIClient, "testpod1", tsparams.TestNamespaceName, NetConfig.CnfNetTestContainer).
+		WithVolume(
+			corev1.Volume{Name: "host", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/"}}}).
+		DefineOnNode(workernodeList[0].Object.Name).
+		RedefineDefaultContainer(*testcontainer).
+		CreateAndWaitUntilRunning(2 * time.Minute)
+	Expect(err).ToNot(HaveOccurred(), "Failed to create test pod")
+
+	output, err := testPod.ExecCommand([]string{"cat", "/host/sys/kernel/security/lockdown"})
+	fmt.Println(output.String())
+	Expect(err).ToNot(HaveOccurred(), "Failed to get /host/sys/kernel/security/lockdown")
+
+	if strings.Contains(output.String(), "No such file or directory") || err != nil {
+		return false
+	}
+
+	By("Deleting test pod")
+
+	_, err = testPod.DeleteAndWait(2 * time.Minute)
+	Expect(err).ToNot(HaveOccurred(), "Failed to delete test pod")
+
+	return strings.Contains(output.String(), "[integrity]") || strings.Contains(output.String(),
+		"[confidentiality]")
+}
+
+func getNodeConfigWithAccCard(devID string) (*sriovfec.NodeConfigBuilder, *fectypes.SriovAccelerator, error) {
+	sfncList, err := sriovfec.List(APIClient, tsparams.OperatorNamespace)
+	Expect(err).ToNot(HaveOccurred(), "Failed to list SriovFecNodeConfig")
+
+	for _, sfnc := range sfncList {
+		for _, accelerator := range sfnc.Object.Status.Inventory.SriovAccelerators {
+			if accelerator.DeviceID == devID {
+				return sfnc, &accelerator, nil
+			}
+		}
+	}
+
+	return nil, nil, fmt.Errorf("cluster doesn`t have sriovfecnodeconfig with accelerator id %s", devID)
+}
+
+func defineFecClusterConfig(pciAddress, nodeName string, secureBoot bool) *sriovfec.ClusterConfigBuilder {
+	queueGroupConfig := fectypes.QueueGroupConfig{
+		AqDepthLog2:     4,
+		NumAqsPerGroups: 16,
+		NumQueueGroups:  2,
+	}
+
+	pfDriverType := "pci-pf-stub"
+
+	if secureBoot {
+		pfDriverType = "vfio-pci"
+	}
+
+	sfccBuilder := sriovfec.NewClusterConfigBuilder(APIClient, "config", tsparams.OperatorNamespace)
+
+	sfccBuilder.Definition.Spec = fectypes.SriovFecClusterConfigSpec{
+		Priority: 1,
+		NodeSelector: map[string]string{
+			"kubernetes.io/hostname": nodeName,
+		},
+		AcceleratorSelector: fectypes.AcceleratorSelector{
+			PCIAddress: pciAddress,
+		},
+		PhysicalFunction: fectypes.PhysicalFunctionConfig{
+			PFDriver: pfDriverType,
+			VFAmount: 2,
+			VFDriver: "vfio-pci",
+			BBDevConfig: fectypes.BBDevConfig{
+				ACC100: &fectypes.ACC100BBDevConfig{
+					Downlink4G:   queueGroupConfig,
+					Downlink5G:   queueGroupConfig,
+					Uplink4G:     queueGroupConfig,
+					Uplink5G:     queueGroupConfig,
+					PFMode:       false,
+					MaxQueueSize: 1024,
+					NumVfBundles: 2,
+				},
+			},
+		},
+	}
+
+	return sfccBuilder
+}
+
+func waitForNodeConfigToSucceed() error {
+	return wait.PollUntilContextTimeout(
+		context.TODO(), 3*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+			sfncList, err := sriovfec.List(APIClient, tsparams.OperatorNamespace)
+			if err != nil {
+				return false, nil
+			}
+
+			for _, sfnc := range sfncList {
+				for _, condition := range sfnc.Object.Status.Conditions {
+					if condition.Reason == "Succeeded" {
+						return true, nil
+					}
+				}
+			}
+
+			return false, nil
+		})
+}
+
+// RunBbdevTests executes bbdev tests in bbdev pod.
+func RunBbdevTests(bbdevPod *pod.Builder, isSecureEnabled bool) string {
+	printEnvCommand := []string{"bash", "-c", "printenv | grep INTEL"}
+
+	if isSecureEnabled {
+		printEnvCommand = []string{"bash", "-c", "printenv | grep INTEL | grep -v INFO"}
+	}
+
+	pcideviceIntelComIntelFec5GBuff, err := bbdevPod.ExecCommand(printEnvCommand)
+	Expect(err).NotTo(HaveOccurred(), "Failed to execute printenv command")
+
+	pcideviceIntelComIntelFec5GString := strings.TrimSpace(
+		strings.Split(pcideviceIntelComIntelFec5GBuff.String(), "=")[1])
+
+	testCommand := fmt.Sprintf("/usr/bbdev/test-bbdev.py"+
+		" -e \"-w %v -d /usr/bbdev/\"  -c validation"+
+		" -p /usr/bbdev/dpdk-test-bbdev"+
+		" -n 64 -b 8"+
+		" -v /usr/bbdev/test_vectors/*", pcideviceIntelComIntelFec5GString)
+
+	if isSecureEnabled {
+		token, err := getVFIOToken(bbdevPod, pcideviceIntelComIntelFec5GString)
+		Expect(err).NotTo(HaveOccurred(), "Failed to get vfio-token")
+
+		testCommand = fmt.Sprintf("/usr/bbdev/test-bbdev.py"+
+			" -e \"-w %v --vfio-vf-token %s -d /usr/bbdev/\"  -c validation"+
+			" -p /usr/bbdev/dpdk-test-bbdev"+
+			" -n 64 -b 8 "+
+			" -v /usr/bbdev/test_vectors/*", pcideviceIntelComIntelFec5GString, token)
+	}
+
+	bbdevTestsOutput, err := bbdevPod.ExecCommand([]string{"bash", "-c", testCommand})
+	Expect(err).NotTo(HaveOccurred(), "Failed to execute test command")
+
+	return bbdevTestsOutput.String()
+}
+
+// getVFIOToken returns the vfio-token.
+func getVFIOToken(bbdevPod *pod.Builder, pci string) (string, error) {
+	vfioTokenJSONBuff, err := bbdevPod.ExecCommand([]string{"bash", "-c", "printenv | grep INFO"})
+
+	if err != nil {
+		return "", err
+	}
+
+	vfioTokenJSONString := strings.TrimSpace(strings.Split(vfioTokenJSONBuff.String(), "=")[1])
+	result := map[string]tsparams.VFIOToken{}
+
+	err = json.Unmarshal([]byte(vfioTokenJSONString), &result)
+
+	if err != nil {
+		return "", err
+	}
+
+	return result[pci].Extra.VfioToken, nil
+}
+
+// countLinesByPatterns counts lines matching specific patterns in bbdev test output.
+func countLinesByPatterns(str string, stringsToGrep ...string) int {
+	count := 0
+	exists := false
+
+	for _, line := range strings.Split(str, "\n") {
+		for _, grep := range stringsToGrep {
+			if !strings.Contains(line, grep) {
+				exists = false
+
+				break
+			}
+
+			exists = true
+		}
+
+		if exists {
+			count++
+		}
+	}
+
+	return count
+}
+
+// isBbdevFailedTests  checks if  any  bbdev test has failed.
+func isBbdevFailedTests(str string) bool {
+	for _, line := range strings.Split(str, "\n") {
+		if strings.Contains(line, "Tests Failed") && !strings.Contains(line, "0") {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Tests
  * Added a public accelerator end-to-end test suite with a dedicated test entry point and full lifecycle hooks.
  * Validates cluster capability for accelerator tests before running.
  * Automatically detects accelerator hardware, verifies operator/daemonset readiness, and handles secure‑boot.
  * Creates and tears down an isolated test namespace with labels and timeouts.
  * Adds configurable test parameters, expected counts, and token handling for BBDEV runs.
  * Provisions BBDEV workloads, validates results, produces JUnit reports, and collects logs/CRDs for troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->