### PR TITLE
system-tests: Whereabouts tests for node drain scenario

### DIFF
--- a/tests/system-tests/rdscore/tests/00_validate_top_level.go
+++ b/tests/system-tests/rdscore/tests/00_validate_top_level.go
@@ -301,6 +301,16 @@ var _ = Describe(
 				reportxml.ID("82740"),
 				rdscorecommon.VerifyWhereaboutsInterDeploymentPodCommunicationOnDifferentNodesAfterPodTermination)
 
+			It("Verify Whereabouts Deployment on different nodes after node drain",
+				Label("whereabouts", "whereabouts-deployment-different-nodes-drain", "whereabouts-deployment"),
+				reportxml.ID("82743"),
+				rdscorecommon.VerifyWhereaboutsInterDeploymentPodCommunicationOnDifferentNodesAfterNodeDrain)
+
+			It("Verify Whereabouts Deployment on the same node after node drain",
+				Label("whereabouts", "whereabouts-deployment-same-node-drain", "whereabouts-deployment"),
+				reportxml.ID("82744"),
+				rdscorecommon.VerifyWhereaboutsInterDeploymentPodCommunicationOnTheSameNodeAfterNodeDrain)
+
 			AfterEach(func(ctx SpecContext) {
 				By("Ensure rootless DPDK server deployment was deleted")
 				rdscorecommon.CleanupRootlessDPDKServerDeployment()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end scenarios validating whereabouts deployments during node drain events for pods colocated on the same node and on different nodes.
  * Extended public test surface with node-drain variants exercising node selection, cordon/drain operations, recovery, and post-drain inter-deployment connectivity checks.
  * Verifies pods are rescheduled off drained nodes and connectivity is preserved after drain; top-level suite includes two labeled test cases and AfterEach now ensures nodes are Ready and schedulable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->