### PR TITLE
cnf ran: add support for o-ran security

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -97,6 +97,7 @@ linters:
             - github.com/prometheus/alertmanager
             - github.com/go-openapi/runtime
             - github.com/go-openapi/strfmt
+            - golang.org/x/oauth2
           deny:
             - pkg: github.com/onsi**
     funlen:

--- a/go.mod
+++ b/go.mod
@@ -244,7 +244,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	go4.org v0.0.0-20230225012048-214862532bf5 // indirect
 	golang.org/x/net v0.42.0 // indirect
-	golang.org/x/oauth2 v0.30.0 // indirect
+	golang.org/x/oauth2 v0.30.0
 	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/sys v0.34.0 // indirect
 	golang.org/x/term v0.33.0 // indirect

--- a/tests/cnf/ran/internal/ranconfig/config.go
+++ b/tests/cnf/ran/internal/ranconfig/config.go
@@ -1,6 +1,7 @@
 package ranconfig
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -50,8 +51,40 @@ type HubConfig struct {
 	ZTPVersion          string
 	HubOperatorVersions map[ranparam.HubOperatorName]string
 	HubKubeconfig       string `envconfig:"ECO_CNF_RAN_KUBECONFIG_HUB"`
-	O2IMSBaseURL        string `envconfig:"ECO_CNF_RAN_O2IMS_BASE_URL"`
-	O2IMSToken          string `envconfig:"ECO_CNF_RAN_O2IMS_TOKEN"`
+
+	// HubAppsDomain is the subdomain for the hub cluster's routes. It should be
+	// apps.<hub-cluster-name>.<hub-cluster-domain> with no leading or trailing dots.
+	//
+	// When running the O-RAN suite, it is assumed that the OAuth endpoint is at keycloak.<hub-apps-domain> and the
+	// O2IMS API is at o2ims.<hub-apps-domain>.
+	HubAppsDomain string `envconfig:"ECO_CNF_RAN_HUB_APPS_DOMAIN"`
+
+	// O2IMSClientCertSecret is the name of the secret in the O2IMSClientCertSecretNamespace namespace that contains
+	// the client certificate to use when interacting with the O2IMS and OAuth APIs.
+	//
+	// It is expected that the secret contains 3 different keys: tls.crt, tls.key, and ca.crt (optional). The
+	// tls.crt and tls.key are used for mTLS and certificate-bound tokens (RFC 8705). If the ca.crt is present, it
+	// is added as a CA certificate when interacting with the O2IMS and OAuth APIs.
+	O2IMSClientCertSecret string `envconfig:"ECO_CNF_RAN_O2IMS_CLIENT_CERT_SECRET"`
+	// O2IMSClientCertSecretNamespace is the namespace for the O2IMS client certificate secret.
+	O2IMSClientCertSecretNamespace string `envconfig:"ECO_CNF_RAN_O2IMS_CLIENT_CERT_SECRET_NAMESPACE"`
+
+	// O2IMSOAuthClientID is the client ID used to request the access token from the OAuth endpoint using the client
+	// credentials grant type.
+	O2IMSOAuthClientID string `envconfig:"ECO_CNF_RAN_O2IMS_OAUTH_CLIENT_ID"`
+	// O2IMSOAuthClientSecret is a string used to request the access token from the OAuth endpoint using the client
+	// credentials grant type.
+	O2IMSOAuthClientSecret string `envconfig:"ECO_CNF_RAN_O2IMS_OAUTH_CLIENT_SECRET"`
+
+	// O2IMSToken is the token for the O-RAN suite to authenticate with the O2IMS API. It is only used when OAuth is
+	// not configured.
+	O2IMSToken string `envconfig:"ECO_CNF_RAN_O2IMS_TOKEN"`
+}
+
+// GetAppsURL returns the apps URL for the given subdomain. It should end up being in a form similar to
+// <subdomain>.apps.<hub-cluster-name>.<hub-cluster-domain>.
+func (hubConfig *HubConfig) GetAppsURL(subdomain string) string {
+	return fmt.Sprintf("%s.%s", subdomain, hubConfig.HubAppsDomain)
 }
 
 // Spoke1Config contains the configuration for the spoke 1 cluster, which should always be present.

