### PR TITLE
cnf network: fix tcpdump command

### DIFF
--- a/tests/cnf/core/network/sriov/tests/allmulti.go
+++ b/tests/cnf/core/network/sriov/tests/allmulti.go
@@ -62,8 +62,8 @@ var (
 		"ping -I net1 ff05:5::05"}
 	multicastPingDualNet1Net2StackCMD = []string{"bash", "-c", "sleep 5; ping -I net1 239.100.100.250 & " +
 		"ping -I net1 ff05:5::05 & ping -I net2 239.100.100.250 & ping -I net2 ff05:5::05"}
-	tcpDumpCMD           = []string{"bash", "-c", "tcpdump -i net1 -c 10"}
-	tcpDumpCMDNet2       = []string{"bash", "-c", "tcpdump -i net2 -c 10"}
+	tcpDumpCMD           = []string{"bash", "-c", "timeout 2m tcpdump -i net1 -c 10"}
+	tcpDumpCMDNet2       = []string{"bash", "-c", "timeout 2m tcpdump -i net2 -c 10"}
 	addIPv6MCGroupMacCMD = []string{"bash", "-c", "ip maddr add 33:33:0:0:0:5 dev net1"}
 	addIPv4MCGroupMacCMD = []string{"bash", "-c", "ip maddr add 01:00:5e:64:64:fa dev net1"}
 )


### PR DESCRIPTION
In some failure scenarios, tcpdump command waits forever to capture packets. Instead the command should be terminated if the required packets are not captured within specific time

Ref:
https://jenkins-csb-kniqe-auto.dno.corp.redhat.com/job/ocp-eco-gotests/4253/console


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Wrapped packet-capture commands in a 2-minute timeout within SR-IOV network tests to prevent hangs and excessively long runs.
  * Improves test reliability, reduces flakiness, and stabilizes CI execution times.
  * Constrains capture duration to keep logs manageable and speeds up failure diagnosis.
  * No impact on application behavior or user-facing features; only affects internal test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->