### PR TITLE
cluster: reliably execute commands

### DIFF
--- a/tests/lca/imagebasedupgrade/mgmt/upgrade/tests/e2e-upgrade-test.go
+++ b/tests/lca/imagebasedupgrade/mgmt/upgrade/tests/e2e-upgrade-test.go
@@ -631,18 +631,16 @@ var _ = Describe(
 
 			By("Validate the proper NTP servers are listed in the config", func() {
 				execCmd := "cat /etc/chrony.conf"
-				cmdOutput, err := cluster.ExecCmdWithStdoutWithRetries(APIClient, 5, 30*time.Second, execCmd)
+				cmdOutput, err := cluster.ExecCommandOnSNOWithRetries(APIClient, 6, 50*time.Second, execCmd)
 				Expect(err).ToNot(HaveOccurred(), "could not execute command: %s", err)
 
-				for _, stdout := range cmdOutput {
-					for _, ntpSource := range strings.Split(MGMTConfig.AdditionalNTPSources, ",") {
+				for _, ntpSource := range strings.Split(MGMTConfig.AdditionalNTPSources, ",") {
 
-						Expect(strings.ReplaceAll(stdout, "\n", "")).To(ContainSubstring("server %s",
-							ntpSource),
-							"error: the expected NTP source %s wasn't found", ntpSource)
-					}
-
+					Expect(strings.ReplaceAll(cmdOutput, "\n", "")).To(ContainSubstring("server %s",
+						ntpSource),
+						"error: the expected NTP source %s wasn't found", ntpSource)
 				}
+
 			})
 		})
 


### PR DESCRIPTION
Previous way of executing commands against nodes
doesn't seem to work properly anymore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved image-based upgrade tests by simplifying output validation to a single-result check and updating the command execution path, reducing flakiness and making NTP source verification more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->