--- a/tests/cnf/ran/internal/ranparam/const.go
+++ b/tests/cnf/ran/internal/ranparam/const.go
@@ -26,6 +26,8 @@ const (
 	OpenshiftGitOpsNamespace = "openshift-gitops"
 	// OpenshiftGitopsRepoServer ocp git repo server.
 	OpenshiftGitopsRepoServer = "openshift-gitops-repo-server"
+	// OCloudOperatorNamespace is the namespace for the O-Cloud operator.
+	OCloudOperatorNamespace = "oran-o2ims"
 	// PtpContainerName is the name of the container in the PTP daemon pod.
 	PtpContainerName = "linuxptp-daemon-container"
 	// PtpDaemonsetLabelSelector is the label selector to find the PTP daemon pod.

--- a/tests/cnf/ran/oran/internal/auth/auth.go
+++ b/tests/cnf/ran/oran/internal/auth/auth.go
@@ -1,0 +1,100 @@
+// Package auth provides functionality for authenticating with the O2IMS API. It assumes that there is a Keycloak
+// instance running in the cluster and that the O2IMS API is accessible via the O2IMS base URL.
+package auth
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+
+	"github.com/golang/glog"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	oranapi "github.com/rh-ecosystem-edge/eco-goinfra/pkg/oran/api"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/secret"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/ranconfig"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/tsparams"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+// oAuthScopes are the OAuth scopes required for the O2IMS API. These are specific to the Keycloak configuration; what
+// is required is that the access token has the o2ims-admin role and the audience is o2ims-client.
+var oAuthScopes = []string{"openid", "roles", "role:o2ims-admin", "o2ims-audience"}
+
+// NewClientBuilderForConfig creates a new ClientBuilder for the O2IMS API using the provided configuration. If the
+// OAuth client id and client secret are not provided, the builder will use the bearer token provided. Otherwise, the
+// builder will attempt to use mTLS and OAuth for authentication and authorization.
+func NewClientBuilderForConfig(config *ranconfig.RANConfig) (*oranapi.ClientBuilder, error) {
+	o2imsBaseURL := "https://" + config.GetAppsURL("o2ims")
+	oAuthURL := "https://" + config.GetAppsURL("keycloak") + "/realms/oran/protocol/openid-connect/token"
+
+	if config.O2IMSOAuthClientID == "" || config.O2IMSOAuthClientSecret == "" {
+		if config.O2IMSToken == "" {
+			glog.V(tsparams.LogLevel).Info("No OAuth credentials or token found for O2IMS API")
+
+			return nil, fmt.Errorf("no OAuth credentials or token found for O2IMS API")
+		}
+
+		clientBuilder := oranapi.NewClientBuilder(o2imsBaseURL).
+			WithToken(config.O2IMSToken).
+			WithTLSConfig(&tls.Config{MinVersion: tls.VersionTLS12, InsecureSkipVerify: true})
+
+		return clientBuilder, nil
+	}
+
+	tlsConfig, err := getTLSConfigFromCertificateSecret(
+		config.HubAPIClient, config.O2IMSClientCertSecret, config.O2IMSClientCertSecretNamespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get TLS config from certificate secret: %w", err)
+	}
+
+	httpClient := &http.Client{Transport: &http.Transport{TLSClientConfig: tlsConfig}}
+	oAuthConfig := clientcredentials.Config{
+		ClientID:     config.O2IMSOAuthClientID,
+		ClientSecret: config.O2IMSOAuthClientSecret,
+		TokenURL:     oAuthURL,
+		Scopes:       oAuthScopes,
+	}
+
+	ctx := context.WithValue(context.TODO(), oauth2.HTTPClient, httpClient)
+	httpClient = oAuthConfig.Client(ctx)
+
+	clientBuilder := oranapi.NewClientBuilder(o2imsBaseURL).
+		WithHTTPClient(httpClient)
+
+	return clientBuilder, nil
+}
+
+func getTLSConfigFromCertificateSecret(
+	hubClient *clients.Settings, certSecretName string, certSecretNamespace string) (*tls.Config, error) {
+	certSecret, err := secret.Pull(hubClient, certSecretName, certSecretNamespace)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(certSecret.Definition.Data["tls.crt"]) == 0 || len(certSecret.Definition.Data["tls.key"]) == 0 {
+		return nil, fmt.Errorf("tls.crt or tls.key not found in certificate secret %q", certSecretName)
+	}
+
+	cert, err := tls.X509KeyPair(certSecret.Definition.Data["tls.crt"], certSecret.Definition.Data["tls.key"])
+	if err != nil {
+		return nil, fmt.Errorf("failed to load client certificate from secret %q: %w", certSecretName, err)
+	}
+
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12, Certificates: []tls.Certificate{cert}}
+
+	if len(certSecret.Definition.Data["ca.crt"]) > 0 {
+		glog.V(tsparams.LogLevel).Infof("Adding CA certificate to certificate pool from secret %q", certSecretName)
+
+		caCertPool := x509.NewCertPool()
+		if !caCertPool.AppendCertsFromPEM(certSecret.Definition.Data["ca.crt"]) {
+			return nil, fmt.Errorf("failed to append CA certificate to certificate pool from secret %q", certSecretName)
+		}
+
+		tlsConfig.RootCAs = caCertPool
+	}
+
+	return tlsConfig, nil
+}

