### PR TITLE
cnf network: add sriov dualstack test cases

### DIFF
--- a/tests/cnf/core/network/internal/netenv/netenv.go
+++ b/tests/cnf/core/network/internal/netenv/netenv.go
@@ -182,3 +182,68 @@ func SetStaticRoute(frrPod *pod.Builder, action, destIP, containerName string,
 
 	return buffer.String(), nil
 }
+
+// GetClusterIPFamily detects the cluster's IP family by checking node external OVN addresses.
+// Returns netparam.IPV4Family, netparam.IPV6Family, or netparam.DualIPFamily.
+func GetClusterIPFamily(apiClient *clients.Settings) (string, error) {
+	klog.V(90).Infof("Detecting cluster IP family from OVN external addresses")
+
+	const ovnExternalAddresses = "k8s.ovn.org/node-primary-ifaddr"
+
+	nodesList, err := nodes.List(apiClient)
+	if err != nil {
+		return "", fmt.Errorf("failed to list nodes: %w", err)
+	}
+
+	if len(nodesList) == 0 {
+		return "", fmt.Errorf("no nodes found")
+	}
+
+	// OVN's node-primary-ifaddr is expected to be consistent cluster-wide; use the first listed node only.
+	node := nodesList[0]
+
+	raw := node.Object.Annotations[ovnExternalAddresses]
+	if raw == "" {
+		return "", fmt.Errorf("node %q missing %q annotation", node.Object.Name, ovnExternalAddresses)
+	}
+
+	var extNetwork nodes.ExternalNetworks
+
+	err = json.Unmarshal([]byte(raw), &extNetwork)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse external network annotation on node %s: %w",
+			node.Object.Name, err)
+	}
+
+	var clusterIPFamily string
+
+	switch {
+	case extNetwork.IPv4 != "" && extNetwork.IPv6 != "":
+		clusterIPFamily = netparam.DualIPFamily
+	case extNetwork.IPv4 != "":
+		clusterIPFamily = netparam.IPV4Family
+	case extNetwork.IPv6 != "":
+		clusterIPFamily = netparam.IPV6Family
+	default:
+		return "", fmt.Errorf("no IPv4 or IPv6 external address found on node %s", node.Object.Name)
+	}
+
+	klog.V(90).Infof("Cluster IP family: %s", clusterIPFamily)
+
+	return clusterIPFamily, nil
+}
+
+// ClusterSupportsIPv4 returns true if the cluster supports IPv4 (single-stack or dual-stack).
+func ClusterSupportsIPv4(ipFamily string) bool {
+	return ipFamily == netparam.IPV4Family || ipFamily == netparam.DualIPFamily
+}
+
+// ClusterSupportsIPv6 returns true if the cluster supports IPv6 (single-stack or dual-stack).
+func ClusterSupportsIPv6(ipFamily string) bool {
+	return ipFamily == netparam.IPV6Family || ipFamily == netparam.DualIPFamily
+}
+
+// ClusterSupportsDualStack returns true if the cluster is dual-stack.
+func ClusterSupportsDualStack(ipFamily string) bool {
+	return ipFamily == netparam.DualIPFamily
+}

