### PR TITLE
global: change args to come before dirs in test runner

### DIFF
--- a/scripts/test-runner.sh
+++ b/scripts/test-runner.sh
@@ -52,7 +52,7 @@ fi
 if [[ ! -z "${ECO_TEST_LABELS}" ]]; then
     cmd+=" --label-filter=\"${ECO_TEST_LABELS}\""
 fi
-cmd+=" "$feature_dirs" $@"   # + user args --xxx=yyy...
+cmd+=" $@ $feature_dirs"   # add user args before feature dirs
 
 # Execute ginkgo command
 echo $cmd


### PR DESCRIPTION
Ginkgo v2.23.1 started emitting an error and exiting whenever flags were provided after the directory. Since the test-runner.sh script has always erroneously added them after the directory argument, it now fails. This PR corrects the issue by moving the extra arguments to the test-runner script to come before the feature directories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Test runner argument ordering adjusted so user-provided CLI options are applied before feature directories, ensuring flags/filters take effect as intended and avoiding positional-argument conflicts. This yields more predictable test execution locally and in CI without altering other behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->