### PR TITLE
system-tests: tests for Whereabouts for reboot and poweroff scenarios…

### DIFF
--- a/tests/system-tests/rdscore/tests/00_validate_top_level.go
+++ b/tests/system-tests/rdscore/tests/00_validate_top_level.go
@@ -311,6 +311,16 @@ var _ = Describe(
 				reportxml.ID("82744"),
 				rdscorecommon.VerifyWhereaboutsInterDeploymentPodCommunicationOnTheSameNodeAfterNodeDrain)
 
+			It("Verify Whereabouts Deployment on different nodes after node power off",
+				Label("whereabouts", "whereabouts-deployment-different-nodes-power-off", "whereabouts-deployment"),
+				reportxml.ID("82909"),
+				rdscorecommon.VerifyWhereaboutsInterDeploymentPodCommunicationOnDifferentNodesAfterNodePowerOff)
+
+			It("Verify Whereabouts Deployment on the same node after node power off",
+				Label("whereabouts", "whereabouts-deployment-same-node-power-off", "whereabouts-deployment"),
+				reportxml.ID("82910"),
+				rdscorecommon.VerifyWhereaboutsInterDeploymentPodCommunicationOnTheSameNodeAfterNodePowerOff)
+
 			AfterEach(func(ctx SpecContext) {
 				By("Ensure rootless DPDK server deployment was deleted")
 				rdscorecommon.CleanupRootlessDPDKServerDeployment()
@@ -363,6 +373,12 @@ var _ = Describe(
 
 				By("Creating Whereabouts Statefulset on different nodes")
 				rdscorecommon.CreateStatefulsetOnDifferentNode(ctx)
+
+				By("Creating Whereabouts Deployment on the same node")
+				rdscorecommon.VerifyWhereaboutsInterDeploymentPodCommunicationOnTheSameNode(ctx)
+
+				By("Creating Whereabouts Deployment on different nodes")
+				rdscorecommon.VerifyWhereaboutsInterDeploymentPodCommunicationOnDifferentNodes(ctx)
 			})
 
 			It("Setups EgressService with Cluster ExternalTrafficPolicy",
@@ -628,6 +644,16 @@ var _ = Describe(
 				reportxml.ID("82920"),
 				rdscorecommon.ValidatePodConnectivityBetweenDifferentNodesAfterClusterReboot)
 
+			It("Verifies connectivity between pods from deployment scheduled on the same node post hard reboot",
+				Label("whereabouts", "deployment-whereabouts", "deployment-same-node-validate"),
+				reportxml.ID("82735"),
+				rdscorecommon.VerifyPodCommunicationOnSameNodeAfterClusterReboot)
+
+			It("Verifies connectivity between pods from deployment scheduled on different nodes post hard reboot",
+				Label("whereabouts", "deployment-whereabouts", "deployment-different-nodes-validate"),
+				reportxml.ID("82734"),
+				rdscorecommon.VerifyPodCommunicationOnDifferentNodesAfterClusterReboot)
+
 			AfterEach(func(ctx SpecContext) {
 				By("Ensure rootless DPDK server deployment was deleted")
 				rdscorecommon.CleanupRootlessDPDKServerDeployment()
@@ -677,6 +703,12 @@ var _ = Describe(
 
 				By("Creating Whereabouts Statefulset on different nodes")
 				rdscorecommon.CreateStatefulsetOnDifferentNode(ctx)
+
+				By("Creating Whereabouts Deployment on the same node")
+				rdscorecommon.VerifyWhereaboutsInterDeploymentPodCommunicationOnTheSameNode(ctx)
+
+				By("Creating Whereabouts Deployment on different nodes")
+				rdscorecommon.VerifyWhereaboutsInterDeploymentPodCommunicationOnDifferentNodes(ctx)
 			})
 
 			It("Setups EgressService with Cluster ExternalTrafficPolicy",
@@ -908,6 +940,16 @@ var _ = Describe(
 				Label("statefulset-whereabouts", "statefulset-different-nodes-validate"),
 				reportxml.ID("82918"),
 				rdscorecommon.ValidatePodConnectivityBetweenDifferentNodesAfterClusterReboot)
+
+			It("Verifies connectivity between pods from deployment scheduled on the same node post soft reboot",
+				Label("whereabouts", "deployment-whereabouts", "deployment-same-node-validate"),
+				reportxml.ID("82737"),
+				rdscorecommon.VerifyPodCommunicationOnSameNodeAfterClusterReboot)
+
+			It("Verifies connectivity between pods from deployment scheduled on different nodes post soft reboot",
+				Label("whereabouts", "deployment-whereabouts", "deployment-different-nodes-validate"),
+				reportxml.ID("82736"),
+				rdscorecommon.VerifyPodCommunicationOnDifferentNodesAfterClusterReboot)
 
 			AfterEach(func(ctx SpecContext) {
 				By("Ensure rootless DPDK server deployment was deleted")


### PR DESCRIPTION
…. (#812)

* system-tests: VerifyConnectivityAfterNodePowerOff function added
* system-tests: configureSameNodeDeployments function added
* system-tests: configureDifferentNodeDeployments function added
* system-tests: Whereabouts tests for powered off node scenario
* system-tests: Whereabouts updated getActivePods to skip pods marked for deletion
* system-tests: updated waitForPodsToBeMarkedForDeletionOrDeleted func
* system-tests: close channel in powerOnNodeWaitReady function

(cherry picked from commit 6099de16b18cc5b5e5ac42ca50771e5e4aa9ca21)