### PR TITLE
hw-accel: update in-tree test module

### DIFF
--- a/tests/hw-accel/kmm/internal/check/check.go
+++ b/tests/hw-accel/kmm/internal/check/check.go
@@ -109,9 +109,9 @@ func ModuleSigned(apiClient *clients.Settings, modName, message, nsname, image s
 	return err
 }
 
-// IntreeICEModuleLoaded makes sure the needed in-tree module is present on the nodes.
-func IntreeICEModuleLoaded(apiClient *clients.Settings, timeout time.Duration) error {
-	return runCommandOnTestPods(apiClient, []string{"modprobe", "ice"}, "", timeout)
+// IntreeModuleLoaded makes sure the needed in-tree module is present on the nodes.
+func IntreeModuleLoaded(apiClient *clients.Settings, module string, timeout time.Duration) error {
+	return runCommandOnTestPods(apiClient, []string{"modprobe", module}, "", timeout)
 }
 
 func runCommandOnTestPods(apiClient *clients.Settings,

--- a/tests/hw-accel/kmm/mcm/tests/intree-test.go
+++ b/tests/hw-accel/kmm/mcm/tests/intree-test.go
@@ -92,7 +92,7 @@ var _ = Describe("KMM-Hub", Ordered, Label(tsparams.LabelSuite), func() {
 			Expect(err).ToNot(HaveOccurred(), "error creating configmap")
 
 			By("Making sure in-tree-module is loaded on spoke")
-			err = check.IntreeICEModuleLoaded(ModulesConfig.SpokeAPIClient, time.Minute)
+			err = check.IntreeModuleLoaded(ModulesConfig.SpokeAPIClient, kmodToRemove, time.Minute)
 			Expect(err).ToNot(HaveOccurred(), "error while loading in-tree module")
 
 			By("Check in-tree-module is loaded on node")


### PR DESCRIPTION
Update KMM in-tree replace test to support s390 arch and use different module for the test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Generalized in-tree kernel module loading checks to accept a module name, removing hardcoded assumptions.
  - Made tests architecture-aware, automatically selecting the appropriate module per cluster architecture (e.g., s390x).
  - Improved resilience by conditionally skipping when architecture detection isn’t available.
  - Updated related validations to align with the new parameterized approach, enhancing cross-platform coverage and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->