### PR TITLE
 cnf ran ptp: make OC cases events-optional 

### DIFF
--- a/tests/cnf/ran/internal/ranparam/const.go
+++ b/tests/cnf/ran/internal/ranparam/const.go
@@ -45,6 +45,8 @@ const (
 	PtpOperatorNamespace = "openshift-ptp"
 	// LinuxPtpDaemonsetName is the name of the Linux PTP daemon daemonset.
 	LinuxPtpDaemonsetName = "linuxptp-daemon"
+	// PtpServiceMonitorName is the name of the PTP operator's ServiceMonitor.
+	PtpServiceMonitorName = "monitor-ptp"
 
 	// CloudEventProxyContainerName is the sidecar in the linuxptp-daemon pod that emits events.
 	CloudEventProxyContainerName = "cloud-event-proxy"

--- a/tests/cnf/ran/ptp/internal/consumer/bothversions.go
+++ b/tests/cnf/ran/ptp/internal/consumer/bothversions.go
@@ -118,6 +118,8 @@ func getEventAPIVersion(client *clients.Settings) (ptpEventAPIVersion, error) {
 		return eventAPIVersionV1, nil
 	case string(eventAPIVersionV2):
 		return eventAPIVersionV2, nil
+	case "":
+		return eventAPIVersionV2, nil
 	default:
 		return "", fmt.Errorf("unknown event API version %s in PTP operator config", apiVersion)
 	}

--- a/tests/cnf/ran/ptp/internal/events/README.md
+++ b/tests/cnf/ran/ptp/internal/events/README.md
@@ -33,9 +33,9 @@ The `WaitForEvent` function accepts several optional parameters:
 
 Specifies the container name within the pod from which to retrieve logs. If not specified, logs are retrieved from the default container. This is particularly useful when monitoring PTP events from specific containers like `"cloud-event-proxy"`.
 
-#### `WithoutCurrentState(ignoreCurrentState bool)`
+#### `WithCurrentState(includeCurrentState bool)`
 
-Controls whether to ignore messages about the current state of events. When set to `true`, only events received as subscriptions are considered, filtering out initial state reports. This is useful when you want to wait for new events rather than existing state information.
+Controls whether to include messages about the current state of events. By default, current state messages are not included.
 
 ### Event Filtering
 
@@ -112,14 +112,13 @@ func main() {
 
     fmt.Printf("Waiting for PTP Sync State Locked event on interface %s...\n", targetInterface)
 
-    // Use both WithContainer and WithoutCurrentState options
+    // Use the container option.
     err := events.WaitForEvent(
         myPtpPod,
         startTime,
         timeout,
         eventFilter,
         events.WithContainer("cloud-event-proxy"),
-        events.WithoutCurrentState(true), // Only wait for new events, not current state
     )
     if err != nil {
         fmt.Printf("Error waiting for event: %v\n", err)

--- a/tests/cnf/ran/ptp/internal/metrics/assert.go
+++ b/tests/cnf/ran/ptp/internal/metrics/assert.go
@@ -139,6 +139,17 @@ func AssertQuery[V constraints.Integer](
 		option(opts)
 	}
 
+	metricQuery := query.ToMetricQuery()
+	klog.V(tsparams.LogLevel).Infof(
+		"Starting query assertion: query=%s expected=%d startTime=%s timeout=%s pollInterval=%s stableDuration=%s",
+		metricQuery.String(),
+		int64(expected),
+		opts.startTime,
+		opts.timeout,
+		opts.pollInterval,
+		opts.stableDuration,
+	)
+
 	// queryTime is the time at which each query is executed. It begins as the start time and will be incremented by
 	// the poll interval until the timeout is reached.
 	queryTime := opts.startTime
@@ -188,6 +199,16 @@ func AssertQuery[V constraints.Integer](
 			return fmt.Errorf("failed to assert query eventually: context finished: %w", ctx.Err())
 		}
 	}
+
+	klog.V(tsparams.LogLevel).Infof(
+		"Query assertion timed out: query=%s expected=%d startTime=%s timeout=%s pollInterval=%s stableDuration=%s",
+		metricQuery.String(),
+		int64(expected),
+		opts.startTime,
+		opts.timeout,
+		opts.pollInterval,
+		opts.stableDuration,
+	)
 
 	return fmt.Errorf("failed to assert query eventually: timeout of %s exceeded", opts.timeout)
 }

--- a/tests/cnf/ran/ptp/internal/metrics/servicemonitor.go
+++ b/tests/cnf/ran/ptp/internal/metrics/servicemonitor.go
@@ -1,0 +1,58 @@
+package metrics
+
+import (
+	"fmt"
+
+	monv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/monitoring"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/ranparam"
+)
+
+// UpdatePtpServiceMonitorInterval pulls the PTP operator's ServiceMonitor, saves a deep copy of the original
+// definition, updates all endpoint scrape intervals to the provided value, and returns the saved copy. The caller
+// should use RestorePtpServiceMonitor with the returned value to restore the original state.
+func UpdatePtpServiceMonitorInterval(
+	client *clients.Settings, interval monv1.Duration) (*monv1.ServiceMonitor, error) {
+	builder, err := monitoring.Pull(client, ranparam.PtpServiceMonitorName, ranparam.PtpOperatorNamespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to pull PTP ServiceMonitor: %w", err)
+	}
+
+	saved := builder.Definition.DeepCopy()
+
+	for i := range builder.Definition.Spec.Endpoints {
+		builder.Definition.Spec.Endpoints[i].Interval = interval
+	}
+
+	_, err = builder.Update()
+	if err != nil {
+		return nil, fmt.Errorf("failed to update PTP ServiceMonitor interval: %w", err)
+	}
+
+	return saved, nil
+}
+
+// RestorePtpServiceMonitor restores the PTP operator's ServiceMonitor to the provided saved state. The saved
+// ServiceMonitor should be the return value from UpdatePtpServiceMonitorInterval.
+func RestorePtpServiceMonitor(client *clients.Settings, saved *monv1.ServiceMonitor) error {
+	if saved == nil {
+		return fmt.Errorf("cannot restore nil ServiceMonitor")
+	}
+
+	builder, err := monitoring.Pull(client, ranparam.PtpServiceMonitorName, ranparam.PtpOperatorNamespace)
+	if err != nil {
+		return fmt.Errorf("failed to pull PTP ServiceMonitor for restoration: %w", err)
+	}
+
+	// Preserve the current resource version so the update succeeds, then restore everything else.
+	saved.ResourceVersion = builder.Object.ResourceVersion
+	builder.Definition = saved
+
+	_, err = builder.Update()
+	if err != nil {
+		return fmt.Errorf("failed to restore PTP ServiceMonitor: %w", err)
+	}
+
+	return nil
+}

--- a/tests/cnf/ran/ptp/ptp_suite_test.go
+++ b/tests/cnf/ran/ptp/ptp_suite_test.go
@@ -63,7 +63,6 @@ var _ = AfterSuite(func() {
 	By("cleaning up Prometheus API client resources")
 	err = querier.CleanupQuerierResources(RANConfig.Spoke1APIClient)
 	Expect(err).ToNot(HaveOccurred(), "Failed to cleanup Prometheus API client resources")
-
 })
 
 var _ = JustAfterEach(func() {

--- a/tests/cnf/ran/ptp/ptp_suite_test.go
+++ b/tests/cnf/ran/ptp/ptp_suite_test.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	monv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/internal/nicinfo"
@@ -13,13 +14,19 @@ import (
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/rancluster"
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/raninittools"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/consumer"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/metrics"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/mustgather"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/tsparams"
 	_ "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/tests"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/reporter"
 )
 
-var _, currentFile, _, _ = runtime.Caller(0)
+var (
+	_, currentFile, _, _ = runtime.Caller(0)
+
+	// savedPtpServiceMonitor holds the original PTP ServiceMonitor state so it can be restored in AfterSuite.
+	savedPtpServiceMonitor *monv1.ServiceMonitor
+)
 
 func TestPTP(t *testing.T) {
 	_, reporterConfig := GinkgoConfiguration()
@@ -34,14 +41,23 @@ var _ = BeforeSuite(func() {
 	isSpoke1Present := rancluster.AreClustersPresent([]*clients.Settings{Spoke1APIClient})
 	Expect(isSpoke1Present).To(BeTrue(), "Spoke 1 cluster must be present for PTP tests")
 
+	By("updating the PTP ServiceMonitor scrape interval to 1s")
+	var err error
+	savedPtpServiceMonitor, err = metrics.UpdatePtpServiceMonitorInterval(RANConfig.Spoke1APIClient, "1s")
+	Expect(err).ToNot(HaveOccurred(), "Failed to update PTP ServiceMonitor scrape interval")
+
 	By("deploying consumers")
-	err := consumer.DeployConsumersOnNodes(RANConfig.Spoke1APIClient)
+	err = consumer.DeployConsumersOnNodes(RANConfig.Spoke1APIClient)
 	Expect(err).ToNot(HaveOccurred(), "Failed to deploy consumers on nodes with PTP daemons")
 })
 
 var _ = AfterSuite(func() {
+	By("restoring the PTP ServiceMonitor")
+	err := metrics.RestorePtpServiceMonitor(RANConfig.Spoke1APIClient, savedPtpServiceMonitor)
+	Expect(err).ToNot(HaveOccurred(), "Failed to restore PTP ServiceMonitor")
+
 	By("removing consumers")
-	err := consumer.CleanupConsumersOnNodes(RANConfig.Spoke1APIClient)
+	err = consumer.CleanupConsumersOnNodes(RANConfig.Spoke1APIClient)
 	Expect(err).ToNot(HaveOccurred(), "Failed to cleanup consumers on nodes with PTP daemons")
 
 	By("cleaning up Prometheus API client resources")

--- a/tests/cnf/ran/ptp/tests/ptp-interfaces.go
+++ b/tests/cnf/ran/ptp/tests/ptp-interfaces.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/ranparam"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/version"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/consumer"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/eventmetric"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/events"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/iface"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/metrics"
@@ -111,10 +112,6 @@ var _ = Describe("PTP Interfaces", Label(tsparams.LabelInterfaces), func() {
 				// Include all interfaces in the interface group in the interface information report for this suite.
 				nicinfo.Node(nodeName).MarkTested(iface.NamesToStrings(interfaceGroup)...)
 
-				By("getting the event pod for the node")
-				eventPod, err := consumer.GetConsumerPodforNode(RANConfig.Spoke1APIClient, nodeName)
-				Expect(err).ToNot(HaveOccurred(), "Failed to get event pod for node %s", nodeName)
-
 				// DeferCleanup will create a pseudo-AfterEach to run after the test completes, even if
 				// it fails. This ensures these interfaces are set up even if the test fails.
 				DeferCleanup(func() {
@@ -141,31 +138,44 @@ var _ = Describe("PTP Interfaces", Label(tsparams.LabelInterfaces), func() {
 					Expect(err).ToNot(HaveOccurred(), "Failed to set interface %s to down on node %s", ifaceName, nodeName)
 				}
 
-				By("waiting for ptp state change HOLDOVER event")
-				holdoverFilter := events.All(
-					events.IsType(eventptp.PtpStateChange),
-					events.HasValue(events.WithSyncState(eventptp.HOLDOVER), events.OnInterface(nicName)),
-				)
-				err = events.WaitForEvent(eventPod, startTime, 3*time.Minute, holdoverFilter)
-				Expect(err).ToNot(HaveOccurred(), "Failed to wait for ptp state change HOLDOVER event")
+				By("checking if events are enabled")
+				eventsEnabled, err := consumer.AreEventsEnabled(RANConfig.Spoke1APIClient)
+				Expect(err).ToNot(HaveOccurred(), "Failed to check if events are enabled")
 
-				By("waiting for ptp state change FREERUN event")
+				if eventsEnabled {
+					By("waiting for ptp state change HOLDOVER event")
+					eventPod, err := consumer.GetConsumerPodforNode(RANConfig.Spoke1APIClient, nodeName)
+					Expect(err).ToNot(HaveOccurred(), "Failed to get event pod for node %s", nodeName)
+
+					holdoverFilter := events.All(
+						events.IsType(eventptp.PtpStateChange),
+						events.HasValue(events.WithSyncState(eventptp.HOLDOVER), events.OnInterface(nicName)),
+					)
+
+					err = events.WaitForEvent(eventPod, startTime, 3*time.Minute, holdoverFilter)
+					Expect(err).ToNot(HaveOccurred(), "Failed to wait for ptp state change HOLDOVER event")
+				}
+
+				By("waiting for ptp state change FREERUN event and metric")
 				freerunFilter := events.All(
 					events.IsType(eventptp.PtpStateChange),
 					events.HasValue(events.WithSyncState(eventptp.FREERUN), events.OnInterface(nicName)),
 				)
-				err = events.WaitForEvent(eventPod, startTime, 5*time.Minute, freerunFilter)
-				Expect(err).ToNot(HaveOccurred(), "Failed to wait for ptp state change FREERUN event")
-
-				By("asserting that interface group on that node has FREERUN metric")
-				clockStateQuery := metrics.ClockStateQuery{
+				ptp4lClockStateQuery := metrics.ClockStateQuery{
 					Interface: metrics.Equals(nicName),
 					Node:      metrics.Equals(nodeName),
+					Process:   metrics.Equals(metrics.ProcessPTP4L),
 				}
-				err = metrics.AssertQuery(context.TODO(), prometheusAPI, clockStateQuery, metrics.ClockStateFreerun,
-					metrics.AssertWithTimeout(5*time.Minute),
-					metrics.AssertWithStableDuration(10*time.Second))
-				Expect(err).ToNot(HaveOccurred(), "Failed to assert that interface group on that node has FREERUN metric")
+				err = eventmetric.NewAssertion(prometheusAPI, ptp4lClockStateQuery, metrics.ClockStateFreerun, freerunFilter).
+					ForNode(RANConfig.Spoke1APIClient, nodeName).
+					WithStartTime(startTime).
+					WithTimeout(5*time.Minute).
+					WithMetricOptions(
+						metrics.AssertWithStableDuration(10*time.Second),
+						metrics.AssertWithPollInterval(1*time.Second),
+					).
+					ExecuteAssertion(context.TODO())
+				Expect(err).ToNot(HaveOccurred(), "Failed to wait for ptp state change FREERUN event and metric")
 
 				By("setting all interfaces in the group up")
 				for _, ifaceName := range interfaceGroup {
@@ -173,13 +183,17 @@ var _ = Describe("PTP Interfaces", Label(tsparams.LabelInterfaces), func() {
 					Expect(err).ToNot(HaveOccurred(), "Failed to set interface %s to up on node %s", ifaceName, nodeName)
 				}
 
-				By("waiting for ptp state change LOCKED event")
+				By("waiting for ptp state change LOCKED event and metric")
 				lockedFilter := events.All(
 					events.IsType(eventptp.PtpStateChange),
 					events.HasValue(events.WithSyncState(eventptp.LOCKED), events.OnInterface(nicName)),
 				)
-				err = events.WaitForEvent(eventPod, startTime, 5*time.Minute, lockedFilter)
-				Expect(err).ToNot(HaveOccurred(), "Failed to wait for ptp state change LOCKED event")
+				err = eventmetric.NewAssertion(prometheusAPI, ptp4lClockStateQuery, metrics.ClockStateLocked, lockedFilter).
+					ForNode(RANConfig.Spoke1APIClient, nodeName).
+					WithStartTime(startTime).
+					WithTimeout(5 * time.Minute).
+					ExecuteAssertion(context.TODO())
+				Expect(err).ToNot(HaveOccurred(), "Failed to wait for ptp state change LOCKED event and metric")
 
 				By("asserting that all metrics are LOCKED")
 				err = metrics.EnsureClocksAreLocked(prometheusAPI)
@@ -248,11 +262,18 @@ var _ = Describe("PTP Interfaces", Label(tsparams.LabelInterfaces), func() {
 				Expect(err).ToNot(HaveOccurred(), "Failed to set interface %s to down on node %s", masterInterface.Name, nodeName)
 			}
 
-			By("validating that the ptp metric stays in locked state")
-			err = metrics.AssertQuery(context.TODO(), prometheusAPI, metrics.ClockStateQuery{}, metrics.ClockStateLocked,
-				metrics.AssertWithStableDuration(30*time.Second),
-				metrics.AssertWithTimeout(45*time.Second))
-			Expect(err).ToNot(HaveOccurred(), "Failed to assert that the PTP metric stays in locked state")
+			By("validating that the ptp metric stays in locked state for each BC master NIC")
+			for nicName := range masterInterfaceGroups {
+				By(fmt.Sprintf("validating that the ptp metric for %s stays in locked state", nicName))
+				bcNICQuery := metrics.ClockStateQuery{
+					Interface: metrics.Equals(nicName),
+				}
+				err = metrics.AssertQuery(context.TODO(), prometheusAPI, bcNICQuery, metrics.ClockStateLocked,
+					metrics.AssertWithStableDuration(30*time.Second),
+					metrics.AssertWithTimeout(45*time.Second))
+				Expect(err).ToNot(HaveOccurred(),
+					"Failed to assert that the PTP metric for %s stays in locked state", nicName)
+			}
 
 			By("validating that no holdover event is generated")
 			for nicName := range masterInterfaceGroups {
@@ -280,7 +301,8 @@ var _ = Describe("PTP Interfaces", Label(tsparams.LabelInterfaces), func() {
 							events.ContainingResource(string(masterInterface.Name.GetNIC())),
 						),
 					)
-					err = events.WaitForEvent(eventPod, startTime, 1*time.Minute, clockClassEventFilter)
+					err = events.WaitForEvent(eventPod, startTime, 1*time.Minute, clockClassEventFilter,
+						events.WithCurrentState(true))
 					Expect(err).ToNot(HaveOccurred(), "Failed to wait for clock class event for interface %s", masterInterface.Name)
 				}
 			}
@@ -295,7 +317,7 @@ var _ = Describe("PTP Interfaces", Label(tsparams.LabelInterfaces), func() {
 			By("validating that the ptp metric stays in locked state")
 			err = metrics.AssertQuery(context.TODO(), prometheusAPI, metrics.ClockStateQuery{}, metrics.ClockStateLocked,
 				metrics.AssertWithStableDuration(30*time.Second),
-				metrics.AssertWithTimeout(45*time.Second))
+				metrics.AssertWithTimeout(3*time.Minute))
 			Expect(err).ToNot(HaveOccurred(), "Failed to assert that the PTP metric stays in locked state")
 		}
 

--- a/tests/cnf/ran/ptp/tests/ptp-ntp-fallback.go
+++ b/tests/cnf/ran/ptp/tests/ptp-ntp-fallback.go
@@ -148,8 +148,7 @@ var _ = Describe("PTP GNSS with NTP Fallback", Label(tsparams.LabelNTPFallback),
 				events.IsType(eventptp.OsClockSyncStateChange),
 				events.HasValue(events.WithSyncState(eventptp.LOCKED)),
 			)
-			err = events.WaitForEvent(
-				eventPod, gnssLossTime, 5*time.Minute, osClockLockedFilter, events.WithoutCurrentState(true))
+			err = events.WaitForEvent(eventPod, gnssLossTime, 5*time.Minute, osClockLockedFilter)
 			Expect(err).ToNot(HaveOccurred(), "Failed to wait for os-clock-sync-state LOCKED event on node %s", nodeName)
 
 			By("verifying phc2sys process is not running")
@@ -170,8 +169,7 @@ var _ = Describe("PTP GNSS with NTP Fallback", Label(tsparams.LabelNTPFallback),
 			Expect(err).ToNot(HaveOccurred(), "Failed to simulate GNSS sync recovery for node %s", nodeName)
 
 			By("waiting for os-clock-sync-state LOCKED event")
-			err = events.WaitForEvent(
-				eventPod, gnssRecoveryTime, 5*time.Minute, osClockLockedFilter, events.WithoutCurrentState(true))
+			err = events.WaitForEvent(eventPod, gnssRecoveryTime, 5*time.Minute, osClockLockedFilter)
 			Expect(err).ToNot(HaveOccurred(), "Failed to wait for os-clock-sync-state LOCKED event on node %s", nodeName)
 
 			By("verifying phc2sys process is running")
@@ -271,8 +269,7 @@ var _ = Describe("PTP GNSS with NTP Fallback", Label(tsparams.LabelNTPFallback),
 				events.IsType(eventptp.OsClockSyncStateChange),
 				events.HasValue(events.WithSyncState(eventptp.LOCKED)),
 			)
-			err = events.WaitForEvent(
-				eventPod, offsetSpikeTime, 5*time.Minute, osClockLockedFilter, events.WithoutCurrentState(true))
+			err = events.WaitForEvent(eventPod, offsetSpikeTime, 5*time.Minute, osClockLockedFilter)
 			Expect(err).ToNot(HaveOccurred(), "Failed to wait for os-clock-sync-state LOCKED event on node %s", nodeName)
 
 			By("verifying phc2sys process is not running")
@@ -291,8 +288,7 @@ var _ = Describe("PTP GNSS with NTP Fallback", Label(tsparams.LabelNTPFallback),
 			// ts2phc will automatically work on correcting the offset spike. Once corrected, the system
 			// will transition back to PTP sync and emit another os-clock-sync-state LOCKED event.
 			recoveryTime := time.Now()
-			err = events.WaitForEvent(
-				eventPod, recoveryTime, 5*time.Minute, osClockLockedFilter, events.WithoutCurrentState(true))
+			err = events.WaitForEvent(eventPod, recoveryTime, 5*time.Minute, osClockLockedFilter)
 			Expect(err).ToNot(HaveOccurred(),
 				"Failed to wait for os-clock-sync-state LOCKED event after recovery on node %s", nodeName)
 
@@ -379,8 +375,7 @@ var _ = Describe("PTP GNSS with NTP Fallback", Label(tsparams.LabelNTPFallback),
 				events.IsType(eventptp.OsClockSyncStateChange),
 				events.HasValue(events.WithSyncState(eventptp.FREERUN)),
 			)
-			err = events.WaitForEvent(
-				eventPod, gnssLossTime, 5*time.Minute, osClockFreerunFilter, events.WithoutCurrentState(true))
+			err = events.WaitForEvent(eventPod, gnssLossTime, 5*time.Minute, osClockFreerunFilter)
 			Expect(err).ToNot(HaveOccurred(), "Failed to wait for os-clock-sync-state FREERUN event on node %s", nodeName)
 
 			By("ensuring no os-clock-sync-state LOCKED event is received")
@@ -413,8 +408,7 @@ var _ = Describe("PTP GNSS with NTP Fallback", Label(tsparams.LabelNTPFallback),
 			Expect(err).ToNot(HaveOccurred(), "Failed to simulate GNSS sync recovery for node %s", nodeName)
 
 			By("waiting for os-clock-sync-state LOCKED event")
-			err = events.WaitForEvent(
-				eventPod, gnssRecoveryTime, 5*time.Minute, osClockLockedFilter, events.WithoutCurrentState(true))
+			err = events.WaitForEvent(eventPod, gnssRecoveryTime, 5*time.Minute, osClockLockedFilter)
 			Expect(err).ToNot(HaveOccurred(), "Failed to wait for os-clock-sync-state LOCKED event on node %s", nodeName)
 
 			By("restoring the original profile configuration")
@@ -509,8 +503,7 @@ var _ = Describe("PTP GNSS with NTP Fallback", Label(tsparams.LabelNTPFallback),
 				events.IsType(eventptp.PtpStateChange),
 				events.HasValue(events.WithSyncState(eventptp.HOLDOVER)),
 			)
-			err = events.WaitForEvent(
-				eventPod, gnssLossTime, 5*time.Minute, holdoverFilter, events.WithoutCurrentState(true))
+			err = events.WaitForEvent(eventPod, gnssLossTime, 5*time.Minute, holdoverFilter)
 			Expect(err).ToNot(HaveOccurred(), "Failed to wait for sync-state HOLDOVER event on node %s", nodeName)
 
 			By("ensuring system clock is within 1.5 ms for entire holdover period")
@@ -528,8 +521,7 @@ var _ = Describe("PTP GNSS with NTP Fallback", Label(tsparams.LabelNTPFallback),
 				events.IsType(eventptp.OsClockSyncStateChange),
 				events.HasValue(events.WithSyncState(eventptp.LOCKED)),
 			)
-			err = events.WaitForEvent(
-				eventPod, gnssRecoveryTime, 5*time.Minute, osClockLockedFilter, events.WithoutCurrentState(true))
+			err = events.WaitForEvent(eventPod, gnssRecoveryTime, 5*time.Minute, osClockLockedFilter)
 			Expect(err).ToNot(HaveOccurred(), "Failed to wait for os-clock-sync-state LOCKED event on node %s", nodeName)
 
 			By("restoring the ts2phc holdover")


### PR DESCRIPTION
This commit uses the eventmetric package to fallback to metric
assertions whenever PTP events are not enabled.

Additionally, it flips the semantics of CurrentState. By default, the
CurrentState logs are excluded since they don't represent events being
sent to the consumer. They may be explicitly enabled when desired.

Closes: CNF-21255
Depends-on: #1123 
Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Combined event+metric assertion framework for PTP state validation (node/interface, start time, timeout).
  * Runtime check to skip event operations when cluster event publishing is disabled.
  * Tests temporarily tighten Prometheus scrape interval during runs and restore it afterwards.

* **Bug Fixes**
  * Improved error handling and clearer messages around event/config/version checks.

* **Refactor**
  * Tests reworked to use metric-driven assertions for LOCKED, FREERUN, HOLDOVER flows.

* **Documentation**
  * Event option renamed to control inclusion of current-state events (default: exclude).

* **Breaking Changes**
  * Event-wait API/option semantics changed; callers must adopt the new assertion-based flow or updated options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->