### PR TITLE
hw-accel: enabled ppc64le support for the kmm tests

### DIFF
--- a/tests/hw-accel/kmm/internal/get/get.go
+++ b/tests/hw-accel/kmm/internal/get/get.go
@@ -136,6 +136,10 @@ func PreflightImage(arch string) string {
 		return kmmparams.PreflightDTKImageARM64
 	}
 
+	if arch == "ppc64le" {
+		return kmmparams.PreflightDTKImagePPC64LE
+	}
+
 	// Default to x86_64/amd64
 	return kmmparams.PreflightDTKImageX86
 }
@@ -148,6 +152,14 @@ func PreflightKernel(arch string, realtime bool) string {
 		}
 
 		return kmmparams.KernelForDTKArm64
+	}
+
+	if arch == "ppc64le" {
+		if realtime {
+			return kmmparams.KernelForDTKPpc64leRealtime
+		}
+
+		return kmmparams.KernelForDTKPpc64le
 	}
 
 	if realtime {

--- a/tests/hw-accel/kmm/internal/kmmparams/const.go
+++ b/tests/hw-accel/kmm/internal/kmmparams/const.go
@@ -247,6 +247,13 @@ const (
 	// Compatible with OpenShift Container Platform 4.18.
 	PreflightDTKImageARM64 = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:" +
 		"ada767898092f36e8d965292843f9a772b2df449aeda06580430162696bd5ddf"
+	// PreflightDTKImagePPC64LE represents PPC64LE DTK image for KMM 2.4 preflightvalidationocp.
+	PreflightDTKImagePPC64LE = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:" +
+		"7785b2a16b2a2c7443cfc59164c74acb341237b09a9f87c5f0747c9140d21b92"
+	// KernelForDTKPpc64le represents kernel string for ppc64le dtk image.
+	KernelForDTKPpc64le = "5.14.0-570.41.1.el9_6.ppc64le"
+	// KernelForDTKPpc64leRealtime represents kernel string for ppc64le realtime dtk image.
+	KernelForDTKPpc64leRealtime = "not supported"
 	// KernelForDTKArm64 represents kernel string for arm64 dtk image.
 	KernelForDTKArm64 = "5.14.0-284.52.1.el9_2.aarch64"
 	// KernelForDTKArm64Realtime represents kernel string for arm64 realtime dtk image.


### PR DESCRIPTION
hw-accel: enabled ppc64le support for the kmm tests

- Able to PASS 46 out of 48 tests.
- As the realtime kernel is currently not compatible with ppc64le arch, two related tests are being skipped.
- The execution results for all KMM tests have been added. Please review them at your convenience

[all-kmm-tests-061025.log](https://github.com/user-attachments/files/22739972/all-kmm-tests-061025.log)

Thank you
Rajakumar Battula

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PPC64LE architecture support for preflight image and kernel selection, including explicit realtime handling (marked not supported).

* **Tests**
  * Made build-pod waits conditional and clarified related messages.
  * Increased preflight completion timeout from 1 to 3 minutes for reliability.
  * Broadened success criteria to accept either verification success or an already-verified image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->