--- a/tests/cnf/ran/oran/tests/oran-post-provision.go
+++ b/tests/cnf/ran/oran/tests/oran-post-provision.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"crypto/tls"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -10,10 +9,10 @@ import (
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/configmap"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/ocm"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/oran"
-	oranapi "github.com/rh-ecosystem-edge/eco-goinfra/pkg/oran/api"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/siteconfig"
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/raninittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/auth"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/helper"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/tsparams"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
@@ -31,10 +30,10 @@ var _ = Describe("ORAN Post-provision Tests", Label(tsparams.LabelPostProvision)
 		var err error
 
 		By("creating the O2IMS API client")
-		o2imsAPIClient, err = oranapi.NewClientBuilder(RANConfig.O2IMSBaseURL).
-			WithToken(RANConfig.O2IMSToken).
-			WithTLSConfig(&tls.Config{InsecureSkipVerify: true}).
-			BuildProvisioning()
+		clientBuilder, err := auth.NewClientBuilderForConfig(RANConfig)
+		Expect(err).ToNot(HaveOccurred(), "Failed to create the O2IMS API client builder")
+
+		o2imsAPIClient, err = clientBuilder.BuildProvisioning()
 		Expect(err).ToNot(HaveOccurred(), "Failed to create the O2IMS API client")
 
 		By("saving the original ProvisioningRequest spec")

--- a/tests/cnf/ran/oran/tests/oran-pre-provision.go
+++ b/tests/cnf/ran/oran/tests/oran-pre-provision.go
@@ -1,16 +1,15 @@
 package tests
 
 import (
-	"crypto/tls"
 	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/oran"
-	oranapi "github.com/rh-ecosystem-edge/eco-goinfra/pkg/oran/api"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/raninittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/auth"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/helper"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/tsparams"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -23,10 +22,10 @@ var _ = Describe("ORAN Pre-provision Tests", Label(tsparams.LabelPreProvision), 
 		var err error
 
 		By("creating the O2IMS API client")
-		o2imsAPIClient, err = oranapi.NewClientBuilder(RANConfig.O2IMSBaseURL).
-			WithToken(RANConfig.O2IMSToken).
-			WithTLSConfig(&tls.Config{InsecureSkipVerify: true}).
-			BuildProvisioning()
+		clientBuilder, err := auth.NewClientBuilderForConfig(RANConfig)
+		Expect(err).ToNot(HaveOccurred(), "Failed to create the O2IMS API client builder")
+
+		o2imsAPIClient, err = clientBuilder.BuildProvisioning()
 		Expect(err).ToNot(HaveOccurred(), "Failed to create the O2IMS API client")
 	})
 

--- a/tests/cnf/ran/oran/tests/oran-provision.go
+++ b/tests/cnf/ran/oran/tests/oran-provision.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"bytes"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"os"
@@ -16,11 +15,11 @@ import (
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/configmap"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/ocm"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/oran"
-	oranapi "github.com/rh-ecosystem-edge/eco-goinfra/pkg/oran/api"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/secret"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/siteconfig"
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/raninittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/auth"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/helper"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/tsparams"
 	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
@@ -34,10 +33,10 @@ var _ = Describe("ORAN Provision Tests", Label(tsparams.LabelProvision), Ordered
 		var err error
 
 		By("creating the O2IMS API client")
-		o2imsAPIClient, err = oranapi.NewClientBuilder(RANConfig.O2IMSBaseURL).
-			WithToken(RANConfig.O2IMSToken).
-			WithTLSConfig(&tls.Config{InsecureSkipVerify: true}).
-			BuildProvisioning()
+		clientBuilder, err := auth.NewClientBuilderForConfig(RANConfig)
+		Expect(err).ToNot(HaveOccurred(), "Failed to create the O2IMS API client builder")
+
+		o2imsAPIClient, err = clientBuilder.BuildProvisioning()
 		Expect(err).ToNot(HaveOccurred(), "Failed to create the O2IMS API client")
 	})
 

--- a/tests/cnf/ran/oran/tests/oran-template-inventory.go
+++ b/tests/cnf/ran/oran/tests/oran-template-inventory.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -15,6 +14,7 @@ import (
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/oran/api/filter"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/raninittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/auth"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/tsparams"
 	"gopkg.in/yaml.v3"
 )
@@ -29,11 +29,11 @@ var _ = Describe("ORAN Template Inventory", Label(tsparams.LabelPreProvision, ts
 		var err error
 
 		By("creating the O2IMS API client")
-		artifactsClient, err = oranapi.NewClientBuilder(RANConfig.O2IMSBaseURL).
-			WithToken(RANConfig.O2IMSToken).
-			WithTLSConfig(&tls.Config{InsecureSkipVerify: true}).
-			BuildArtifacts()
-		Expect(err).ToNot(HaveOccurred(), "Failed to create the O2IMS API client")
+		clientBuilder, err := auth.NewClientBuilderForConfig(RANConfig)
+		Expect(err).ToNot(HaveOccurred(), "Failed to create the O2IMS API client builder")
+
+		artifactsClient, err = clientBuilder.BuildArtifacts()
+		Expect(err).ToNot(HaveOccurred(), "Failed to create the O2IMS API artifacts client")
 	})
 
 	// 82940 - Successfully list ManagedInfrastructureTemplates


### PR DESCRIPTION
Part of CNF-17787. This PR adds support for OAuth and mTLS to the O-RAN test suite. When the OAuth/mTLS-specific config options are not provided, the tests should behave the same and use the provided bearer token for all auth. If the options for OAuth/mTLS are provided, then these will be used instead and the provided client certificate will be used to authenticate with the O2IMS and Keycloak APIs.

Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OAuth-based authentication for O2IMS supporting client-credentials and token modes.
  * Configuration adds a hub apps domain and automatic app URL derivation; new operator namespace constant added.

* **Refactor**
  * Unified client creation via a configuration-driven builder for provisioning, artifacts, and pre/post-provision flows, removing manual TLS/token setup in callers.

* **Chores**
  * Lint configuration updated to allow the OAuth library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->