### PR TITLE
system-tests: moved uncordonNode to a dedicated file

### DIFF
--- a/tests/system-tests/rdscore/internal/rdscorecommon/hard-reboot.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/hard-reboot.go
@@ -207,6 +207,9 @@ func VerifySoftReboot(ctx SpecContext) {
 		err := _node.Cordon()
 		Expect(err).ToNot(HaveOccurred(),
 			fmt.Sprintf("Failed to cordon %q due to %v", _node.Definition.Name, err))
+
+		defer UncordonNode(_node, uncordonNodeInterval, uncordonNodeTimeout)
+
 		time.Sleep(5 * time.Second)
 
 		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Draining node %q", _node.Definition.Name)

--- a/tests/system-tests/rdscore/internal/rdscorecommon/rdscore-helpers.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/rdscore-helpers.go
@@ -1,0 +1,45 @@
+package rdscorecommon
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+
+	"github.com/golang/glog"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nodes"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/system-tests/rdscore/internal/rdscoreparams"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	uncordonNodeInterval = 15 * time.Second
+	uncordonNodeTimeout  = 3 * time.Minute
+)
+
+// UncordonNode uncordons a node referenced by nodeToUncordon parameter.
+// It retries uncordoning for the specified timeout duration at regular intervals.
+func UncordonNode(nodeToUncordon *nodes.Builder, interval, timeout time.Duration) {
+	By(fmt.Sprintf("Uncordoning node %q", nodeToUncordon.Definition.Name))
+
+	err := wait.PollUntilContextTimeout(context.TODO(), interval, timeout, true,
+		func(context.Context) (bool, error) {
+			err := nodeToUncordon.Uncordon()
+
+			if err != nil {
+				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to uncordon %q: %v", nodeToUncordon.Definition.Name, err)
+
+				return false, nil
+			}
+
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Successfully uncordon %q", nodeToUncordon.Definition.Name)
+
+			return err == nil, nil
+		})
+
+	if err != nil {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to uncordon %q: %v", nodeToUncordon.Definition.Name, err)
+	}
+}

--- a/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-deployment.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-deployment.go
@@ -845,7 +845,7 @@ func VerifyConnectivityAfterNodeDrain(
 	Expect(err).ToNot(HaveOccurred(),
 		fmt.Sprintf("Failed to cordon node %s due to: %v", nodeToDrain, err))
 
-	defer uncordonNode(nodeObj, 15*time.Second, 3*time.Minute)
+	defer UncordonNode(nodeObj, uncordonNodeInterval, uncordonNodeTimeout)
 
 	By(fmt.Sprintf("Draining node %q", nodeToDrain))
 

--- a/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-statefulset.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-statefulset.go
@@ -533,7 +533,7 @@ func ensurePodConnectivityAfterNodeDrain(stLabel, namespace, targetPort string, 
 	Expect(err).ToNot(HaveOccurred(),
 		fmt.Sprintf("Failed to cordon node %s due to: %v", nodeToDrain, err))
 
-	defer uncordonNode(nodeObj, 15*time.Second, 3*time.Minute)
+	defer UncordonNode(nodeObj, uncordonNodeInterval, uncordonNodeTimeout)
 
 	By(fmt.Sprintf("Draining node %q", nodeToDrain))
 
@@ -593,29 +593,6 @@ func ensurePodConnectivityAfterNodeDrain(stLabel, namespace, targetPort string, 
 		fmt.Sprintf("Failed to parse port number: %v", targetPort))
 
 	VerifyPodConnectivity(stLabel, namespace, interfaceName, parsedPort)
-}
-
-func uncordonNode(nodeToUncordon *nodes.Builder, interval, timeout time.Duration) {
-	By(fmt.Sprintf("Uncordoning node %q", nodeToUncordon.Definition.Name))
-
-	err := wait.PollUntilContextTimeout(context.TODO(), interval, timeout, true,
-		func(context.Context) (bool, error) {
-			err := nodeToUncordon.Uncordon()
-
-			if err != nil {
-				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to uncordon %q: %v", nodeToUncordon.Definition.Name, err)
-
-				return false, nil
-			}
-
-			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Successfully uncordon %q", nodeToUncordon.Definition.Name)
-
-			return err == nil, nil
-		})
-
-	if err != nil {
-		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to uncordon %q: %v", nodeToUncordon.Definition.Name, err)
-	}
 }
 
 func powerOnNodeWaitReady(bmcClient *bmc.BMC, nodeToPowerOff string, stopCh chan bool) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Improved system test stability by introducing a standardized, retry-capable node uncordon helper with configurable polling interval and timeout.
  - Automatically schedules node uncordon cleanup after cordon operations in reboot and networking tests, reducing flakiness and ensuring cleanup even for multiple nodes.
  - Consolidated uncordon behavior across test suites for consistency.
  - No changes to product behavior or user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->