### PR TITLE
Closes CNF-19306; Migration of BC HA test cases from cnf-gotests

### DIFF
--- a/tests/cnf/ran/ptp/internal/profiles/ha.go
+++ b/tests/cnf/ran/ptp/internal/profiles/ha.go
@@ -1,0 +1,50 @@
+package profiles
+
+import (
+	"context"
+	"fmt"
+
+	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/metrics"
+)
+
+// GetHAProfiles returns a list of HA profile names matching the specified status for a given node.
+// Use metrics.HAProfileStatusActive or metrics.HAProfileStatusInactive as the status parameter.
+func GetHAProfiles(
+	ctx context.Context,
+	prometheusAPI prometheusv1.API,
+	nodeName string,
+	status metrics.PtpHAProfileStatus,
+) ([]string, error) {
+	query := metrics.HAProfileStatusQuery{
+		Node: metrics.Equals(nodeName),
+	}
+
+	result, err := metrics.ExecuteQuery(ctx, prometheusAPI, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute HA profile status query for node %s: %w", nodeName, err)
+	}
+
+	var profiles []string
+
+	for _, sample := range result {
+		// Filter by the requested status value
+		if metrics.PtpHAProfileStatus(sample.Value) != status {
+			continue
+		}
+
+		profileName := string(sample.Metric["profile"])
+		if profileName == "" {
+			return nil, fmt.Errorf("HA profile metric missing required 'profile' label on node %s: %v",
+				nodeName, sample.Metric)
+		}
+
+		profiles = append(profiles, profileName)
+	}
+
+	if len(profiles) == 0 {
+		return nil, fmt.Errorf("no HA profiles with status %d found for node %s", status, nodeName)
+	}
+
+	return profiles, nil
+}

--- a/tests/cnf/ran/ptp/tests/ptp-interfaces.go
+++ b/tests/cnf/ran/ptp/tests/ptp-interfaces.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -272,4 +273,492 @@ var _ = Describe("PTP Interfaces", Label(tsparams.LabelInterfaces), func() {
 			Skip("Could not find any boundary clock to test")
 		}
 	})