--- a/tests/cnf/core/network/internal/netparam/netvars.go
+++ b/tests/cnf/core/network/internal/netparam/netvars.go
@@ -9,10 +9,6 @@ import (
 var (
 	// Labels represents the range of labels that can be used for test cases selection.
 	Labels = append(coreparams.Labels, Label)
-	// LabelHostName contains the key for the hostname label.
-	LabelHostName = "kubernetes.io/hostname"
-	// OperatorResourceInjector defaults SR-IOV network resource injector daemonset.
-	OperatorResourceInjector = "network-resources-injector"
 	// DefaultTimeout represents the default timeout for most of Eventually/PollImmediate functions.
 	DefaultTimeout = 300 * time.Second
 	// MCOWaitTimeout represent timeout for mco operations.
@@ -23,11 +19,8 @@ var (
 	ClusterMonitoringNSLabel = map[string]string{"openshift.io/cluster-monitoring": "true"}
 	// MlxVendorID is the Mellanox Sriov Vendor ID.
 	MlxVendorID = "15b3"
-	// IPForwardAndSleepCmd defines a shell command to enable IPv4 forwarding and keep a process running indefinitely.
-	IPForwardAndSleepCmd = []string{
-		"/bin/bash",
-		"-c",
-		`echo 1 > /proc/sys/net/ipv4/ip_forward 2>/dev/null || true; \
-trap : TERM INT; sleep infinity & wait`,
-	}
+	// IPForwardAndSleepCmd is a container command that enables IPv4 forwarding and keeps the container running.
+	// Used by FRR hub pods and nftables tests that need forwarding enabled.
+	IPForwardAndSleepCmd = []string{"/bin/bash", "-c",
+		"echo 1 > /proc/sys/net/ipv4/ip_forward 2>/dev/null || true; trap : TERM INT; sleep infinity & wait"}
 )

--- a/tests/cnf/core/network/metallb/tests/bgp-unnumbered.go
+++ b/tests/cnf/core/network/metallb/tests/bgp-unnumbered.go
@@ -150,7 +150,7 @@ var _ = Describe("BGP Unnumbered", Ordered, Label(tsparams.LabelBGPUnnumbered),
 				By("Creating BGP Peers")
 				createBGPPeerUnnumberedAndVerifyIfItsReady(tsparams.BgpPeerName1, tsparams.BgpPeerDynamicASiBGP,
 					interfacesUnderTest[0], tsparams.BfdProfileName, tsparams.LocalBGPASN, 0, false,
-					0, frrk8sPods[0], map[string]string{netparam.LabelHostName: cnfWorkerNodeList[0].Definition.Name})
+					0, frrk8sPods[0], map[string]string{corev1.LabelHostname: cnfWorkerNodeList[0].Definition.Name})
 
 				By("Checking that BGP session is established and up")
 				verifyMetalLbBGPSessionsAreUPOnFrrPod(frrPod, []string{interfacesUnderTest[0]})
@@ -186,7 +186,7 @@ var _ = Describe("BGP Unnumbered", Ordered, Label(tsparams.LabelBGPUnnumbered),
 				createBGPPeerUnnumberedAndVerifyIfItsReady(tsparams.BgpPeerName1, tsparams.BgpPeerDynamicASeBGP,
 					interfacesUnderTest[0], tsparams.BfdProfileName, tsparams.LocalBGPASN, 0, false,
 					0, frrk8sPods[0],
-					map[string]string{netparam.LabelHostName: cnfWorkerNodeList[0].Definition.Name})
+					map[string]string{corev1.LabelHostname: cnfWorkerNodeList[0].Definition.Name})
 
 				frrPod := createFrrPod(
 					workerNodeList[1].Object.Name, frrConfigMap.Definition.Name, []string{}, frrStaticAnnotation)
@@ -235,7 +235,7 @@ var _ = Describe("BGP Unnumbered", Ordered, Label(tsparams.LabelBGPUnnumbered),
 				createBGPPeerUnnumberedAndVerifyIfItsReady(tsparams.BgpPeerName1, tsparams.BgpPeerDynamicASeBGP,
 					interfacesUnderTest[0], "", tsparams.LocalBGPASN, 0, false,
 					0, frrk8sPods[0],
-					map[string]string{netparam.LabelHostName: cnfWorkerNodeList[0].Definition.Name})
+					map[string]string{corev1.LabelHostname: cnfWorkerNodeList[0].Definition.Name})
 
 				frrPod := createFrrPod(
 					workerNodeList[1].Object.Name, frrConfigMap.Definition.Name, []string{}, frrStaticAnnotation)
@@ -281,7 +281,7 @@ var _ = Describe("BGP Unnumbered", Ordered, Label(tsparams.LabelBGPUnnumbered),
 				By("Creating BGP Peers")
 				createBGPPeerUnnumberedAndVerifyIfItsReady(tsparams.BgpPeerName1, "",
 					interfacesUnderTest[0], tsparams.BfdProfileName, tsparams.LocalBGPASN, tsparams.LocalBGPASN,
-					false, 0, frrk8sPods[0], map[string]string{netparam.LabelHostName: cnfWorkerNodeList[0].Definition.Name})
+					false, 0, frrk8sPods[0], map[string]string{corev1.LabelHostname: cnfWorkerNodeList[0].Definition.Name})
 
 				frrPod := createFrrPod(
 					workerNodeList[1].Object.Name, frrConfigMap.Definition.Name, []string{}, frrStaticAnnotation)

--- a/tests/cnf/core/network/metallb/tests/common.go
+++ b/tests/cnf/core/network/metallb/tests/common.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"encoding/json"
 	"fmt"
 	"net"
 	"strings"
@@ -59,9 +58,8 @@ var (
 )
 
 var (
-	metalLbTestsLabel    = map[string]string{"metallb": "metallbtests"}
-	ovnExternalAddresses = "k8s.ovn.org/node-primary-ifaddr"
-	frrPodSubnet         = map[string]string{
+	metalLbTestsLabel = map[string]string{"metallb": "metallbtests"}
+	frrPodSubnet      = map[string]string{
 		netparam.IPV4Family: netparam.IPSubnet24,
 		netparam.IPV6Family: netparam.IPSubnet64,
 	}
@@ -84,67 +82,6 @@ func clusterSupportsIPv4() bool {
 	return clusterIPVersion == netparam.IPV4Family || clusterIPVersion == netparam.DualIPFamily
 }
 
-func getClusterIPVersion() (string, error) {
-	nodesList, err := nodes.List(APIClient)
-	if err != nil {
-		return "", err
-	}
-
-	if len(nodesList) == 0 {
-		return "", fmt.Errorf("no nodes found")
-	}
-
-	var ipVersion string
-
-	for nodeIndex, node := range nodesList {
-		ipVersion, _, err = getNodeExternalIP(node)
-		if err != nil {
-			return "", err
-		}
-
-		if nodeIndex == 0 {
-			clusterIPVersion = ipVersion
-
-			continue
-		}
-
-		if ipVersion != clusterIPVersion {
-			return "", fmt.Errorf("mixed IP families detected: %s and %s", clusterIPVersion, ipVersion)
-		}
-	}
-
-	return clusterIPVersion, nil
-}
-
-func getNodeExternalIP(nodeBuilder *nodes.Builder) (string, nodes.ExternalNetworks, error) {
-	var extNetwork nodes.ExternalNetworks
-
-	raw := nodeBuilder.Object.Annotations[ovnExternalAddresses]
-	if raw == "" {
-		return "", nodes.ExternalNetworks{}, fmt.Errorf(
-			"node %q missing %q annotation",
-			nodeBuilder.Object.Name,
-			ovnExternalAddresses,
-		)
-	}
-
-	err := json.Unmarshal([]byte(raw), &extNetwork)
-	if err != nil {
-		return "", nodes.ExternalNetworks{}, err
-	}
-
-	switch {
-	case extNetwork.IPv4 != "" && extNetwork.IPv6 == "":
-		return netparam.IPV4Family, extNetwork, nil
-	case extNetwork.IPv4 == "" && extNetwork.IPv6 != "":
-		return netparam.IPV6Family, extNetwork, nil
-	case extNetwork.IPv4 != "" && extNetwork.IPv6 != "":
-		return netparam.DualIPFamily, extNetwork, nil
-	default:
-		return "", nodes.ExternalNetworks{}, fmt.Errorf("no IPv4 or IPv6 nodes found")
-	}
-}
-
 // Initializes and validates Vars:
 // ipv4metalLbIPList, ipv6metalLbIPList,
 // ipv4NodeAddrList, ipv6NodeAddrList,
@@ -159,7 +96,7 @@ func validateEnvVarAndGetNodeList() {
 
 	By("Getting cluster IP version")
 
-	clusterIPVersion, err = getClusterIPVersion()
+	clusterIPVersion, err = netenv.GetClusterIPFamily(APIClient)
 	Expect(err).ToNot(HaveOccurred(), "Failed to get cluster IP version")
 
 	By("Fetching IPv4 and IPv6 IPs from ENV VAR to be used for External FRR Pod")

--- a/tests/cnf/core/network/sriov/internal/sriovenv/sriovenv.go
+++ b/tests/cnf/core/network/sriov/internal/sriovenv/sriovenv.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	nadV1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
-	sriovV1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nad"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nodes"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
@@ -24,36 +23,54 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// ValidateSriovInterfaces checks that provided interfaces by env var exist on the nodes.
+// ActivateSCTPModuleOnWorkerNodes loads the SCTP kernel module on worker nodes when possible.
+// Used by SR-IOV suites (ipv4, ipv6, dual-stack) so tests can run without pre-configuring SCTP.
+// If modprobe fails (e.g. restricted environment), the existing lsmod check in the suites will still skip.
+func ActivateSCTPModuleOnWorkerNodes() {
+	klog.V(90).Infof("Activating SCTP module on worker nodes")
+
+	_, _ = cluster.ExecCmdWithStdout(APIClient, "modprobe sctp",
+		metav1.ListOptions{LabelSelector: labels.Set(NetConfig.WorkerLabelMap).String()})
+}
+
+// ValidateSriovInterfaces checks that the requested interfaces (from env) exist on every worker
+// in workerNodeList. This ensures "Different Node" and other multi-worker tests do not fail
+// later when scheduling on a worker that does not expose the requested PF names.
 func ValidateSriovInterfaces(workerNodeList []*nodes.Builder, requestedNumber int) error {
-	var validSriovIntefaceList []sriovV1.InterfaceExt
-
-	availableUpSriovInterfaces, err := sriov.NewNetworkNodeStateBuilder(APIClient,
-		workerNodeList[0].Definition.Name, NetConfig.SriovOperatorNamespace).GetUpNICs()
-	if err != nil {
-		return fmt.Errorf("failed get SR-IOV devices from the node %s", workerNodeList[0].Definition.Name)
-	}
-
 	requestedSriovInterfaceList, err := NetConfig.GetSriovInterfaces(requestedNumber)
 	if err != nil {
 		return err
 	}
 
-	for _, availableUpSriovInterface := range availableUpSriovInterfaces {
-		for _, requestedSriovInterface := range requestedSriovInterfaceList {
-			if availableUpSriovInterface.Name == requestedSriovInterface {
-				validSriovIntefaceList = append(validSriovIntefaceList, availableUpSriovInterface)
+	for _, worker := range workerNodeList {
+		availableUpSriovInterfaces, err := sriov.NewNetworkNodeStateBuilder(APIClient,
+			worker.Definition.Name, NetConfig.SriovOperatorNamespace).GetUpNICs()
+		if err != nil {
+			return fmt.Errorf("failed to get SR-IOV devices from node %s: %w", worker.Definition.Name, err)
+		}
+
+		var validCount int
+
+		for _, availableUpSriovInterface := range availableUpSriovInterfaces {
+			for _, requestedSriovInterface := range requestedSriovInterfaceList {
+				if availableUpSriovInterface.Name == requestedSriovInterface {
+					validCount++
+
+					break
+				}
 			}
 		}
-	}
 
-	if len(validSriovIntefaceList) < requestedNumber {
-		return fmt.Errorf("requested interfaces %v are not present on the cluster node", requestedSriovInterfaceList)
+		if validCount < requestedNumber {
+			return fmt.Errorf("requested interfaces %v are not all present on node %s (found %d of %d)",
+				requestedSriovInterfaceList, worker.Definition.Name, validCount, requestedNumber)
+		}
 	}
 
 	return nil
@@ -421,30 +438,89 @@ func CreateSriovNetworkWithStaticIPAM(name, resourceName string) error {
 	return CreateSriovNetworkAndWaitForNADCreation(networkBuilder, tsparams.NADWaitTimeout)
 }
 
+// whereaboutsDualStackIPAMJSON builds Whereabouts IPAM using ipRanges (per upstream Whereabouts README):
+// two RangeConfiguration entries with "range" (CIDR) plus optional range_start/range_end.
+// Do not use "ranges"/"subnet" — they are not unmarshaled into types.IPAMConfig, so allocation returns
+// no IPs and Multus/SR-IOV reports "IPAM plugin returned missing IP config".
+// IPv4/IPv6 gateways are not passed here: a bare IPv6 gateway string is parsed as CIDR elsewhere and fails.
+func whereaboutsDualStackIPAMJSON(ipRange, ipv6Range, networkName string) string {
+	v4Start, v4End := tsparams.WhereaboutsIPv4AllocStart, tsparams.WhereaboutsIPv4AllocEnd
+	v6Start, v6End := tsparams.WhereaboutsIPv6AllocStart, tsparams.WhereaboutsIPv6AllocEnd
+
+	if ipRange == tsparams.WhereaboutsIPv4Range2 {
+		v4Start, v4End = tsparams.WhereaboutsIPv4AllocStart2, tsparams.WhereaboutsIPv4AllocEnd2
+		v6Start, v6End = tsparams.WhereaboutsIPv6AllocStart2, tsparams.WhereaboutsIPv6AllocEnd2
+	}
+
+	if networkName != "" {
+		return fmt.Sprintf(`{
+			"type": "whereabouts",
+			"ipRanges": [
+				{"range": "%s", "range_start": "%s", "range_end": "%s"},
+				{"range": "%s", "range_start": "%s", "range_end": "%s"}
+			],
+			"network_name": "%s"
+		}`, ipRange, v4Start, v4End, ipv6Range, v6Start, v6End, networkName)
+	}
+
+	return fmt.Sprintf(`{
+		"type": "whereabouts",
+		"ipRanges": [
+			{"range": "%s", "range_start": "%s", "range_end": "%s"},
+			{"range": "%s", "range_start": "%s", "range_end": "%s"}
+		]
+	}`, ipRange, v4Start, v4End, ipv6Range, v6Start, v6End)
+}
+
 // CreateSriovNetworkWithWhereaboutsIPAM creates an SR-IOV network with whereabouts IPAM for dynamic IP assignment.
 // ipRange should be in CIDR notation (e.g., "2001:100::/64" for IPv6 or "192.168.1.0/24" for IPv4).
-// gateway is the gateway address for the range.
+// gateway is used for single-stack only. Dual-stack uses ranges without gateway (ipv6Gateway is ignored).
 func CreateSriovNetworkWithWhereaboutsIPAM(
-	name, resourceName, ipRange, gateway, networkName string) error {
+	name,
+	resourceName,
+	ipRange,
+	gateway,
+	networkName,
+	ipv6Range string,
+) error {
 	klog.V(90).Infof("Creating SR-IOV network %s with whereabouts IPAM, range %s, gateway %s",
 		name, ipRange, gateway)
 
 	networkBuilder := sriov.NewNetworkBuilder(
 		APIClient, name, NetConfig.SriovOperatorNamespace,
-		tsparams.TestNamespaceName, resourceName).WithWhereaboutsIPAM(ipRange, gateway, "", networkName)
+		tsparams.TestNamespaceName, resourceName)
+
+	if ipv6Range != "" {
+		networkBuilder.Definition.Spec.IPAM = whereaboutsDualStackIPAMJSON(ipRange, ipv6Range, networkName)
+	} else {
+		networkBuilder = networkBuilder.WithWhereaboutsIPAM(ipRange, gateway, "", networkName)
+	}
 
 	return CreateSriovNetworkAndWaitForNADCreation(networkBuilder, tsparams.NADWaitTimeout)
 }
 
 // CreateSriovNetworkWithVLANAndWhereabouts creates an SR-IOV network with Whereabouts IPAM and VLAN tagging.
-func CreateSriovNetworkWithVLANAndWhereabouts(name, resourceName string, vlanID uint16,
-	ipRange, gateway string) error {
+// Dual-stack uses ipRanges without gateway (ipv6Gateway is ignored, same as CreateSriovNetworkWithWhereaboutsIPAM).
+func CreateSriovNetworkWithVLANAndWhereabouts(
+	name,
+	resourceName string,
+	vlanID uint16,
+	ipRange,
+	gateway,
+	ipv6Range string,
+) error {
 	klog.V(90).Infof("Creating SR-IOV network %s with Whereabouts IPAM, VLAN %d, range %s",
 		name, vlanID, ipRange)
 
 	networkBuilder := sriov.NewNetworkBuilder(
 		APIClient, name, NetConfig.SriovOperatorNamespace,
-		tsparams.TestNamespaceName, resourceName).WithVLAN(vlanID).WithWhereaboutsIPAM(ipRange, gateway, "", "")
+		tsparams.TestNamespaceName, resourceName).WithVLAN(vlanID)
+
+	if ipv6Range != "" {
+		networkBuilder.Definition.Spec.IPAM = whereaboutsDualStackIPAMJSON(ipRange, ipv6Range, "")
+	} else {
+		networkBuilder = networkBuilder.WithWhereaboutsIPAM(ipRange, gateway, "", "")
+	}
 
 	return CreateSriovNetworkAndWaitForNADCreation(networkBuilder, tsparams.NADWaitTimeout)
 }
@@ -660,12 +736,17 @@ func CreateTestClientPod(
 		return nil, fmt.Errorf("failed to create container config: %w", err)
 	}
 
-	return pod.NewBuilder(APIClient, name, tsparams.TestNamespaceName, NetConfig.CnfNetTestContainer).
+	podBuilder, err := pod.NewBuilder(APIClient, name, tsparams.TestNamespaceName, NetConfig.CnfNetTestContainer).
 		DefineOnNode(nodeName).
 		RedefineDefaultContainer(*container).
 		WithPrivilegedFlag().
 		WithSecondaryNetwork(secNetwork).
 		CreateAndWaitUntilRunning(netparam.DefaultTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	return podBuilder, nil
 }
 
 // CreateTestServerPod creates a server pod with testcmd listeners for TCP, UDP, SCTP, and multicast.
@@ -800,6 +881,11 @@ func buildMulticastSetup(isIPv6 bool, interfaceName string, mtu int) (setupCmd, 
 
 	return fmt.Sprintf("ip maddr add %s dev %s 2>/dev/null || true; ",
 		ipv4MAC, interfaceName), ipv4Group
+}
+
+// BuildMulticastSetup returns shell fragments to configure multicast for testcmd listeners (IPv4 or IPv6).
+func BuildMulticastSetup(isIPv6 bool, interfaceName string, mtu int) (setupCmd, multicastGroup string) {
+	return buildMulticastSetup(isIPv6, interfaceName, mtu)
 }
 
 // buildDynamicIPServerCommand builds the server command for Whereabouts IPAM

--- a/tests/cnf/core/network/sriov/internal/tsparams/consts.go
+++ b/tests/cnf/core/network/sriov/internal/tsparams/consts.go
@@ -84,4 +84,9 @@ const (
 	MulticastIPv6Group = "ff05:5::5"
 	// MulticastIPv6MAC is the Ethernet multicast MAC for ff05:5::5.
 	MulticastIPv6MAC = "33:33:00:00:00:05"
+
+	// DualStackSCTPv6Port is the SCTP listener port for IPv6 in dual-stack tests (IPv4 uses 5003).
+	DualStackSCTPv6Port = 5005
+	// DualStackMulticastV6Port is the multicast listener port for IPv6 in dual-stack tests.
+	DualStackMulticastV6Port = 5006
 )

--- a/tests/cnf/core/network/sriov/internal/tsparams/sriovvars.go
+++ b/tests/cnf/core/network/sriov/internal/tsparams/sriovvars.go
@@ -64,7 +64,6 @@ var (
 	ClientIPv6IPAddress2 = "2001:100::1/64"
 	// ServerIPv6IPAddress2 represents the full test IPv6 address.
 	ServerIPv6IPAddress2 = "2001:100::2/64"
-
 	// ClientMacAddress represents the test client MAC address.
 	ClientMacAddress = "20:04:0f:f1:88:01"
 	// ServerMacAddress represents the test server MAC address.
@@ -73,7 +72,6 @@ var (
 	ClientMacAddress2 = "20:04:0f:f1:88:03"
 	// ServerMacAddress2 represents the second test server MAC address.
 	ServerMacAddress2 = "20:04:0f:f1:88:04"
-
 	// WhereaboutsIPv4Range is the IP range for whereabouts IPAM.
 	WhereaboutsIPv4Range = "192.168.100.0/24"
 	// WhereaboutsIPv4Gateway is the gateway for whereabouts IPAM.
@@ -82,7 +80,6 @@ var (
 	WhereaboutsIPv4Range2 = "192.168.101.0/24"
 	// WhereaboutsIPv4Gateway2 is the gateway for whereabouts IPAM range 2.
 	WhereaboutsIPv4Gateway2 = "192.168.101.1"
-
 	// WhereaboutsIPv6Range is the IPv6 range for whereabouts IPAM.
 	WhereaboutsIPv6Range = "2001:100:100::/64"
 	// WhereaboutsIPv6Gateway is the IPv6 gateway for whereabouts IPAM.
@@ -91,7 +88,22 @@ var (
 	WhereaboutsIPv6Range2 = "2001:100:101::/64"
 	// WhereaboutsIPv6Gateway2 is the IPv6 gateway for whereabouts IPAM range 2.
 	WhereaboutsIPv6Gateway2 = "2001:100:101::1"
-
+	// WhereaboutsIPv4AllocStart is the first IPv4 in the dynamic pool for dual-stack Whereabouts NADs (ipRanges).
+	WhereaboutsIPv4AllocStart = "192.168.100.10"
+	// WhereaboutsIPv4AllocEnd is the last IPv4 in the dynamic pool for dual-stack Whereabouts NADs (ipRanges).
+	WhereaboutsIPv4AllocEnd = "192.168.100.250"
+	// WhereaboutsIPv6AllocStart is the first IPv6 in the dynamic pool for dual-stack Whereabouts NADs (ipRanges).
+	WhereaboutsIPv6AllocStart = "2001:100:100::10"
+	// WhereaboutsIPv6AllocEnd is the last IPv6 in the dynamic pool for dual-stack Whereabouts NADs (ipRanges).
+	WhereaboutsIPv6AllocEnd = "2001:100:100::ff00"
+	// WhereaboutsIPv4AllocStart2 is the first IPv4 in the second pool (WhereaboutsIPv4Range2 / IPv6 range 2).
+	WhereaboutsIPv4AllocStart2 = "192.168.101.10"
+	// WhereaboutsIPv4AllocEnd2 is the last IPv4 in the second pool.
+	WhereaboutsIPv4AllocEnd2 = "192.168.101.250"
+	// WhereaboutsIPv6AllocStart2 is the first IPv6 in the second pool.
+	WhereaboutsIPv6AllocStart2 = "2001:100:101::10"
+	// WhereaboutsIPv6AllocEnd2 is the last IPv6 in the second pool.
+	WhereaboutsIPv6AllocEnd2 = "2001:100:101::ff00"
 	// OperatorConfigDaemon defaults SR-IOV config daemon daemonset.
 	OperatorConfigDaemon = "sriov-network-config-daemon"
 	// OperatorWebhook defaults SR-IOV webhook daemonset.

--- a/tests/cnf/core/network/sriov/tests/sriov-ipdual.go
+++ b/tests/cnf/core/network/sriov/tests/sriov-ipdual.go
@@ -22,16 +22,14 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-var _ = Describe("SR-IOV IPv6", Ordered, Label(tsparams.LabelSuite), ContinueOnFailure, func() {
+var _ = Describe("SR-IOV DualStack", Ordered, Label(tsparams.LabelSuite), ContinueOnFailure, func() {
 	const (
-		// SR-IOV resource names for policies.
-		sriovResourcePF1MTU1280 = "sriovpf1mtu1280v6"
-		sriovResourcePF1MTU9000 = "sriovpf1mtu9000v6"
-		sriovResourcePF2MTU1280 = "sriovpf2mtu1280v6"
-		sriovResourcePF2MTU9000 = "sriovpf2mtu9000v6"
-		// MTU values for testing. 1280 is the IPv6 minimum MTU.
-		mtu1280 = 1280
-		mtu9000 = 9000
+		sriovResourcePF1MTU1280 = "sriovpf1mtu1280ds"
+		sriovResourcePF1MTU9000 = "sriovpf1mtu9000ds"
+		sriovResourcePF2MTU1280 = "sriovpf2mtu1280ds"
+		sriovResourcePF2MTU9000 = "sriovpf2mtu9000ds"
+		mtu1280                 = 1280
+		mtu9000                 = 9000
 	)
 
 	var (
@@ -48,8 +46,8 @@ var _ = Describe("SR-IOV IPv6", Ordered, Label(tsparams.LabelSuite), ContinueOnF
 		clusterIPFamily, err := netenv.GetClusterIPFamily(APIClient)
 		Expect(err).ToNot(HaveOccurred(), "Failed to detect cluster IP family")
 
-		if !netenv.ClusterSupportsIPv6(clusterIPFamily) {
-			Skip("Cluster does not support IPv6 - skipping IPv6 SR-IOV tests")
+		if !netenv.ClusterSupportsDualStack(clusterIPFamily) {
+			Skip("Cluster is not dual-stack - skipping dual-stack SR-IOV tests")
 		}
 
 		By("Discover and list worker nodes")
@@ -89,7 +87,7 @@ var _ = Describe("SR-IOV IPv6", Ordered, Label(tsparams.LabelSuite), ContinueOnF
 			sriovInterfacePF1, sriovInterfacePF2,
 			sriovResourcePF1MTU1280, sriovResourcePF1MTU9000,
 			sriovResourcePF2MTU1280, sriovResourcePF2MTU9000,
-			"ipv6", mtu1280, mtu9000)
+			"dualstack", mtu1280, mtu9000)
 		Expect(err).ToNot(HaveOccurred(), "Failed to create SR-IOV policies")
 	})
 
@@ -105,13 +103,12 @@ var _ = Describe("SR-IOV IPv6", Ordered, Label(tsparams.LabelSuite), ContinueOnF
 		Expect(err).ToNot(HaveOccurred(), "Failed to remove SR-IOV configuration")
 	})
 
-	// Context for Same Node, Same PF connectivity tests.
 	Context("Same Node Same PF", func() {
 		const (
-			sriovNetworkSamePFMTU1280     = "sriov-net-samepf-mtu1280-v6"
-			sriovNetworkSamePFMTU9000     = "sriov-net-samepf-mtu9000-v6"
-			sriovNetworkVlanSamePFMTU1280 = "sriov-net-vlan-samepf-mtu1280-v6"
-			sriovNetworkVlanSamePFMTU9000 = "sriov-net-vlan-samepf-mtu9000-v6"
+			sriovNetworkSamePFMTU1280     = "sriov-net-samepf-mtu1280-ds"
+			sriovNetworkSamePFMTU9000     = "sriov-net-samepf-mtu9000-ds"
+			sriovNetworkVlanSamePFMTU1280 = "sriov-net-vlan-samepf-mtu1280-ds"
+			sriovNetworkVlanSamePFMTU9000 = "sriov-net-vlan-samepf-mtu9000-ds"
 		)
 
 		BeforeAll(func() {
@@ -122,19 +119,20 @@ var _ = Describe("SR-IOV IPv6", Ordered, Label(tsparams.LabelSuite), ContinueOnF
 				sriovResourcePF1MTU1280, sriovResourcePF1MTU9000)
 			Expect(err).ToNot(HaveOccurred(), "Failed to create SR-IOV networks")
 
-			// VLAN network for Same PF VLAN test.
 			vlanID, err := NetConfig.GetVLAN()
 			Expect(err).ToNot(HaveOccurred(), "Failed to get VLAN ID from ECO_CNF_CORE_NET_VLAN")
 
 			err = sriovenv.CreateSriovNetworkWithVLANAndWhereabouts(
 				sriovNetworkVlanSamePFMTU1280, sriovResourcePF1MTU1280, vlanID,
-				tsparams.WhereaboutsIPv6Range, tsparams.WhereaboutsIPv6Gateway, "")
-			Expect(err).ToNot(HaveOccurred(), "Failed to create VLAN network for Same PF MTU 1280")
+				tsparams.WhereaboutsIPv4Range, tsparams.WhereaboutsIPv4Gateway,
+				tsparams.WhereaboutsIPv6Range)
+			Expect(err).ToNot(HaveOccurred(), "Failed to create dual-stack VLAN network for Same PF MTU 1280")
 
 			err = sriovenv.CreateSriovNetworkWithVLANAndWhereabouts(
 				sriovNetworkVlanSamePFMTU9000, sriovResourcePF1MTU9000, vlanID,
-				tsparams.WhereaboutsIPv6Range2, tsparams.WhereaboutsIPv6Gateway2, "")
-			Expect(err).ToNot(HaveOccurred(), "Failed to create VLAN network for Same PF MTU 9000")
+				tsparams.WhereaboutsIPv4Range2, tsparams.WhereaboutsIPv4Gateway2,
+				tsparams.WhereaboutsIPv6Range2)
+			Expect(err).ToNot(HaveOccurred(), "Failed to create dual-stack VLAN network for Same PF MTU 9000")
 		})
 
 		AfterEach(func() {
@@ -152,117 +150,134 @@ var _ = Describe("SR-IOV IPv6", Ordered, Label(tsparams.LabelSuite), ContinueOnF
 				APIClient, NetConfig.SriovOperatorNamespace, tsparams.TestNamespaceName)
 			Expect(err).ToNot(HaveOccurred(), "Failed to delete SR-IOV networks")
 		})
-
-		It("Verify SR-IOV IPv6 connectivity with Static IPAM and Static MAC", reportxml.ID("87522"), func() {
+		It("Verify SR-IOV dual-stack connectivity with Static IPAM and Static MAC", reportxml.ID("88141"), func() {
 			By("Creating client and server pods for MTU 1280")
 
-			clientMTU1280, _, err := sriovenv.CreatePodPair(
+			clientMTU1280, _, err := CreateDualStackPodPair(
 				tsparams.ClientPodMTU1280, tsparams.ServerPodMTU1280,
 				workerNodeList[0].Definition.Name, workerNodeList[0].Definition.Name,
 				sriovNetworkSamePFMTU1280, sriovNetworkSamePFMTU1280,
+				ipaddr.RemovePrefix(tsparams.ServerIPv4IPAddress),
 				ipaddr.RemovePrefix(tsparams.ServerIPv6IPAddress),
 				tsparams.ClientMacAddress, tsparams.ServerMacAddress,
-				[]string{tsparams.ClientIPv6IPAddress}, []string{tsparams.ServerIPv6IPAddress},
+				[]string{tsparams.ClientIPv4IPAddress, tsparams.ClientIPv6IPAddress},
+				[]string{tsparams.ServerIPv4IPAddress, tsparams.ServerIPv6IPAddress},
 				mtu1280)
 			Expect(err).ToNot(HaveOccurred(), "Failed to create pods for MTU 1280")
 
 			By("Creating client and server pods for MTU 9000")
 
-			clientMTU9000, _, err := sriovenv.CreatePodPair(
+			clientMTU9000, _, err := CreateDualStackPodPair(
 				tsparams.ClientPodMTU9000, tsparams.ServerPodMTU9000,
 				workerNodeList[0].Definition.Name, workerNodeList[0].Definition.Name,
 				sriovNetworkSamePFMTU9000, sriovNetworkSamePFMTU9000,
-				ipaddr.RemovePrefix(tsparams.ServerIPv6IPAddress2), tsparams.ClientMacAddress2, tsparams.ServerMacAddress2,
-				[]string{tsparams.ClientIPv6IPAddress2}, []string{tsparams.ServerIPv6IPAddress2},
+				ipaddr.RemovePrefix(tsparams.ServerIPv4IPAddress2),
+				ipaddr.RemovePrefix(tsparams.ServerIPv6IPAddress2),
+				tsparams.ClientMacAddress2, tsparams.ServerMacAddress2,
+				[]string{tsparams.ClientIPv4IPAddress2, tsparams.ClientIPv6IPAddress2},
+				[]string{tsparams.ServerIPv4IPAddress2, tsparams.ServerIPv6IPAddress2},
 				mtu9000)
 			Expect(err).ToNot(HaveOccurred(), "Failed to create pods for MTU 9000")
 
-			err = sriovenv.RunTrafficTestsForBothMTUs(clientMTU1280, clientMTU9000,
+			err = RunDualStackTrafficTestsForBothMTUs(clientMTU1280, clientMTU9000,
+				ipaddr.RemovePrefix(tsparams.ServerIPv4IPAddress),
 				ipaddr.RemovePrefix(tsparams.ServerIPv6IPAddress),
+				ipaddr.RemovePrefix(tsparams.ServerIPv4IPAddress2),
 				ipaddr.RemovePrefix(tsparams.ServerIPv6IPAddress2),
 				mtu1280, mtu9000)
-			Expect(err).ToNot(HaveOccurred(), "Traffic tests failed")
+			Expect(err).ToNot(HaveOccurred(), "Dual-stack traffic tests failed")
 		})
 
-		It("Verify SR-IOV IPv6 connectivity with Whereabouts IPAM, Dynamic MAC, and VLAN",
-			reportxml.ID("87558"), func() {
+		It("Verify SR-IOV dual-stack connectivity with Whereabouts IPAM, Dynamic MAC, and VLAN",
+			reportxml.ID("88142"), func() {
 				By("Creating VLAN pods for MTU 1280")
 
-				vlanClientMTU1280, vlanServerMTU1280, err := sriovenv.CreatePodPair(
+				vlanClientMTU1280, vlanServerMTU1280, err := CreateDualStackPodPair(
 					tsparams.ClientPodVlanMTU1280, tsparams.ServerPodVlanMTU1280,
 					workerNodeList[0].Definition.Name, workerNodeList[0].Definition.Name,
 					sriovNetworkVlanSamePFMTU1280, sriovNetworkVlanSamePFMTU1280,
-					"", "", "",
+					"", "", "", "",
 					nil, nil, mtu1280)
 				Expect(err).ToNot(HaveOccurred(), "Failed to create VLAN pods for MTU 1280")
 
 				By("Creating VLAN pods for MTU 9000")
 
-				vlanClientMTU9000, vlanServerMTU9000, err := sriovenv.CreatePodPair(
+				vlanClientMTU9000, vlanServerMTU9000, err := CreateDualStackPodPair(
 					tsparams.ClientPodVlanMTU9000, tsparams.ServerPodVlanMTU9000,
 					workerNodeList[0].Definition.Name, workerNodeList[0].Definition.Name,
 					sriovNetworkVlanSamePFMTU9000, sriovNetworkVlanSamePFMTU9000,
-					"", "", "",
+					"", "", "", "",
 					nil, nil, mtu9000)
 				Expect(err).ToNot(HaveOccurred(), "Failed to create VLAN pods for MTU 9000")
 
 				By("Getting server IPs from pod interfaces")
 
-				serverIPMTU1280, err := sriovenv.GetPodIPFromInterface(vlanServerMTU1280, tsparams.Net1Interface, "ipv6")
-				Expect(err).ToNot(HaveOccurred(), "Failed to get server IP from VLAN pod for MTU 1280")
+				serverIPv4MTU1280, err := sriovenv.GetPodIPFromInterface(
+					vlanServerMTU1280, tsparams.Net1Interface, "ipv4")
+				Expect(err).ToNot(HaveOccurred(), "Failed to get IPv4 server IP for MTU 1280")
 
-				serverIPMTU9000, err := sriovenv.GetPodIPFromInterface(vlanServerMTU9000, tsparams.Net1Interface, "ipv6")
-				Expect(err).ToNot(HaveOccurred(), "Failed to get server IP from VLAN pod for MTU 9000")
+				serverIPv6MTU1280, err := sriovenv.GetPodIPFromInterface(
+					vlanServerMTU1280, tsparams.Net1Interface, "ipv6")
+				Expect(err).ToNot(HaveOccurred(), "Failed to get IPv6 server IP for MTU 1280")
 
-				By("Running traffic tests over VLAN with dynamic IP for MTU 1280")
+				serverIPv4MTU9000, err := sriovenv.GetPodIPFromInterface(
+					vlanServerMTU9000, tsparams.Net1Interface, "ipv4")
+				Expect(err).ToNot(HaveOccurred(), "Failed to get IPv4 server IP for MTU 9000")
 
-				err = sriovenv.RunTrafficTest(vlanClientMTU1280, serverIPMTU1280, mtu1280)
-				Expect(err).ToNot(HaveOccurred(), "Traffic tests failed for VLAN MTU 1280")
+				serverIPv6MTU9000, err := sriovenv.GetPodIPFromInterface(
+					vlanServerMTU9000, tsparams.Net1Interface, "ipv6")
+				Expect(err).ToNot(HaveOccurred(), "Failed to get IPv6 server IP for MTU 9000")
 
-				By("Running traffic tests over VLAN with dynamic IP for MTU 9000")
+				By("Running dual-stack traffic tests over VLAN for MTU 1280")
 
-				err = sriovenv.RunTrafficTest(vlanClientMTU9000, serverIPMTU9000, mtu9000)
-				Expect(err).ToNot(HaveOccurred(), "Traffic tests failed for VLAN MTU 9000")
+				err = RunDualStackTrafficTest(vlanClientMTU1280,
+					serverIPv4MTU1280, serverIPv6MTU1280, mtu1280)
+				Expect(err).ToNot(HaveOccurred(), "Dual-stack traffic tests failed for VLAN MTU 1280")
+
+				By("Running dual-stack traffic tests over VLAN for MTU 9000")
+
+				err = RunDualStackTrafficTest(vlanClientMTU9000,
+					serverIPv4MTU9000, serverIPv6MTU9000, mtu9000)
+				Expect(err).ToNot(HaveOccurred(), "Dual-stack traffic tests failed for VLAN MTU 9000")
 			})
 	})
 
-	// Context for Same Node, Different PF connectivity tests.
 	Context("Same Node Different PF", func() {
 		const (
-			sriovNetworkDiffPFClientMTU1280            = "sriov-net-diffpf-client-mtu1280-v6"
-			sriovNetworkDiffPFServerMTU1280            = "sriov-net-diffpf-server-mtu1280-v6"
-			sriovNetworkDiffPFClientMTU9000            = "sriov-net-diffpf-client-mtu9000-v6"
-			sriovNetworkDiffPFServerMTU9000            = "sriov-net-diffpf-server-mtu9000-v6"
-			sriovNetworkWhereaboutsDiffPFClientMTU1280 = "sriov-net-wb-diffpf-client-mtu1280-v6"
-			sriovNetworkWhereaboutsDiffPFServerMTU1280 = "sriov-net-wb-diffpf-server-mtu1280-v6"
+			sriovNetworkDiffPFClientMTU1280            = "sriov-net-diffpf-client-mtu1280-ds"
+			sriovNetworkDiffPFServerMTU1280            = "sriov-net-diffpf-server-mtu1280-ds"
+			sriovNetworkDiffPFClientMTU9000            = "sriov-net-diffpf-client-mtu9000-ds"
+			sriovNetworkDiffPFServerMTU9000            = "sriov-net-diffpf-server-mtu9000-ds"
+			sriovNetworkWhereaboutsDiffPFClientMTU1280 = "sriov-net-wb-diffpf-client-mtu1280-ds"
+			sriovNetworkWhereaboutsDiffPFServerMTU1280 = "sriov-net-wb-diffpf-server-mtu1280-ds"
 		)
 
 		BeforeAll(func() {
 			By("Creating SR-IOV Networks for Same Node Different PF")
-			// Client networks use PF1 resources.
+
 			err = sriovenv.CreateSriovNetworksForBothMTUs(
 				sriovNetworkDiffPFClientMTU1280, sriovNetworkDiffPFClientMTU9000,
 				sriovResourcePF1MTU1280, sriovResourcePF1MTU9000)
 			Expect(err).ToNot(HaveOccurred(), "Failed to create client networks")
 
-			// Server networks use PF2 resources.
 			err = sriovenv.CreateSriovNetworksForBothMTUs(
 				sriovNetworkDiffPFServerMTU1280, sriovNetworkDiffPFServerMTU9000,
 				sriovResourcePF2MTU1280, sriovResourcePF2MTU9000)
 			Expect(err).ToNot(HaveOccurred(), "Failed to create server networks")
 
-			// Whereabouts networks for dynamic IP/MAC test.
 			err = sriovenv.CreateSriovNetworkWithWhereaboutsIPAM(
 				sriovNetworkWhereaboutsDiffPFClientMTU1280, sriovResourcePF1MTU1280,
-				tsparams.WhereaboutsIPv6Range, tsparams.WhereaboutsIPv6Gateway,
-				sriovNetworkWhereaboutsDiffPFClientMTU1280, "")
-			Expect(err).ToNot(HaveOccurred(), "Failed to create whereabouts client network")
+				tsparams.WhereaboutsIPv4Range, tsparams.WhereaboutsIPv4Gateway,
+				sriovNetworkWhereaboutsDiffPFClientMTU1280,
+				tsparams.WhereaboutsIPv6Range)
+			Expect(err).ToNot(HaveOccurred(), "Failed to create dual-stack whereabouts client network")
 
 			err = sriovenv.CreateSriovNetworkWithWhereaboutsIPAM(
 				sriovNetworkWhereaboutsDiffPFServerMTU1280, sriovResourcePF2MTU1280,
-				tsparams.WhereaboutsIPv6Range, tsparams.WhereaboutsIPv6Gateway,
-				sriovNetworkWhereaboutsDiffPFClientMTU1280, "")
-			Expect(err).ToNot(HaveOccurred(), "Failed to create whereabouts server network")
+				tsparams.WhereaboutsIPv4Range, tsparams.WhereaboutsIPv4Gateway,
+				sriovNetworkWhereaboutsDiffPFClientMTU1280,
+				tsparams.WhereaboutsIPv6Range)
+			Expect(err).ToNot(HaveOccurred(), "Failed to create dual-stack whereabouts server network")
 		})
 
 		AfterEach(func() {
@@ -281,67 +296,79 @@ var _ = Describe("SR-IOV IPv6", Ordered, Label(tsparams.LabelSuite), ContinueOnF
 			Expect(err).ToNot(HaveOccurred(), "Failed to delete SR-IOV networks")
 		})
 
-		It("Verify SR-IOV IPv6 connectivity between different PFs on same node with Static IPAM and Static MAC",
-			reportxml.ID("87559"), func() {
+		It("Verify SR-IOV dual-stack connectivity between different PFs with Static IPAM and Static MAC",
+			reportxml.ID("88143"), func() {
 				By("Creating client and server pods for MTU 1280")
 
-				clientMTU1280, _, err := sriovenv.CreatePodPair(
+				clientMTU1280, _, err := CreateDualStackPodPair(
 					tsparams.ClientPodMTU1280, tsparams.ServerPodMTU1280,
 					workerNodeList[0].Definition.Name, workerNodeList[0].Definition.Name,
 					sriovNetworkDiffPFClientMTU1280, sriovNetworkDiffPFServerMTU1280,
-					ipaddr.RemovePrefix(tsparams.ServerIPv6IPAddress), tsparams.ClientMacAddress, tsparams.ServerMacAddress,
-					[]string{tsparams.ClientIPv6IPAddress}, []string{tsparams.ServerIPv6IPAddress},
+					ipaddr.RemovePrefix(tsparams.ServerIPv4IPAddress),
+					ipaddr.RemovePrefix(tsparams.ServerIPv6IPAddress),
+					tsparams.ClientMacAddress, tsparams.ServerMacAddress,
+					[]string{tsparams.ClientIPv4IPAddress, tsparams.ClientIPv6IPAddress},
+					[]string{tsparams.ServerIPv4IPAddress, tsparams.ServerIPv6IPAddress},
 					mtu1280)
 				Expect(err).ToNot(HaveOccurred(), "Failed to create pods for MTU 1280")
 
 				By("Creating client and server pods for MTU 9000")
 
-				clientMTU9000, _, err := sriovenv.CreatePodPair(
+				clientMTU9000, _, err := CreateDualStackPodPair(
 					tsparams.ClientPodMTU9000, tsparams.ServerPodMTU9000,
 					workerNodeList[0].Definition.Name, workerNodeList[0].Definition.Name,
 					sriovNetworkDiffPFClientMTU9000, sriovNetworkDiffPFServerMTU9000,
-					ipaddr.RemovePrefix(tsparams.ServerIPv6IPAddress2), tsparams.ClientMacAddress2, tsparams.ServerMacAddress2,
-					[]string{tsparams.ClientIPv6IPAddress2}, []string{tsparams.ServerIPv6IPAddress2},
+					ipaddr.RemovePrefix(tsparams.ServerIPv4IPAddress2),
+					ipaddr.RemovePrefix(tsparams.ServerIPv6IPAddress2),
+					tsparams.ClientMacAddress2, tsparams.ServerMacAddress2,
+					[]string{tsparams.ClientIPv4IPAddress2, tsparams.ClientIPv6IPAddress2},
+					[]string{tsparams.ServerIPv4IPAddress2, tsparams.ServerIPv6IPAddress2},
 					mtu9000)
 				Expect(err).ToNot(HaveOccurred(), "Failed to create pods for MTU 9000")
 
-				err = sriovenv.RunTrafficTestsForBothMTUs(clientMTU1280, clientMTU9000,
+				err = RunDualStackTrafficTestsForBothMTUs(clientMTU1280, clientMTU9000,
+					ipaddr.RemovePrefix(tsparams.ServerIPv4IPAddress),
 					ipaddr.RemovePrefix(tsparams.ServerIPv6IPAddress),
+					ipaddr.RemovePrefix(tsparams.ServerIPv4IPAddress2),
 					ipaddr.RemovePrefix(tsparams.ServerIPv6IPAddress2),
 					mtu1280, mtu9000)
-				Expect(err).ToNot(HaveOccurred(), "Traffic tests failed")
+				Expect(err).ToNot(HaveOccurred(), "Dual-stack traffic tests failed")
 			})
 
-		It("Verify SR-IOV IPv6 connectivity with Whereabouts IPAM and Dynamic MAC",
-			reportxml.ID("87560"), func() {
+		It("Verify SR-IOV dual-stack connectivity with Whereabouts IPAM and Dynamic MAC",
+			reportxml.ID("88144"), func() {
 				By("Creating whereabouts pods with dynamic IP/MAC")
 
-				whereaboutsClient, whereaboutsServer, err := sriovenv.CreatePodPair(
+				whereaboutsClient, whereaboutsServer, err := CreateDualStackPodPair(
 					tsparams.ClientPodWhereabouts, tsparams.ServerPodWhereabouts,
 					workerNodeList[0].Definition.Name, workerNodeList[0].Definition.Name,
 					sriovNetworkWhereaboutsDiffPFClientMTU1280, sriovNetworkWhereaboutsDiffPFServerMTU1280,
-					"", "", "",
+					"", "", "", "",
 					nil, nil, mtu1280)
 				Expect(err).ToNot(HaveOccurred(), "Failed to create whereabouts pods")
 
-				By("Getting server IP from pod interface")
+				By("Getting server IPs from pod interface")
 
-				serverIP, err := sriovenv.GetPodIPFromInterface(whereaboutsServer, tsparams.Net1Interface, "ipv6")
-				Expect(err).ToNot(HaveOccurred(), "Failed to get server IP from whereabouts pod")
+				serverIPv4, err := sriovenv.GetPodIPFromInterface(
+					whereaboutsServer, tsparams.Net1Interface, "ipv4")
+				Expect(err).ToNot(HaveOccurred(), "Failed to get IPv4 server IP")
 
-				By("Running traffic tests with whereabouts IPAM")
+				serverIPv6, err := sriovenv.GetPodIPFromInterface(
+					whereaboutsServer, tsparams.Net1Interface, "ipv6")
+				Expect(err).ToNot(HaveOccurred(), "Failed to get IPv6 server IP")
 
-				err = sriovenv.RunTrafficTest(whereaboutsClient, serverIP, mtu1280)
-				Expect(err).ToNot(HaveOccurred(), "Traffic tests failed for whereabouts IPAM")
+				By("Running dual-stack traffic tests with whereabouts IPAM")
+
+				err = RunDualStackTrafficTest(whereaboutsClient, serverIPv4, serverIPv6, mtu1280)
+				Expect(err).ToNot(HaveOccurred(), "Dual-stack traffic tests failed for whereabouts IPAM")
 			})
 	})
 
-	// Context for Different Node connectivity tests.
 	Context("Different Node", func() {
 		const (
-			sriovNetworkDiffNodeMTU1280            = "sriov-net-diffnode-mtu1280-v6"
-			sriovNetworkDiffNodeMTU9000            = "sriov-net-diffnode-mtu9000-v6"
-			sriovNetworkWhereaboutsDiffNodeMTU1280 = "sriov-net-whereabouts-diffnode-mtu1280-v6"
+			sriovNetworkDiffNodeMTU1280            = "sriov-net-diffnode-mtu1280-ds"
+			sriovNetworkDiffNodeMTU9000            = "sriov-net-diffnode-mtu9000-ds"
+			sriovNetworkWhereaboutsDiffNodeMTU1280 = "sriov-net-whereabouts-diffnode-mtu1280-ds"
 		)
 
 		BeforeAll(func() {
@@ -357,9 +384,10 @@ var _ = Describe("SR-IOV IPv6", Ordered, Label(tsparams.LabelSuite), ContinueOnF
 
 			err = sriovenv.CreateSriovNetworkWithWhereaboutsIPAM(
 				sriovNetworkWhereaboutsDiffNodeMTU1280, sriovResourcePF1MTU1280,
-				tsparams.WhereaboutsIPv6Range, tsparams.WhereaboutsIPv6Gateway,
-				sriovNetworkWhereaboutsDiffNodeMTU1280, "")
-			Expect(err).ToNot(HaveOccurred(), "Failed to create whereabouts network for Different Node")
+				tsparams.WhereaboutsIPv4Range, tsparams.WhereaboutsIPv4Gateway,
+				sriovNetworkWhereaboutsDiffNodeMTU1280,
+				tsparams.WhereaboutsIPv6Range)
+			Expect(err).ToNot(HaveOccurred(), "Failed to create dual-stack whereabouts network for Different Node")
 		})
 
 		AfterEach(func() {
@@ -378,60 +406,71 @@ var _ = Describe("SR-IOV IPv6", Ordered, Label(tsparams.LabelSuite), ContinueOnF
 			Expect(err).ToNot(HaveOccurred(), "Failed to delete SR-IOV networks")
 		})
 
-		It("Verify SR-IOV IPv6 connectivity between different nodes with Static IPAM and Dynamic MAC",
-			reportxml.ID("87565"), func() {
+		It("Verify SR-IOV dual-stack connectivity between different nodes with Static IPAM and Dynamic MAC",
+			reportxml.ID("88145"), func() {
 				By("Creating client and server pods for MTU 1280")
 
-				clientMTU1280, _, err := sriovenv.CreatePodPair(
+				clientMTU1280, _, err := CreateDualStackPodPair(
 					tsparams.ClientPodMTU1280, tsparams.ServerPodMTU1280,
 					workerNodeList[0].Definition.Name, workerNodeList[1].Definition.Name,
 					sriovNetworkDiffNodeMTU1280, sriovNetworkDiffNodeMTU1280,
+					ipaddr.RemovePrefix(tsparams.ServerIPv4IPAddress),
 					ipaddr.RemovePrefix(tsparams.ServerIPv6IPAddress),
 					"", "",
-					[]string{tsparams.ClientIPv6IPAddress}, []string{tsparams.ServerIPv6IPAddress},
+					[]string{tsparams.ClientIPv4IPAddress, tsparams.ClientIPv6IPAddress},
+					[]string{tsparams.ServerIPv4IPAddress, tsparams.ServerIPv6IPAddress},
 					mtu1280)
 				Expect(err).ToNot(HaveOccurred(), "Failed to create pods for MTU 1280")
 
 				By("Creating client and server pods for MTU 9000")
 
-				clientMTU9000, _, err := sriovenv.CreatePodPair(
+				clientMTU9000, _, err := CreateDualStackPodPair(
 					tsparams.ClientPodMTU9000, tsparams.ServerPodMTU9000,
 					workerNodeList[0].Definition.Name, workerNodeList[1].Definition.Name,
 					sriovNetworkDiffNodeMTU9000, sriovNetworkDiffNodeMTU9000,
+					ipaddr.RemovePrefix(tsparams.ServerIPv4IPAddress2),
 					ipaddr.RemovePrefix(tsparams.ServerIPv6IPAddress2),
 					"", "",
-					[]string{tsparams.ClientIPv6IPAddress2}, []string{tsparams.ServerIPv6IPAddress2},
+					[]string{tsparams.ClientIPv4IPAddress2, tsparams.ClientIPv6IPAddress2},
+					[]string{tsparams.ServerIPv4IPAddress2, tsparams.ServerIPv6IPAddress2},
 					mtu9000)
 				Expect(err).ToNot(HaveOccurred(), "Failed to create pods for MTU 9000")
 
-				err = sriovenv.RunTrafficTestsForBothMTUs(clientMTU1280, clientMTU9000,
+				err = RunDualStackTrafficTestsForBothMTUs(clientMTU1280, clientMTU9000,
+					ipaddr.RemovePrefix(tsparams.ServerIPv4IPAddress),
 					ipaddr.RemovePrefix(tsparams.ServerIPv6IPAddress),
+					ipaddr.RemovePrefix(tsparams.ServerIPv4IPAddress2),
 					ipaddr.RemovePrefix(tsparams.ServerIPv6IPAddress2),
 					mtu1280, mtu9000)
-				Expect(err).ToNot(HaveOccurred(), "Traffic tests failed")
+				Expect(err).ToNot(HaveOccurred(), "Dual-stack traffic tests failed")
 			})
 
-		It("Verify SR-IOV IPv6 connectivity between different nodes with Whereabouts IPAM and Dynamic MAC",
-			reportxml.ID("87566"), func() {
+		It("Verify SR-IOV dual-stack connectivity between different nodes with Whereabouts IPAM and Dynamic MAC",
+			reportxml.ID("88146"), func() {
 				By("Creating whereabouts pods with dynamic IP/MAC")
 
-				whereaboutsClient, whereaboutsServer, err := sriovenv.CreatePodPair(
+				whereaboutsClient, whereaboutsServer, err := CreateDualStackPodPair(
 					tsparams.ClientPodWhereabouts, tsparams.ServerPodWhereabouts,
 					workerNodeList[0].Definition.Name, workerNodeList[1].Definition.Name,
 					sriovNetworkWhereaboutsDiffNodeMTU1280, sriovNetworkWhereaboutsDiffNodeMTU1280,
-					"", "", "",
+					"", "", "", "",
 					nil, nil, mtu1280)
 				Expect(err).ToNot(HaveOccurred(), "Failed to create whereabouts pods")
 
-				By("Getting server IP from pod interface")
+				By("Getting server IPs from pod interface")
 
-				serverIP, err := sriovenv.GetPodIPFromInterface(whereaboutsServer, tsparams.Net1Interface, "ipv6")
-				Expect(err).ToNot(HaveOccurred(), "Failed to get server IP from whereabouts pod")
+				serverIPv4, err := sriovenv.GetPodIPFromInterface(
+					whereaboutsServer, tsparams.Net1Interface, "ipv4")
+				Expect(err).ToNot(HaveOccurred(), "Failed to get IPv4 server IP")
 
-				By("Running traffic tests with whereabouts IPAM")
+				serverIPv6, err := sriovenv.GetPodIPFromInterface(
+					whereaboutsServer, tsparams.Net1Interface, "ipv6")
+				Expect(err).ToNot(HaveOccurred(), "Failed to get IPv6 server IP")
 
-				err = sriovenv.RunTrafficTest(whereaboutsClient, serverIP, mtu1280)
-				Expect(err).ToNot(HaveOccurred(), "Traffic tests failed for whereabouts IPAM")
+				By("Running dual-stack traffic tests with whereabouts IPAM")
+
+				err = RunDualStackTrafficTest(whereaboutsClient, serverIPv4, serverIPv6, mtu1280)
+				Expect(err).ToNot(HaveOccurred(), "Dual-stack traffic tests failed for whereabouts IPAM")
 			})
 	})
 })

--- a/tests/cnf/core/network/sriov/tests/sriov-ipv4.go
+++ b/tests/cnf/core/network/sriov/tests/sriov-ipv4.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/sriov"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/ipaddr"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netenv"
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netinittools"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netparam"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/sriov/internal/sriovenv"
@@ -44,6 +45,15 @@ var _ = Describe("SR-IOV IPv4", Ordered, Label(tsparams.LabelSuite), ContinueOnF
 	)
 
 	BeforeAll(func() {
+		By("Checking cluster IP family")
+
+		clusterIPFamily, err := netenv.GetClusterIPFamily(APIClient)
+		Expect(err).ToNot(HaveOccurred(), "Failed to detect cluster IP family")
+
+		if !netenv.ClusterSupportsIPv4(clusterIPFamily) {
+			Skip("Cluster does not support IPv4 - skipping IPv4 SR-IOV tests")
+		}
+
 		By("Discover and list worker nodes")
 
 		workerNodeList, err = nodes.List(
@@ -64,13 +74,16 @@ var _ = Describe("SR-IOV IPv4", Ordered, Label(tsparams.LabelSuite), ContinueOnF
 		sriovInterfacePF1 = sriovInterfaces[0]
 		sriovInterfacePF2 = sriovInterfaces[1]
 
+		sriovenv.ActivateSCTPModuleOnWorkerNodes()
+
 		By("Verifying SCTP kernel module is loaded on worker nodes")
 
 		sctpOutput, err := cluster.ExecCmdWithStdout(APIClient, "lsmod | grep -q sctp && echo loaded",
 			metav1.ListOptions{LabelSelector: labels.Set(NetConfig.WorkerLabelMap).String()})
-		if err != nil || len(sctpOutput) == 0 {
-			Skip("SCTP kernel module is not loaded on worker nodes - cluster must be pre-configured with SCTP")
-		}
+		Expect(err).ToNot(HaveOccurred(), "Failed to check SCTP kernel module on worker nodes")
+		Expect(sctpOutput).NotTo(BeEmpty(),
+			"SCTP kernel module must be loaded on workers for this suite (traffic tests require SCTP); "+
+				"configure SCTP per tests/cnf/core/network/README prerequisites (e.g. MachineConfig)")
 
 		By("Create all test case SR-IOV policies and waiting for them to be applied")
 
@@ -117,12 +130,14 @@ var _ = Describe("SR-IOV IPv4", Ordered, Label(tsparams.LabelSuite), ContinueOnF
 
 			err = sriovenv.CreateSriovNetworkWithVLANAndWhereabouts(
 				sriovNetworkVlanSamePFMTU500, sriovResourcePF1MTU500, vlanID,
-				tsparams.WhereaboutsIPv4Range, tsparams.WhereaboutsIPv4Gateway)
+				tsparams.WhereaboutsIPv4Range, tsparams.WhereaboutsIPv4Gateway,
+				"")
 			Expect(err).ToNot(HaveOccurred(), "Failed to create VLAN network for Same PF MTU 500")
 
 			err = sriovenv.CreateSriovNetworkWithVLANAndWhereabouts(
 				sriovNetworkVlanSamePFMTU9000, sriovResourcePF1MTU9000, vlanID,
-				tsparams.WhereaboutsIPv4Range2, tsparams.WhereaboutsIPv4Gateway2)
+				tsparams.WhereaboutsIPv4Range2, tsparams.WhereaboutsIPv4Gateway2,
+				"")
 			Expect(err).ToNot(HaveOccurred(), "Failed to create VLAN network for Same PF MTU 9000")
 		})
 
@@ -244,13 +259,15 @@ var _ = Describe("SR-IOV IPv4", Ordered, Label(tsparams.LabelSuite), ContinueOnF
 			err = sriovenv.CreateSriovNetworkWithWhereaboutsIPAM(
 				sriovNetworkWhereaboutsDiffPFClientMTU500, sriovResourcePF1MTU500,
 				tsparams.WhereaboutsIPv4Range, tsparams.WhereaboutsIPv4Gateway,
-				sriovNetworkWhereaboutsDiffPFClientMTU500)
+				sriovNetworkWhereaboutsDiffPFClientMTU500,
+				"")
 			Expect(err).ToNot(HaveOccurred(), "Failed to create whereabouts client network")
 
 			err = sriovenv.CreateSriovNetworkWithWhereaboutsIPAM(
 				sriovNetworkWhereaboutsDiffPFServerMTU500, sriovResourcePF2MTU500,
 				tsparams.WhereaboutsIPv4Range, tsparams.WhereaboutsIPv4Gateway,
-				sriovNetworkWhereaboutsDiffPFClientMTU500)
+				sriovNetworkWhereaboutsDiffPFClientMTU500,
+				"")
 			Expect(err).ToNot(HaveOccurred(), "Failed to create whereabouts server network")
 		})
 
@@ -347,7 +364,8 @@ var _ = Describe("SR-IOV IPv4", Ordered, Label(tsparams.LabelSuite), ContinueOnF
 			err = sriovenv.CreateSriovNetworkWithWhereaboutsIPAM(
 				sriovNetworkWhereaboutsDiffNodeMTU500, sriovResourcePF1MTU500,
 				tsparams.WhereaboutsIPv4Range, tsparams.WhereaboutsIPv4Gateway,
-				sriovNetworkWhereaboutsDiffNodeMTU500)
+				sriovNetworkWhereaboutsDiffNodeMTU500,
+				"")
 			Expect(err).ToNot(HaveOccurred(), "Failed to create whereabouts network for Different Node")
 		})
 

--- a/tests/cnf/core/network/sriov/tests/sriov_ipdual_helpers.go
+++ b/tests/cnf/core/network/sriov/tests/sriov_ipdual_helpers.go
@@ -1,0 +1,321 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/cmd"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/ipaddr"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netinittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netparam"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/sriov/internal/sriovenv"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/sriov/internal/tsparams"
+	"gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+)
+
+// waitForDualStackServerReady waits for all 6 dual-stack testcmd listeners to be ready.
+// It requires at least 6 listeners; more are accepted (e.g. an extra process from the container image).
+func waitForDualStackServerReady(serverPod *pod.Builder, timeout time.Duration) error {
+	klog.V(90).Infof("Waiting for dual-stack server pod %s to be ready", serverPod.Definition.Name)
+
+	const minListeners = 6
+
+	err := wait.PollUntilContextTimeout(
+		context.TODO(),
+		tsparams.RetryInterval,
+		timeout,
+		true,
+		func(ctx context.Context) (bool, error) {
+			output, execErr := serverPod.ExecCommand([]string{"bash", "-c",
+				"pgrep -c -f 'testcmd -listen'"})
+			if execErr != nil {
+				klog.V(90).Infof("Listeners not ready on pod %s: %v", serverPod.Definition.Name, execErr)
+
+				return false, nil
+			}
+
+			countStr := strings.TrimSpace(output.String())
+
+			var count int
+
+			if _, parseErr := fmt.Sscanf(countStr, "%d", &count); parseErr != nil {
+				klog.V(90).Infof("Invalid listener count %q on pod %s", countStr, serverPod.Definition.Name)
+
+				return false, nil
+			}
+
+			if count < minListeners {
+				klog.V(90).Infof("Only %d/%d testcmd listeners ready on pod %s",
+					count, minListeners, serverPod.Definition.Name)
+
+				return false, nil
+			}
+
+			return true, nil
+		})
+	if err != nil {
+		return fmt.Errorf("dual-stack listeners not ready on pod %s: %w", serverPod.Definition.Name, err)
+	}
+
+	return nil
+}
+
+// buildDualStackServerCommand builds the server command for dual-stack pods that have both IPv4 and IPv6 addresses.
+// It starts listeners for both families: TCP/UDP are shared, SCTP and multicast use separate ports per family.
+func buildDualStackServerCommand(ipv4BindIP, ipv6BindIP, interfaceName string, mtu int) []string {
+	klog.V(90).Infof("Building dual-stack server command for interface %s with MTU %d, ipv4=%q, ipv6=%q",
+		interfaceName, mtu, ipv4BindIP, ipv6BindIP)
+
+	packetSize := mtu - 100
+
+	if ipv4BindIP == "" && ipv6BindIP == "" {
+		return buildDynamicDualStackServerCommand(interfaceName, mtu, packetSize)
+	}
+
+	ipv4McastSetup, ipv4McastGroup := sriovenv.BuildMulticastSetup(false, interfaceName, mtu)
+	ipv6McastSetup, ipv6McastGroup := sriovenv.BuildMulticastSetup(true, interfaceName, mtu)
+
+	listeners := fmt.Sprintf(
+		"testcmd -listen -protocol tcp -port 5001 -interface %s -mtu %d & "+
+			"testcmd -listen -protocol udp -port 5002 -interface %s -mtu %d & "+
+			"testcmd -listen -protocol sctp -port 5003 -interface %s -server %s -mtu %d & "+
+			"testcmd -listen -multicast -protocol udp -port 5004 -interface %s -server %s -mtu %d & "+
+			"testcmd -listen -protocol sctp -port %d -interface %s -server %s -mtu %d & "+
+			"testcmd -listen -multicast -protocol udp -port %d -interface %s -server %s -mtu %d & "+
+			"sleep infinity",
+		interfaceName, packetSize,
+		interfaceName, packetSize,
+		interfaceName, ipv4BindIP, packetSize,
+		interfaceName, ipv4McastGroup, packetSize,
+		tsparams.DualStackSCTPv6Port, interfaceName, ipv6BindIP, packetSize,
+		tsparams.DualStackMulticastV6Port, interfaceName, ipv6McastGroup, packetSize)
+
+	return []string{"bash", "-c", ipv4McastSetup + ipv6McastSetup + "sleep 5; " + listeners}
+}
+
+func buildDynamicDualStackServerCommand(interfaceName string, mtu, packetSize int) []string {
+	ipv4McastSetup, ipv4McastGroup := sriovenv.BuildMulticastSetup(false, interfaceName, mtu)
+	ipv6McastSetup, ipv6McastGroup := sriovenv.BuildMulticastSetup(true, interfaceName, mtu)
+
+	discoverIPs := fmt.Sprintf(
+		"for _ in $(seq 1 10); do "+
+			"IPV4=$(ip -4 -o addr show %s 2>/dev/null | awk '{print $4}' | cut -d'/' -f1 | head -1); "+
+			"IPV6=$(ip -6 -o addr show %s 2>/dev/null | grep -v fe80 | awk '{print $4}' | cut -d'/' -f1 | head -1); "+
+			"[ -n \"$IPV4\" ] && [ -n \"$IPV6\" ] && break; "+
+			"sleep 1; done; "+
+			"[ -n \"$IPV4\" ] || { echo 'Failed to discover IPv4'; exit 1; }; "+
+			"[ -n \"$IPV6\" ] || { echo 'Failed to discover IPv6'; exit 1; }; "+
+			"echo \"Discovered IPv4: $IPV4, IPv6: $IPV6\"; ",
+		interfaceName, interfaceName)
+
+	listeners := fmt.Sprintf(
+		"testcmd -listen -protocol tcp -port 5001 -interface %s -mtu %d & "+
+			"testcmd -listen -protocol udp -port 5002 -interface %s -mtu %d & "+
+			"testcmd -listen -protocol sctp -port 5003 -interface %s -server $IPV4 -mtu %d & "+
+			"testcmd -listen -multicast -protocol udp -port 5004 -interface %s -server %s -mtu %d & "+
+			"testcmd -listen -protocol sctp -port %d -interface %s -server $IPV6 -mtu %d & "+
+			"testcmd -listen -multicast -protocol udp -port %d -interface %s -server %s -mtu %d & "+
+			"sleep infinity",
+		interfaceName, packetSize,
+		interfaceName, packetSize,
+		interfaceName, packetSize,
+		interfaceName, ipv4McastGroup, packetSize,
+		tsparams.DualStackSCTPv6Port, interfaceName, packetSize,
+		tsparams.DualStackMulticastV6Port, interfaceName, ipv6McastGroup, packetSize)
+
+	waitForDAD := "sleep 3; "
+
+	return []string{"bash", "-c", discoverIPs + ipv4McastSetup + ipv6McastSetup + waitForDAD + listeners}
+}
+
+// RunDualStackTrafficTest runs all traffic tests for both IPv4 and IPv6 against a dual-stack server pod.
+func RunDualStackTrafficTest(clientPod *pod.Builder, serverIPv4, serverIPv6 string, mtu int) error {
+	klog.V(90).Infof("Running dual-stack traffic tests against IPv4=%s, IPv6=%s with MTU %d",
+		serverIPv4, serverIPv6, mtu)
+
+	ipv4Addr := ipaddr.RemovePrefix(serverIPv4)
+	ipv6Addr := ipaddr.RemovePrefix(serverIPv6)
+	packetSize := mtu - 100
+
+	var failedProtocols []string
+
+	if err := cmd.ICMPConnectivityCheck(
+		clientPod, []string{ipv4Addr + "/32"}, tsparams.Net1Interface); err != nil {
+		failedProtocols = append(failedProtocols, fmt.Sprintf("IPv4 ICMP: %v", err))
+	}
+
+	if err := sriovenv.RunProtocolTest(clientPod, "IPv4 TCP",
+		fmt.Sprintf("testcmd -protocol tcp -port 5001 -interface %s -server %s -mtu %d",
+			tsparams.Net1Interface, ipv4Addr, packetSize)); err != nil {
+		failedProtocols = append(failedProtocols, fmt.Sprintf("IPv4 TCP: %v", err))
+	}
+
+	if err := sriovenv.RunProtocolTest(clientPod, "IPv4 UDP",
+		fmt.Sprintf("testcmd -protocol udp -port 5002 -interface %s -server %s -mtu %d",
+			tsparams.Net1Interface, ipv4Addr, packetSize)); err != nil {
+		failedProtocols = append(failedProtocols, fmt.Sprintf("IPv4 UDP: %v", err))
+	}
+
+	if err := sriovenv.RunProtocolTest(clientPod, "IPv4 SCTP",
+		fmt.Sprintf("testcmd -protocol sctp -port 5003 -interface %s -server %s -mtu %d",
+			tsparams.Net1Interface, ipv4Addr, packetSize)); err != nil {
+		failedProtocols = append(failedProtocols, fmt.Sprintf("IPv4 SCTP: %v", err))
+	}
+
+	ipv4McastGroup := tsparams.MulticastIPv4Group
+
+	if mtu == 9000 {
+		ipv4McastGroup = tsparams.MulticastIPv4GroupLargeMTU
+	}
+
+	if err := sriovenv.RunProtocolTest(clientPod, "IPv4 multicast",
+		fmt.Sprintf("testcmd -multicast -protocol udp -port 5004 -interface %s -server %s -mtu %d",
+			tsparams.Net1Interface, ipv4McastGroup, packetSize)); err != nil {
+		failedProtocols = append(failedProtocols, fmt.Sprintf("IPv4 multicast: %v", err))
+	}
+
+	if err := cmd.ICMPConnectivityCheck(
+		clientPod, []string{ipv6Addr + "/128"}, tsparams.Net1Interface); err != nil {
+		failedProtocols = append(failedProtocols, fmt.Sprintf("IPv6 ICMP: %v", err))
+	}
+
+	if err := sriovenv.RunProtocolTest(clientPod, "IPv6 TCP",
+		fmt.Sprintf("testcmd -protocol tcp -port 5001 -interface %s -server %s -mtu %d",
+			tsparams.Net1Interface, ipv6Addr, packetSize)); err != nil {
+		failedProtocols = append(failedProtocols, fmt.Sprintf("IPv6 TCP: %v", err))
+	}
+
+	if err := sriovenv.RunProtocolTest(clientPod, "IPv6 UDP",
+		fmt.Sprintf("testcmd -protocol udp -port 5002 -interface %s -server %s -mtu %d",
+			tsparams.Net1Interface, ipv6Addr, packetSize)); err != nil {
+		failedProtocols = append(failedProtocols, fmt.Sprintf("IPv6 UDP: %v", err))
+	}
+
+	if err := sriovenv.RunProtocolTest(clientPod, "IPv6 SCTP",
+		fmt.Sprintf("testcmd -protocol sctp -port %d -interface %s -server %s -mtu %d",
+			tsparams.DualStackSCTPv6Port, tsparams.Net1Interface, ipv6Addr, packetSize)); err != nil {
+		failedProtocols = append(failedProtocols, fmt.Sprintf("IPv6 SCTP: %v", err))
+	}
+
+	if err := sriovenv.RunProtocolTest(clientPod, "IPv6 multicast",
+		fmt.Sprintf("testcmd -multicast -protocol udp -port %d -interface %s -server %s -mtu %d",
+			tsparams.DualStackMulticastV6Port, tsparams.Net1Interface, tsparams.MulticastIPv6Group, packetSize)); err != nil {
+		failedProtocols = append(failedProtocols, fmt.Sprintf("IPv6 multicast: %v", err))
+	}
+
+	if len(failedProtocols) > 0 {
+		return fmt.Errorf("dual-stack traffic tests failed: %s", strings.Join(failedProtocols, "; "))
+	}
+
+	return nil
+}
+
+// RunDualStackTrafficTestsForBothMTUs runs dual-stack traffic tests for two MTU configurations.
+func RunDualStackTrafficTestsForBothMTUs(
+	clientSmallMTU,
+	clientLargeMTU *pod.Builder,
+	serverIPv4Small,
+	serverIPv6Small,
+	serverIPv4Large,
+	serverIPv6Large string,
+	mtuSmall,
+	mtuLarge int,
+) error {
+	klog.V(90).Infof("Running dual-stack traffic tests with MTU %d", mtuSmall)
+
+	if err := RunDualStackTrafficTest(clientSmallMTU, serverIPv4Small, serverIPv6Small, mtuSmall); err != nil {
+		return fmt.Errorf("dual-stack traffic tests failed for MTU %d: %w", mtuSmall, err)
+	}
+
+	klog.V(90).Infof("Running dual-stack traffic tests with MTU %d", mtuLarge)
+
+	if err := RunDualStackTrafficTest(clientLargeMTU, serverIPv4Large, serverIPv6Large, mtuLarge); err != nil {
+		return fmt.Errorf("dual-stack traffic tests failed for MTU %d: %w", mtuLarge, err)
+	}
+
+	return nil
+}
+
+// CreateDualStackPodPair creates a client and server pod pair for dual-stack traffic testing.
+func CreateDualStackPodPair(
+	clientName,
+	serverName,
+	clientNode,
+	serverNode,
+	clientNetwork,
+	serverNetwork,
+	ipv4ServerBindIP,
+	ipv6ServerBindIP,
+	clientMAC,
+	serverMAC string,
+	clientIPs,
+	serverIPs []string,
+	mtu int,
+) (*pod.Builder, *pod.Builder, error) {
+	klog.V(90).Infof("Creating dual-stack client pod %s and server pod %s", clientName, serverName)
+
+	client, err := sriovenv.CreateTestClientPod(clientName, clientNode, clientNetwork, clientMAC, clientIPs)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create client pod: %w", err)
+	}
+
+	server, err := createDualStackServerPod(
+		serverName, serverNode, serverNetwork, serverMAC,
+		ipv4ServerBindIP, ipv6ServerBindIP, serverIPs, mtu)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create server pod: %w", err)
+	}
+
+	return client, server, nil
+}
+
+func createDualStackServerPod(
+	name,
+	nodeName,
+	networkName,
+	macAddress,
+	ipv4BindIP,
+	ipv6BindIP string,
+	ipAddresses []string,
+	mtu int,
+) (*pod.Builder, error) {
+	klog.V(90).Infof("Creating dual-stack server pod %s on node %s", name, nodeName)
+
+	secNetwork := []*types.NetworkSelectionElement{{Name: networkName}}
+
+	if macAddress != "" {
+		secNetwork[0].MacRequest = macAddress
+	}
+
+	if len(ipAddresses) > 0 {
+		secNetwork[0].IPRequest = ipAddresses
+	}
+
+	command := buildDualStackServerCommand(ipv4BindIP, ipv6BindIP, tsparams.Net1Interface, mtu)
+
+	container, err := pod.NewContainerBuilder("server", NetConfig.CnfNetTestContainer, command).GetContainerCfg()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create container config: %w", err)
+	}
+
+	serverPod, err := pod.NewBuilder(APIClient, name, tsparams.TestNamespaceName, NetConfig.CnfNetTestContainer).
+		DefineOnNode(nodeName).
+		RedefineDefaultContainer(*container).
+		WithPrivilegedFlag().
+		WithSecondaryNetwork(secNetwork).
+		CreateAndWaitUntilRunning(netparam.DefaultTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := waitForDualStackServerReady(serverPod, tsparams.WaitTimeout); err != nil {
+		return nil, fmt.Errorf("server pod %s not ready: %w", name, err)
+	}
+
+	return serverPod, nil
+}

--- a/tests/cnf/core/network/sriov/tests/webhook-matchConditions.go
+++ b/tests/cnf/core/network/sriov/tests/webhook-matchConditions.go
@@ -101,7 +101,7 @@ var _ = Describe("webhook-resource-injector", Ordered, Label(tsparams.LabelWebho
 
 		AfterEach(func() {
 			By("Delete network-resources-injector daemonset")
-			deleteDaemonSetAndWaitForNewDaemonSet(netparam.OperatorResourceInjector, NetConfig.SriovOperatorNamespace)
+			deleteDaemonSetAndWaitForNewDaemonSet(tsparams.OperatorResourceInjector, NetConfig.SriovOperatorNamespace)
 		})
 
 		It("resourceInjectorMatchCondition set to True", reportxml.ID("80110"), func() {


### PR DESCRIPTION
Dual-stack SR-IOV test cases (sriov-ipdual.go)
Added dual-stack connectivity tests that verify both IPv4 and IPv6 traffic over SR-IOV interfaces. Each test creates pods with both address families and runs all 5 protocols (ICMP, TCP, UDP, SCTP, multicast) for each family.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added dual-stack (IPv4 + IPv6) support for SR-IOV networks with VLAN and Whereabouts IPAM configurations.

* **Tests**
  * Introduced comprehensive dual-stack traffic tests for SR-IOV across multiple MTU and topology scenarios.
  * Added cluster IP family detection to conditionally run tests based on cluster capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->