### PR TITLE
cnf ran: increase wait for labels in post-provision

### DIFF
--- a/tests/cnf/ran/oran/tests/oran-post-provision.go
+++ b/tests/cnf/ran/oran/tests/oran-post-provision.go
@@ -275,7 +275,7 @@ func waitForLabels() {
 	clusterInstance, err := siteconfig.PullClusterInstance(HubAPIClient, RANConfig.Spoke1Name, RANConfig.Spoke1Name)
 	Expect(err).ToNot(HaveOccurred(), "Failed to pull spoke 1 ClusterInstance")
 
-	_, err = clusterInstance.WaitForExtraLabel("ManagedCluster", tsparams.TestName, 2*time.Minute)
+	_, err = clusterInstance.WaitForExtraLabel("ManagedCluster", tsparams.TestName, 5*time.Minute)
 	Expect(err).ToNot(HaveOccurred(), "Failed to wait for spoke 1 ClusterInstance to have the extraLabel")
 
 	By("waiting for ManagedCluster to have label")
@@ -283,7 +283,7 @@ func waitForLabels() {
 	mcl, err := ocm.PullManagedCluster(HubAPIClient, RANConfig.Spoke1Name)
 	Expect(err).ToNot(HaveOccurred(), "Failed to pull spoke 1 ManagedCluster")
 
-	_, err = mcl.WaitForLabel(tsparams.TestName, 2*time.Minute)
+	_, err = mcl.WaitForLabel(tsparams.TestName, 5*time.Minute)
 	Expect(err).ToNot(HaveOccurred(), "Failed to wait for spoke 1 ManagedCluster to have the label")
 }
 


### PR DESCRIPTION
This commit increases the timeouts in the post-provision waitForLabels
function to be 5 minutes instead of 2. This was done for other timeouts,
but missed for this one.

Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased timeout durations in test scenarios to improve test stability and reduce false failures during provisioning validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->