+
+	// 73093 - Validating HA failover when active interface goes down
+	It("should change high availability active profile when other nic interface is down", reportxml.ID("73093"), func() {
+		testActuallyRan := false
+
+		By("getting node info map")
+		nodeInfoMap, err := profiles.GetNodeInfoMap(RANConfig.Spoke1APIClient)
+		Expect(err).ToNot(HaveOccurred(), "Failed to get node info map")
+
+		for nodeName, nodeInfo := range nodeInfoMap {
+			By("checking if node has HA configuration")
+			if nodeInfo.Counts[profiles.ProfileTypeHA] == 0 {
+				klog.V(tsparams.LogLevel).Infof("Node %s has no HA configuration, skipping", nodeName)
+
+				continue
+			}
+
+			By("getting the active and inactive HA profiles")
+			activeProfiles, err := profiles.GetHAProfiles(context.TODO(), prometheusAPI, nodeName,
+				metrics.HAProfileStatusActive)
+			Expect(err).ToNot(HaveOccurred(), "Failed to get active HA profiles")
+			Expect(len(activeProfiles)).To(Equal(1), "Expected exactly one active HA profile")
+
+			inactiveProfiles, err := profiles.GetHAProfiles(context.TODO(), prometheusAPI, nodeName,
+				metrics.HAProfileStatusInactive)
+			Expect(err).ToNot(HaveOccurred(), "Failed to get inactive HA profiles")
+			Expect(len(inactiveProfiles)).To(BeNumerically(">=", 1), "Expected at least one inactive HA profile")
+
+			activeProfile := activeProfiles[0]
+
+			// Client interfaces are the interfaces that are used to synchronize the clock.
+			By("getting active profile client interface")
+			activeProfileClientInterface := getHAProfileClientInterface(nodeInfo, activeProfile)
+
+			inactiveProfileClientInterfaces := make([]iface.Name, 0, 1)
+			for _, inactiveProfile := range inactiveProfiles {
+				inactiveProfileClientInterface := getHAProfileClientInterface(nodeInfo, inactiveProfile)
+				inactiveProfileClientInterfaces = append(inactiveProfileClientInterfaces, inactiveProfileClientInterface)
+			}
+
+			By("checking if active profile client interface is the egress interface")
+			egressInterface, err := iface.GetEgressInterfaceName(RANConfig.Spoke1APIClient, nodeName)
+			Expect(err).ToNot(HaveOccurred(), "Failed to get egress interface")
+
+			if activeProfileClientInterface == egressInterface {
+				klog.V(tsparams.LogLevel).Infof("Skipping test for egress interface %s", activeProfileClientInterface.GetNIC())
+
+				continue
+			}
+
+			testActuallyRan = true
+			startTime := time.Now()
+
+			By(fmt.Sprintf("bringing down the active HA's interface %s", activeProfileClientInterface))
+
+			DeferCleanup(func() {
+				By("restoring original active HA's interface")
+				err := iface.SetInterfaceStatus(RANConfig.Spoke1APIClient,
+					nodeName, activeProfileClientInterface, iface.InterfaceStateUp)
+				Expect(err).ToNot(HaveOccurred(), "Failed to restore original active HA's interface")
+			})
+
+			err = iface.SetInterfaceStatus(RANConfig.Spoke1APIClient,
+				nodeName, activeProfileClientInterface, iface.InterfaceStateDown)
+			Expect(err).ToNot(HaveOccurred(), "Failed to set the active HA's interface down")
+
+			By("validating the active HA profile changed")
+			newActiveProfile := waitForActiveHAProfileChange(prometheusAPI, nodeName, activeProfile, 2*time.Minute)
+			Expect(newActiveProfile).NotTo(Equal(activeProfile), "Active profile should have changed: %s", newActiveProfile)
+
+			By("validating the original active interface is in FREERUN state")
+			activeNIC := activeProfileClientInterface.GetNIC()
+			clockStateQuery := metrics.ClockStateQuery{
+				Interface: metrics.Equals(activeNIC),
+				Node:      metrics.Equals(nodeName),
+			}
+			err = metrics.AssertQuery(context.TODO(), prometheusAPI, clockStateQuery, metrics.ClockStateFreerun,
+				metrics.AssertWithTimeout(5*time.Minute),
+				metrics.AssertWithStableDuration(10*time.Second))
+			Expect(err).ToNot(HaveOccurred(), "Failed to assert original active interface is in FREERUN")
+
+			By("validating that all inactive HA profile client interfaces are in LOCKED state")
+			inactiveProfileClientNICs := make([]iface.NICName, 0, len(inactiveProfileClientInterfaces))
+			for _, inactiveProfileClientInterface := range inactiveProfileClientInterfaces {
+				inactiveProfileClientNICs = append(inactiveProfileClientNICs, inactiveProfileClientInterface.GetNIC())
+			}
+
+			inactiveIfacesClockStateQuery := metrics.ClockStateQuery{
+				Interface: metrics.Includes(inactiveProfileClientNICs...),
+				Node:      metrics.Equals(nodeName),
+			}
+			err = metrics.AssertQuery(context.TODO(), prometheusAPI, inactiveIfacesClockStateQuery, metrics.ClockStateLocked,
+				metrics.AssertWithTimeout(5*time.Minute),
+				metrics.AssertWithStableDuration(10*time.Second))
+			Expect(err).ToNot(HaveOccurred(), "Failed to assert all inactive interfaces are in LOCKED state")
+
+			By("validating no HOLDOVER event for original inactive interfaces")
+			eventPod, err := consumer.GetConsumerPodforNode(RANConfig.Spoke1APIClient, nodeName)
+			Expect(err).ToNot(HaveOccurred(), "Failed to get event pod")
+
+			for _, inactiveProfileClientInterface := range inactiveProfileClientInterfaces {
+				inactiveProfileClientNIC := inactiveProfileClientInterface.GetNIC()
+				holdoverFilter := events.All(
+					events.IsType(eventptp.PtpStateChange),
+					events.HasValue(events.WithSyncState(eventptp.HOLDOVER), events.OnInterface(inactiveProfileClientNIC)),
+				)
+				err = events.WaitForEvent(eventPod, startTime, 10*time.Second, holdoverFilter)
+				Expect(err).To(HaveOccurred(), "Unexpected HOLDOVER event on original inactive interface %s",
+					inactiveProfileClientNIC)
+			}
+
+			By("validating CLOCK_REALTIME is in LOCKED state")
+			clockRealtimeQuery := metrics.ClockStateQuery{
+				Interface: metrics.Equals(iface.ClockRealtime),
+				Node:      metrics.Equals(nodeName),
+			}
+			err = metrics.AssertQuery(context.TODO(), prometheusAPI, clockRealtimeQuery, metrics.ClockStateLocked,
+				metrics.AssertWithTimeout(5*time.Minute),
+				metrics.AssertWithStableDuration(10*time.Second))
+			Expect(err).ToNot(HaveOccurred(), "Failed to assert CLOCK_REALTIME is LOCKED")
+
+			By("restoring original active HA's interface")
+			err = iface.SetInterfaceStatus(RANConfig.Spoke1APIClient,
+				nodeName, activeProfileClientInterface, iface.InterfaceStateUp)
+			Expect(err).ToNot(HaveOccurred(), "Failed to restore original active HA's interface")
+
+			By("validating restored active profile client interface returns to LOCKED state")
+			activeNIC = activeProfileClientInterface.GetNIC()
+			clockStateQuery = metrics.ClockStateQuery{
+				Interface: metrics.Equals(activeNIC),
+				Node:      metrics.Equals(nodeName),
+			}
+			err = metrics.AssertQuery(context.TODO(), prometheusAPI, clockStateQuery, metrics.ClockStateLocked,
+				metrics.AssertWithTimeout(3*time.Minute),
+				metrics.AssertWithStableDuration(10*time.Second))
+			Expect(err).ToNot(HaveOccurred(), "Failed to assert restored active profile client interface is LOCKED")
+
+			initialTotalProfiles := len(activeProfiles) + len(inactiveProfiles)
+			By("validating HA system returns to healthy state")
+			waitForHAHealthy(prometheusAPI, nodeName, initialTotalProfiles, 2*time.Minute)
+
+			By("validating CLOCK_REALTIME remains LOCKED")
+			clockRealtimeQuery = metrics.ClockStateQuery{
+				Interface: metrics.Equals(iface.ClockRealtime),
+				Node:      metrics.Equals(nodeName),
+			}
+			err = metrics.AssertQuery(context.TODO(), prometheusAPI, clockRealtimeQuery, metrics.ClockStateLocked,
+				metrics.AssertWithTimeout(1*time.Minute),
+				metrics.AssertWithStableDuration(10*time.Second))
+			Expect(err).ToNot(HaveOccurred(), "Failed to assert CLOCK_REALTIME is LOCKED")
+
+			break
+		}
+
+		if !testActuallyRan {
+			Skip("Could not find any HA configuration to test")
+		}
+	})
+
+	// 73094 - Validating complete HA failure when both active and inactive interfaces go down
+	It("should move to FREERUN state when active and inactive interfaces are down", reportxml.ID("73094"), func() {
+		testActuallyRan := false
+
+		By("getting node info map")
+		nodeInfoMap, err := profiles.GetNodeInfoMap(RANConfig.Spoke1APIClient)
+		Expect(err).ToNot(HaveOccurred(), "Failed to get node info map")
+
+		for nodeName, nodeInfo := range nodeInfoMap {
+			By("checking if node has HA configuration")
+			if nodeInfo.Counts[profiles.ProfileTypeHA] == 0 {
+				klog.V(tsparams.LogLevel).Infof("Node %s has no HA configuration, skipping", nodeName)
+
+				continue
+			}
+
+			By("getting the active and inactive HA profiles")
+			activeProfiles, err := profiles.GetHAProfiles(context.TODO(), prometheusAPI, nodeName, metrics.HAProfileStatusActive)
+			Expect(err).ToNot(HaveOccurred(), "Failed to get active HA profiles")
+			Expect(len(activeProfiles)).To(Equal(1), "Expected exactly one active HA profile")
+
+			activeProfileInfo := nodeInfo.GetProfileByName(activeProfiles[0])
+			Expect(activeProfileInfo).ToNot(BeNil(), "Failed to find active profile in node info")
+
+			activeClientInterfaces := activeProfileInfo.GetInterfacesByClockType(profiles.ClockTypeClient)
+			Expect(len(activeClientInterfaces)).To(Equal(1), "Expected exactly one client interface for HA profile")
+
+			inactiveProfiles, err := profiles.GetHAProfiles(context.TODO(),
+				prometheusAPI, nodeName, metrics.HAProfileStatusInactive)
+			Expect(err).ToNot(HaveOccurred(), "Failed to get inactive HA profiles")
+			Expect(len(inactiveProfiles)).To(BeNumerically(">=", 1), "Expected at least one inactive HA profile")
+
+			haInterfaces := make([]iface.Name, 0, len(activeProfiles)+len(inactiveProfiles))
+			haInterfaces = append(haInterfaces, activeClientInterfaces[0].Name)
+			for _, inactiveProfile := range inactiveProfiles {
+				inactiveProfileInfo := nodeInfo.GetProfileByName(inactiveProfile)
+				Expect(inactiveProfileInfo).ToNot(BeNil(), "Failed to find inactive profile in node info")
+
+				inactiveClientInterfaces := inactiveProfileInfo.GetInterfacesByClockType(profiles.ClockTypeClient)
+				Expect(len(inactiveClientInterfaces)).To(Equal(1), "Expected exactly one client interface for HA profile")
+				haInterfaces = append(haInterfaces, inactiveClientInterfaces[0].Name)
+			}
+
+			By("checking if any interface is the egress interface")
+			egressInterface, err := iface.GetEgressInterfaceName(RANConfig.Spoke1APIClient, nodeName)
+			Expect(err).ToNot(HaveOccurred(), "Failed to get egress interface")
+
+			if slices.Contains(haInterfaces, egressInterface) {
+				klog.V(tsparams.LogLevel).Infof("Skipping test - HA interface is egress interface")
+
+				continue
+			}
+
+			testActuallyRan = true
+
+			By("bringing down all HA interfaces")
+			DeferCleanup(func() {
+				By("restoring all HA interfaces")
+				for _, haInterface := range haInterfaces {
+					err := iface.SetInterfaceStatus(RANConfig.Spoke1APIClient, nodeName, haInterface, iface.InterfaceStateUp)
+					Expect(err).ToNot(HaveOccurred(), "Failed to restore HA interface %s", haInterface)
+				}
+			})
+
+			for _, haInterface := range haInterfaces {
+				err = iface.SetInterfaceStatus(RANConfig.Spoke1APIClient, nodeName, haInterface, iface.InterfaceStateDown)
+				Expect(err).ToNot(HaveOccurred(), "Failed to set HA interface %s down", haInterface)
+			}
+
+			By("validating all HA Clock States are in FREERUN state")
+			haNICs := make([]iface.NICName, 0, len(haInterfaces))
+			for _, haInterface := range haInterfaces {
+				haNICs = append(haNICs, haInterface.GetNIC())
+			}
+
+			haIfacesClockStateQuery := metrics.ClockStateQuery{
+				Interface: metrics.Includes(haNICs...),
+				Node:      metrics.Equals(nodeName),
+			}
+
+			err = metrics.AssertQuery(context.TODO(), prometheusAPI, haIfacesClockStateQuery, metrics.ClockStateFreerun,
+				metrics.AssertWithTimeout(1*time.Minute),
+				metrics.AssertWithStableDuration(10*time.Second))
+			Expect(err).ToNot(HaveOccurred(), "Failed to assert all HA interfaces are in FREERUN state")
+
+			By("validating CLOCK_REALTIME is in FREERUN state")
+			clockRealtimeQuery := metrics.ClockStateQuery{
+				Interface: metrics.Equals(iface.ClockRealtime),
+				Node:      metrics.Equals(nodeName),
+			}
+			err = metrics.AssertQuery(context.TODO(), prometheusAPI, clockRealtimeQuery, metrics.ClockStateFreerun,
+				metrics.AssertWithTimeout(1*time.Minute),
+				metrics.AssertWithStableDuration(10*time.Second))
+			Expect(err).ToNot(HaveOccurred(), "Failed to assert CLOCK_REALTIME is in FREERUN")
+
+			By("restoring HA interfaces")
+			for _, haInterface := range haInterfaces {
+				err = iface.SetInterfaceStatus(RANConfig.Spoke1APIClient, nodeName, haInterface, iface.InterfaceStateUp)
+				Expect(err).ToNot(HaveOccurred(), "Failed to restore HA interface %s", haInterface)
+			}
+
+			By("validating all Clock State metrics return to LOCKED state")
+			haNICs = make([]iface.NICName, 0, len(haInterfaces))
+			for _, haInterface := range haInterfaces {
+				haNICs = append(haNICs, haInterface.GetNIC())
+			}
+
+			haIfacesClockStateQuery = metrics.ClockStateQuery{
+				Interface: metrics.Includes(haNICs...),
+				Node:      metrics.Equals(nodeName),
+			}
+
+			err = metrics.AssertQuery(context.TODO(), prometheusAPI, haIfacesClockStateQuery, metrics.ClockStateLocked,
+				metrics.AssertWithTimeout(3*time.Minute),
+				metrics.AssertWithStableDuration(10*time.Second))
+			Expect(err).ToNot(HaveOccurred(), "Failed to assert all HA interfaces are in LOCKED state")
+
+			By("validating HA system returns to healthy state")
+			waitForHAHealthy(prometheusAPI, nodeName, len(haInterfaces), 2*time.Minute)
+
+			By("validating CLOCK_REALTIME returns to LOCKED state")
+			clockRealtimeQuery = metrics.ClockStateQuery{
+				Interface: metrics.Equals(iface.ClockRealtime),
+				Node:      metrics.Equals(nodeName),
+			}
+			err = metrics.AssertQuery(context.TODO(), prometheusAPI, clockRealtimeQuery, metrics.ClockStateLocked,
+				metrics.AssertWithTimeout(3*time.Minute),
+				metrics.AssertWithStableDuration(10*time.Second))
+			Expect(err).ToNot(HaveOccurred(), "Failed to assert CLOCK_REALTIME is LOCKED")
+
+			break
+		}
+
+		if !testActuallyRan {
+			Skip("Could not find any HA configuration to test")
+		}
+	})
+
+	Context("HA profile configuration deletion", func() {
+		// 73095 - Validating HA failover when active profile configuration is deleted
+		It("should change high availability active profile when active profile is deleted",
+			reportxml.ID("73095"), func() {
+				testActuallyRan := false
+
+				By("getting node info map")
+				nodeInfoMap, err := profiles.GetNodeInfoMap(RANConfig.Spoke1APIClient)
+				Expect(err).ToNot(HaveOccurred(), "Failed to get node info map")
+
+				for nodeName, nodeInfo := range nodeInfoMap {
+					By("checking if node has HA configuration")
+					if nodeInfo.Counts[profiles.ProfileTypeHA] == 0 {
+						klog.V(tsparams.LogLevel).Infof("Node %s has no HA configuration, skipping", nodeName)
+
+						continue
+					}
+
+					testActuallyRan = true
+
+					totalHAProfiles := 0
+
+					By("getting the active HA profile & total number of HA profiles")
+					activeProfiles, err := profiles.GetHAProfiles(context.TODO(),
+						prometheusAPI, nodeName, metrics.HAProfileStatusActive)
+					Expect(err).ToNot(HaveOccurred(), "Failed to get active HA profiles")
+					Expect(len(activeProfiles)).To(Equal(1), "Expected exactly one active HA profile")
+
+					activeProfileName := activeProfiles[0]
+					totalHAProfiles++
+
+					By(fmt.Sprintf("getting the PtpConfig for active profile %s", activeProfileName))
+					activeProfileInfo := nodeInfo.GetProfileByName(activeProfileName)
+					Expect(activeProfileInfo).ToNot(BeNil(), "Failed to find profile info for active profile %s", activeProfileName)
+
+					By(fmt.Sprintf("pulling PtpConfig %s", activeProfileInfo.Reference.ConfigReference.Name))
+					activeProfilePtpConfig, err := activeProfileInfo.Reference.PullPtpConfig(RANConfig.Spoke1APIClient)
+					Expect(err).ToNot(HaveOccurred(), "Failed to pull PtpConfig")
+
+					inactiveProfiles, err := profiles.GetHAProfiles(context.TODO(),
+						prometheusAPI, nodeName, metrics.HAProfileStatusInactive)
+					Expect(err).ToNot(HaveOccurred(), "Failed to get inactive HA profiles")
+					Expect(len(inactiveProfiles)).To(BeNumerically(">=", 1), "Expected at least one inactive HA profile")
+					totalHAProfiles += len(inactiveProfiles)
+
+					DeferCleanup(func() {
+						By("validating HA is healthy after restoration")
+						waitForHAHealthy(prometheusAPI, nodeName, totalHAProfiles, 5*time.Minute)
+
+						By("validating all clocks are locked after restoration")
+						err = metrics.EnsureClocksAreLocked(prometheusAPI)
+						Expect(err).ToNot(HaveOccurred(), "Failed to assert all clocks are locked after restoration")
+					})
+
+					By(fmt.Sprintf("deleting PtpProfile %s from PtpConfig %s",
+						activeProfileName, activeProfilePtpConfig.Definition.Name))
+					err = profiles.RemoveProfileFromConfig(RANConfig.Spoke1APIClient, activeProfileInfo.Reference)
+					Expect(err).ToNot(HaveOccurred(),
+						"Failed to delete PtpProfile %s from PtpConfig %s",
+						activeProfileName, activeProfilePtpConfig.Definition.Name)
+
+					By("validating active profile has changed")
+					newActiveProfile := waitForActiveHAProfileChange(prometheusAPI, nodeName, activeProfileName, 2*time.Minute)
+
+					By("validating new active interface is in LOCKED state")
+					newActiveInterface := getHAProfileClientInterface(nodeInfo, newActiveProfile)
+					nicName := newActiveInterface.GetNIC()
+					clockStateQuery := metrics.ClockStateQuery{
+						Interface: metrics.Equals(nicName),
+						Node:      metrics.Equals(nodeName),
+					}
+					err = metrics.AssertQuery(context.TODO(), prometheusAPI, clockStateQuery, metrics.ClockStateLocked,
+						metrics.AssertWithTimeout(3*time.Minute),
+						metrics.AssertWithStableDuration(10*time.Second))
+					Expect(err).ToNot(HaveOccurred(), "Failed to assert new active interface is LOCKED")
+
+					// Test only on first HA node found
+					break
+				}
+
+				if !testActuallyRan {
+					Skip("Could not find any HA configuration to test")
+				}
+			})
+	})
 })
+
+// waitForActiveHAProfileChange waits for the active HA profile to change away from the specified profile.
+// It returns the new active profile name.
+func waitForActiveHAProfileChange(
+	prometheusAPI prometheusv1.API,
+	nodeName string,
+	oldProfileName string,
+	timeout time.Duration,
+) string {
+	GinkgoHelper()
+
+	var newActiveProfile string
+
+	Eventually(func() (bool, error) {
+		activeProfiles, err := profiles.GetHAProfiles(context.TODO(), prometheusAPI, nodeName,
+			metrics.HAProfileStatusActive)
+		if err != nil {
+			klog.V(tsparams.LogLevel).Infof("Failed to get active HA profiles: %v", err)
+
+			return false, err
+		}
+
+		// Must have exactly one active profile
+		if len(activeProfiles) != 1 {
+			klog.V(tsparams.LogLevel).Infof("Expected 1 active profile, got %d", len(activeProfiles))
+
+			return false, fmt.Errorf("expected 1 active profile, got %d", len(activeProfiles))
+		}
+
+		// Active profile must be different from the old one
+		if activeProfiles[0] == oldProfileName {
+			return false, nil
+		}
+
+		newActiveProfile = activeProfiles[0]
+
+		return true, nil
+	}, timeout, 5*time.Second).Should(BeTrue(),
+		"Active HA profile should have changed from %s on node %s", oldProfileName, nodeName)
+
+	return newActiveProfile
+}
+
+// getHAProfileClientInterface returns the client interface for a given HA profile name.
+// This is a convenience helper to reduce boilerplate in tests. It expects the profile to have exactly one client.
+func getHAProfileClientInterface(nodeInfo *profiles.NodeInfo, profileName string) iface.Name {
+	GinkgoHelper()
+
+	profileInfo := nodeInfo.GetProfileByName(profileName)
+	Expect(profileInfo).ToNot(BeNil(), "Failed to find profile %s in node info", profileName)
+
+	clientInterfaces := profileInfo.GetInterfacesByClockType(profiles.ClockTypeClient)
+	Expect(len(clientInterfaces)).To(Equal(1),
+		"Expected exactly one client interface for HA profile %s", profileName)
+
+	return clientInterfaces[0].Name
+}
+
+// waitForHAHealthy waits for the HA to return to a healthy state with the expected
+// number of profiles. This is used for cleanup/restoration validation.
+func waitForHAHealthy(
+	prometheusAPI prometheusv1.API,
+	nodeName string,
+	expectedTotalProfiles int,
+	timeout time.Duration,
+) {
+	GinkgoHelper()
+	Eventually(func() (bool, error) {
+		activeProfiles, activeErr := profiles.GetHAProfiles(context.TODO(), prometheusAPI, nodeName,
+			metrics.HAProfileStatusActive)
+		if activeErr != nil {
+			klog.V(tsparams.LogLevel).Infof("Failed to get active HA profiles: %v",
+				activeErr)
+
+			return false, activeErr
+		}
+
+		inactiveProfiles, inactiveErr := profiles.GetHAProfiles(context.TODO(), prometheusAPI, nodeName,
+			metrics.HAProfileStatusInactive)
+		if inactiveErr != nil {
+			klog.V(tsparams.LogLevel).Infof("Failed to get inactive HA profiles: %v",
+				inactiveErr)
+
+			return false, inactiveErr
+		}
+
+		// Should have exactly 1 active profile
+		if len(activeProfiles) != 1 {
+			klog.V(tsparams.LogLevel).Infof("Expected 1 active profile, got %d", len(activeProfiles))
+
+			return false, nil
+		}
+
+		// Total profiles should match expected
+		totalProfiles := len(activeProfiles) + len(inactiveProfiles)
+		if totalProfiles != expectedTotalProfiles {
+			klog.V(tsparams.LogLevel).Infof("Expected %d total profiles, got %d (active=%d, inactive=%d)",
+				expectedTotalProfiles, totalProfiles, len(activeProfiles), len(inactiveProfiles))
+
+			return false, nil
+		}
+
+		return true, nil
+	}, timeout, 5*time.Second).Should(BeTrue(),
+		"HA system should be healthy with %d total profiles on node %s", expectedTotalProfiles, nodeName)
+}


### PR DESCRIPTION
This is a migration of three test cases from cnf-gotests of the PTP BC HA.
CNF-73093 - 'should change high availability active profile when other nic interface is down'
CNF-73094 - 'should move to FREERUN state when active and inactive interfaces are down'
CNF-73095 - 'should change high availability active profile when active profile is deleted'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retrieve HA profile names from metrics for a node.
  * Remove a profile from a configuration with validation and orphaned-recommendation cleanup.

* **Tests**
  * Expanded HA failover coverage: active-profile switch, total HA failure, and profile-deletion scenarios.
  * Added helpers to wait for profile changes, verify HA health, and ensure interface/config restoration.

* **Bug Fixes**
  * Treat missing/restored profiles in configs as benign; preserve original indexes and append restored entries instead of failing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->