### PR TITLE
rhwa nhc: add NHC & SNR sudden-loss system test

### DIFF
--- a/tests/rhwa/internal/rhwaconfig/default.yaml
+++ b/tests/rhwa/internal/rhwaconfig/default.yaml
@@ -1,3 +1,11 @@
 ---
 # RHWA default configurations.
-...
+
+nhc_target_worker: ""       # e.g. "openshift-worker-0.ocp.example.org"
+nhc_failover_workers: []    # e.g. ["openshift-worker-1.ocp.example.org"]
+nhc_storage_class: ""       # e.g. "ocs-external-storagecluster-ceph-rbd"
+nhc_app_image: ""           # e.g. "registry.ocp.example.org:5000/test/ubi-minimal:latest"
+nhc_target_worker_bmc:
+  address: ""               # e.g. "10.1.0.2"
+  username: ""              # e.g. "example-user"
+  password: ""              # e.g. "example-pass"

--- a/tests/rhwa/internal/rhwaconfig/rhwaconfig.go
+++ b/tests/rhwa/internal/rhwaconfig/rhwaconfig.go
@@ -1,10 +1,12 @@
 package rhwaconfig
 
 import (
+	"encoding/json"
 	"log"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/config"
@@ -16,9 +18,33 @@ const (
 	PathToDefaultRhwaParamsFile = "./default.yaml"
 )
 
+// BMCDetails holds BMC connection details for a single node.
+type BMCDetails struct {
+	Address  string `yaml:"address" json:"address"`
+	Username string `yaml:"username" json:"username"`
+	Password string `yaml:"password" json:"password"`
+}
+
+// Decode implements the envconfig.Decoder interface to parse a JSON string
+// from an environment variable into BMCDetails.
+func (b *BMCDetails) Decode(value string) error {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+
+	return json.Unmarshal([]byte(value), b)
+}
+
 // RHWAConfig type keeps rhwa configuration.
 type RHWAConfig struct {
 	*config.GeneralConfig
+
+	// NHC/SNR sudden-loss test configuration.
+	TargetWorker    string     `yaml:"nhc_target_worker" envconfig:"ECO_RHWA_NHC_TARGET_WORKER"`
+	FailoverWorkers []string   `yaml:"nhc_failover_workers" envconfig:"ECO_RHWA_NHC_FAILOVER_WORKERS"`
+	StorageClass    string     `yaml:"nhc_storage_class" envconfig:"ECO_RHWA_NHC_STORAGE_CLASS"`
+	AppImage        string     `yaml:"nhc_app_image" envconfig:"ECO_RHWA_NHC_APP_IMAGE"`
+	TargetWorkerBMC BMCDetails `yaml:"nhc_target_worker_bmc" envconfig:"ECO_RHWA_NHC_TARGET_WORKER_BMC"`
 }
 
 // NewRHWAConfig returns instance of RHWA config type.

--- a/tests/rhwa/internal/rhwaparams/rhwavars.go
+++ b/tests/rhwa/internal/rhwaparams/rhwavars.go
@@ -1,0 +1,14 @@
+package rhwaparams
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var (
+	// SnrGVR is the GroupVersionResource for SelfNodeRemediation resources.
+	SnrGVR = schema.GroupVersionResource{
+		Group:    "self-node-remediation.medik8s.io",
+		Version:  "v1alpha1",
+		Resource: "selfnoderemediations",
+	}
+)

--- a/tests/rhwa/nhc-operator/README.md
+++ b/tests/rhwa/nhc-operator/README.md
@@ -1,0 +1,153 @@
+# RHWA Team - Node Health Check Operator
+
+## Overview
+
+NHC operator tests validate that the Node Health Check (NHC) and Self Node Remediation (SNR) operators
+work together to detect unhealthy nodes and remediate them by fencing and evicting stateful workloads
+to healthy nodes.
+
+The first test scenario is **Sudden loss of a node**: a healthy MNO cluster experiences the unexpected
+shutdown of a worker node running a stateful application. The NHC operator detects the node failure
+and creates a `SelfNodeRemediation` resource. The SNR operator fences the node by attempting to reboot
+it and waiting `safeTimeToAssumeNodeRebootedSeconds`, then applies an `out-of-service` taint to enforce
+deletion of pods and volume attachments, allowing the stateful pod to reschedule on a healthy node
+with its persistent storage reattached.
+
+### Prerequisites for running these tests:
+
+The test suite is designed to run on an OCP cluster version 4.19+ with the following components
+and configuration.
+
+It has been run successfully on these OCP versions:
+- 4.19
+
+It has been tested on bare-metal nodes. For virtualised infrastructure, a virtual BMC must be used, 
+such as:
+
+  - sushy-emulator (from the sushy project) — exposes a Redfish API that maps to libvirt VM power
+  operations
+  - VirtualBMC (vbmc) — maps IPMI commands to libvirt, though the test uses Redfish not IPMI
+
+With the sushy-emulator running on the hypervisor, the ECO_RHWA_NHC_TARGET_WORKER_BMC environment
+variable must point at the sushy endpoint, 
+e.g. `{"address":"hypervisor:8000","username":"admin","password":"password"}`). The VMs must have a
+watchdog device configured (e.g. i6300esb in libvirt), or set `isSoftwareRebootEnabled: true` as a
+fallback.
+
+#### Cluster topology
+
+* A Multi-Node OpenShift (MNO) cluster with **bare-metal** or **virtualised** worker nodes
+* At least **2 worker nodes** that will be used by the test (a target node and one or more
+  failover nodes). The test labels the target node with `node-role.kubernetes.io/appworker`
+  first to guarantee initial pod placement, then labels the failover nodes after the app is
+  deployed. All labels are removed at the end
+* The target worker node must have **BMC/Redfish** (or iLO/IPMI) access for power control.
+  The test powers it off via BMC to simulate sudden power loss and powers it back on at the end
+
+The test observes the full remediation lifecycle:
+
+1. Node `Ready` condition transitions to `Unknown` (~40s after power-off)
+2. NHC detects the unhealthy condition and creates a `SelfNodeRemediation` CR (~60s after condition change)
+3. SNR fences the node by attempting to reboot it and waiting `safeTimeToAssumeNodeRebootedSeconds` (~180s)
+4. SNR applies an `out-of-service` taint, enforcing deletion of pods and volume attachments on the fenced node
+5. The stateful pod is rescheduled on a healthy node with its PVC reattached
+6. The node is powered back on via BMC and returns to `Ready` state
+
+#### Operators
+
+* **Node Health Check operator** (namespace: `openshift-workload-availability`)
+* **Self Node Remediation operator** (installed as default remediation provider by NHC)
+
+#### Operator configuration
+
+* A `SelfNodeRemediationTemplate` CR with `remediationStrategy: OutOfServiceTaint`
+* A `NodeHealthCheck` CR (named `nhc-worker-self`) configured with:
+  * A `selector` matching the worker nodes monitored by NHC (e.g. `node-role.kubernetes.io/worker`).
+    The selector must match the target and failover nodes
+  * `minHealthy` set to a value that is **still satisfied** when one node goes down.
+    For example, with 4 workers under NHC, use `75%` — losing 1 node leaves 3/4 = 75% healthy,
+    which meets the threshold. If `minHealthy` is too high (e.g. `90%` with 4 nodes requires
+    all 4 healthy), NHC will not remediate
+  * `unhealthyConditions` with `duration: 60s` for `Ready` in `False` and `Unknown` status
+  * A `remediationTemplate` pointing to the `SelfNodeRemediationTemplate` above
+* A `SelfNodeRemediationConfig` CR with `safeTimeToAssumeNodeRebootedSeconds: 180`
+
+The [Telco Reference CRs](https://github.com/openshift-kni/telco-reference/)
+can provide an up-to-date configuration and values for the settings above.
+
+#### Storage
+
+* A **StorageClass** capable of dynamically provisioning `ReadWriteOnce` PersistentVolumes
+  (e.g. NFS-based). The test creates a 1Gi PVC for the stateful application. The storage
+  must support volume reattachment to a different node after the original node is fenced
+* The test verifies `VolumeAttachment` resources for CSI-backed storage. For non-CSI storage
+  (e.g. NFS), this check is skipped — the PVC being Bound and the pod Running on the new node
+  is sufficient verification
+
+#### Container image
+
+* A container image accessible from the cluster (e.g. `ubi-minimal`). In disconnected
+  environments, mirror it to the local registry. The test uses this image to run a simple
+  heartbeat loop as the stateful application
+
+### Test suites:
+
+| Name | Description |
+|------|-------------|
+| [sudden-node-loss](tests/sudden-node-loss.go) | Powers off a worker node via BMC and verifies NHC/SNR remediation and pod rescheduling |
+
+### Internal pkgs
+
+| Name | Description |
+|------|-------------|
+| [nhcparams](internal/nhcparams/const.go) | Constants, labels, timeouts, and reporter configuration for NHC tests |
+
+### Inputs
+
+Environment variables for test configuration:
+
+- `ECO_RHWA_NHC_TARGET_WORKER`: FQDN of the worker node to power off (must match the BMC address)
+- `ECO_RHWA_NHC_FAILOVER_WORKERS`: comma-separated list of worker FQDNs eligible for pod rescheduling
+- `ECO_RHWA_NHC_STORAGE_CLASS`: StorageClass name for the test PVC (e.g. `standard`)
+- `ECO_RHWA_NHC_APP_IMAGE`: container image for the stateful test application
+- `ECO_RHWA_NHC_TARGET_WORKER_BMC`: JSON object with BMC connection details, e.g. `{"address":"10.1.29.13","username":"user","password":"pass"}`
+
+Please refer to the project README for a list of global inputs - [How to run](../../../README.md#how-to-run)
+
+### Running NHC Test Suites
+
+```bash
+# export KUBECONFIG=</path/to/kubeconfig>
+# export ECO_RHWA_NHC_TARGET_WORKER=openshift-worker-0.example.com
+# export ECO_RHWA_NHC_FAILOVER_WORKERS=openshift-worker-1.example.com
+# export ECO_RHWA_NHC_STORAGE_CLASS=standard
+# export ECO_RHWA_NHC_APP_IMAGE=registry.example.com:5000/test/ubi-minimal:latest
+# export ECO_RHWA_NHC_TARGET_WORKER_BMC='{"address":"10.1.29.13","username":"admin","password":"secret"}'
+# make run-tests
+```
+
+**Note on timeouts:** The `go test` command must use `-timeout` greater than the ginkgo timeout
+(e.g. `-timeout=30m` with `-ginkgo.timeout=20m`). If `go test` uses its default of 10 minutes,
+the Go test harness will kill the process before ginkgo can complete the test and run cleanup
+(AfterAll), which includes powering the node back on.
+
+**Expected duration:** A full sudden-node-loss run typically takes **11–15 minutes** end-to-end,
+broken down as follows (observed on a 4-worker bare-metal cluster with `unhealthyConditions.duration=60s`
+and `safeTimeToAssumeNodeRebootedSeconds=180`):
+
+| Phase | Typical duration | Notes |
+|-------|-----------------|-------|
+| Step 3: Deploy app & verify placement | ~10s | PVC binding + pod scheduling |
+| Step 4: Power off node & detect failure | ~50s | ~40s for kubelet heartbeat timeout |
+| Step 5: NHC marks unhealthy & creates SNR | ~60s | Matches `unhealthyConditions.duration` |
+| Step 6: SNR fences node (out-of-service taint) | 3–5 min | 180s fence timer + SNR waits for all pods on the dead node to finish terminating; system pods like `dns-default` can extend this |
+| Step 7: Verify rescheduling | < 1s | Pod is rescheduled as soon as taint is applied |
+| AfterAll: Power on node & wait for Ready | ~5 min | Bare metal boot + kubelet registration |
+
+Step 6 is the most variable: after the 180s `safeTimeToAssumeNodeRebootedSeconds` timer expires,
+the SNR operator waits for all terminating pods on the fenced node to complete deletion before
+marking fencing as complete. System pods (e.g. `dns-default`, `ingress-canary`) on an unreachable
+node can take several additional minutes to terminate, pushing Step 6 to 5–8 minutes in the worst
+case. Combined with the AfterAll node recovery, the total can reach ~17–20 minutes, which is why
+the ginkgo timeout is set to 20 minutes and the Go test timeout to 30 minutes.
+

--- a/tests/rhwa/nhc-operator/internal/nhcparams/const.go
+++ b/tests/rhwa/nhc-operator/internal/nhcparams/const.go
@@ -3,4 +3,31 @@ package nhcparams
 const (
 	// Label represents nhc operator label that can be used for test cases selection.
 	Label = "nhc"
+
+	// LabelSuddenLoss is the label for the sudden-loss test scenario.
+	LabelSuddenLoss = "sudden-loss"
+
+	// NHCResourceName is the name of the NodeHealthCheck CR.
+	NHCResourceName = "nhc-worker-self"
+
+	// AppNamespace is the namespace for the stateful test application.
+	AppNamespace = "stateful-app-test"
+
+	// AppName is the name of the stateful test deployment.
+	AppName = "stateful-app"
+
+	// AppLabelKey is the label key for the stateful test application.
+	AppLabelKey = "app"
+
+	// AppLabelValue is the label value for the stateful test application.
+	AppLabelValue = "stateful-app"
+
+	// AppWorkerLabel is the node label used to select worker nodes for the test app.
+	AppWorkerLabel = "node-role.kubernetes.io/appworker"
+
+	// PVCName is the name of the PersistentVolumeClaim for the test app.
+	PVCName = "app-data"
+
+	// PVCSize is the size of the PVC for the test app.
+	PVCSize = "1Gi"
 )

--- a/tests/rhwa/nhc-operator/internal/nhcparams/nhcvars.go
+++ b/tests/rhwa/nhc-operator/internal/nhcparams/nhcvars.go
@@ -1,8 +1,66 @@
 package nhcparams
 
-import "github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/internal/rhwaparams"
+import (
+	"time"
+
+	"github.com/openshift-kni/k8sreporter"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/internal/rhwaparams"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
 
 var (
 	// Labels represents the range of labels that can be used for test cases selection.
 	Labels = []string{rhwaparams.Label, Label}
+
+	// OperatorDeploymentName represents NHC deployment name.
+	OperatorDeploymentName = "node-healthcheck-controller-manager"
+
+	// OperatorControllerPodLabel is how the controller pod is labeled.
+	OperatorControllerPodLabel = "node-healthcheck-operator"
+
+	// ReporterNamespacesToDump tells to the reporter from where to collect logs.
+	ReporterNamespacesToDump = map[string]string{
+		rhwaparams.RhwaOperatorNs: rhwaparams.RhwaOperatorNs,
+		AppNamespace:              AppNamespace,
+	}
+
+	// ReporterCRDsToDump tells to the reporter what CRs to dump.
+	ReporterCRDsToDump = []k8sreporter.CRData{
+		{Cr: &corev1.PodList{}},
+	}
+
+	// NhcGVR is the GroupVersionResource for NodeHealthCheck resources.
+	NhcGVR = schema.GroupVersionResource{
+		Group:    "remediation.medik8s.io",
+		Version:  "v1alpha1",
+		Resource: "nodehealthchecks",
+	}
+
+	// NodeReadyTimeout is how long to wait for a node Ready condition change.
+	NodeReadyTimeout = 2 * time.Minute
+
+	// NHCObserveTimeout is how long to wait for NHC to mark a node unhealthy.
+	NHCObserveTimeout = 3 * time.Minute
+
+	// SNRFenceTimeout is how long to wait for SNR to fence the node.
+	SNRFenceTimeout = 5 * time.Minute
+
+	// RescheduleTimeout is how long to wait for the pod to reschedule.
+	RescheduleTimeout = 5 * time.Minute
+
+	// DeploymentTimeout is how long to wait for a deployment to become ready.
+	DeploymentTimeout = 5 * time.Minute
+
+	// DeletionTimeout is how long to wait for a deletion to apply.
+	DeletionTimeout = 5 * time.Minute
+
+	// NodeRecoveryTimeout is how long to wait for a node to become Ready after power-on.
+	NodeRecoveryTimeout = 25 * time.Minute
+
+	// PollingInterval is the default polling interval for Eventually blocks.
+	PollingInterval = 10 * time.Second
+
+	// BMCTimeout is the Redfish operation timeout.
+	BMCTimeout = 6 * time.Minute
 )

--- a/tests/rhwa/nhc-operator/nhc_suite_test.go
+++ b/tests/rhwa/nhc-operator/nhc_suite_test.go
@@ -1,0 +1,34 @@
+package nhc
+
+import (
+	"runtime"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/reporter"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/internal/rhwainittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/nhc-operator/internal/nhcparams"
+	_ "github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/nhc-operator/tests"
+)
+
+var _, currentFile, _, _ = runtime.Caller(0)
+
+func TestNHC(t *testing.T) {
+	_, reporterConfig := GinkgoConfiguration()
+	reporterConfig.JUnitReport = RHWAConfig.GetJunitReportPath(currentFile)
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "NHC", Label(nhcparams.Labels...), reporterConfig)
+}
+
+var _ = JustAfterEach(func() {
+	reporter.ReportIfFailed(
+		CurrentSpecReport(), currentFile, nhcparams.ReporterNamespacesToDump, nhcparams.ReporterCRDsToDump)
+})
+
+var _ = ReportAfterSuite("", func(report Report) {
+	reportxml.Create(
+		report, RHWAConfig.GetReportPath(), RHWAConfig.TCPrefix)
+})

--- a/tests/rhwa/nhc-operator/tests/nhc.go
+++ b/tests/rhwa/nhc-operator/tests/nhc.go
@@ -1,0 +1,48 @@
+package tests
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/deployment"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
+
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/internal/rhwainittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/internal/rhwaparams"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/nhc-operator/internal/nhcparams"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe(
+	"NHC Post Deployment tests",
+	Ordered,
+	ContinueOnFailure,
+	Label(nhcparams.Label), func() {
+		BeforeAll(func() {
+			By("Get NHC deployment object")
+
+			nhcDeployment, err := deployment.Pull(
+				APIClient, nhcparams.OperatorDeploymentName, rhwaparams.RhwaOperatorNs)
+			Expect(err).ToNot(HaveOccurred(), "Failed to get NHC deployment")
+
+			By("Verify NHC deployment is Ready")
+			Expect(nhcDeployment.IsReady(rhwaparams.DefaultTimeout)).To(BeTrue(), "NHC deployment is not Ready")
+		})
+
+		It("Verify Node Health Check Operator pod is running", func() {
+			listOptions := metav1.ListOptions{
+				LabelSelector: fmt.Sprintf("app.kubernetes.io/name=%s", nhcparams.OperatorControllerPodLabel),
+			}
+			controllerPods, err := pod.WaitForAllPodsInNamespaceRunning(
+				APIClient,
+				rhwaparams.RhwaOperatorNs,
+				rhwaparams.DefaultTimeout,
+				listOptions,
+			)
+			Expect(err).ToNot(HaveOccurred(), "Pod is not ready")
+			Expect(controllerPods).To(BeTrue(), "no controller pod matched selector for OperatorControllerPodLabel")
+		})
+	})

--- a/tests/rhwa/nhc-operator/tests/sudden-node-loss.go
+++ b/tests/rhwa/nhc-operator/tests/sudden-node-loss.go
@@ -1,0 +1,802 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/bmc"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/deployment"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/namespace"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nodes"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/storage"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/internal/rhwainittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/internal/rhwaparams"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/nhc-operator/internal/nhcparams"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+)
+
+var _ = Describe(
+	"Sudden loss of a node",
+	Ordered,
+	ContinueOnFailure,
+	Label(nhcparams.Label, nhcparams.LabelSuddenLoss), func() {
+		var (
+			targetNode       string
+			bmcClient        *bmc.BMC
+			labeledWorkers   []string
+			unlabeledWorkers []string
+		)
+
+		BeforeAll(func() {
+			By("Checking required configuration is provided")
+
+			if RHWAConfig.TargetWorker == "" {
+				Skip("ECO_RHWA_NHC_TARGET_WORKER not set")
+			}
+
+			if RHWAConfig.StorageClass == "" {
+				Skip("ECO_RHWA_NHC_STORAGE_CLASS not set")
+			}
+
+			if RHWAConfig.AppImage == "" {
+				Skip("ECO_RHWA_NHC_APP_IMAGE not set")
+			}
+
+			if len(RHWAConfig.FailoverWorkers) == 0 {
+				Skip("ECO_RHWA_NHC_FAILOVER_WORKERS not set")
+			}
+
+			hasHealthyFailover := false
+
+			for _, failoverName := range RHWAConfig.FailoverWorkers {
+				if failoverName == RHWAConfig.TargetWorker {
+					continue
+				}
+
+				failoverNode, pullErr := nodes.Pull(APIClient, failoverName)
+				if pullErr != nil {
+					klog.Warningf("Failed to pull failover node %s: %v", failoverName, pullErr)
+
+					continue
+				}
+
+				for _, condition := range failoverNode.Object.Status.Conditions {
+					if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
+						hasHealthyFailover = true
+
+						break
+					}
+				}
+
+				if hasHealthyFailover {
+					break
+				}
+			}
+
+			if !hasHealthyFailover {
+				Skip("No distinct healthy failover worker available")
+			}
+
+			if RHWAConfig.TargetWorkerBMC.Address == "" {
+				Skip("ECO_RHWA_NHC_TARGET_WORKER_BMC address not set")
+			}
+
+			if RHWAConfig.TargetWorkerBMC.Username == "" || RHWAConfig.TargetWorkerBMC.Password == "" {
+				Skip("ECO_RHWA_NHC_TARGET_WORKER_BMC username or password not set")
+			}
+
+			targetNode = RHWAConfig.TargetWorker
+
+			By("Waiting for target worker node to be Ready")
+
+			klog.Infof("Waiting up to %s for node %s to become Ready", nhcparams.NodeRecoveryTimeout, targetNode)
+
+			targetNodeObj, err := nodes.Pull(APIClient, targetNode)
+			Expect(err).ToNot(HaveOccurred(),
+				fmt.Sprintf("Failed to pull node %s", targetNode))
+
+			err = targetNodeObj.WaitUntilReady(nhcparams.NodeRecoveryTimeout)
+			Expect(err).ToNot(HaveOccurred(),
+				fmt.Sprintf("Target worker node %s did not become Ready", targetNode))
+
+			klog.Infof("Node %s is Ready", targetNode)
+
+			By("Verifying NHC deployment is Ready")
+
+			nhcDeployment, err := deployment.Pull(
+				APIClient, nhcparams.OperatorDeploymentName, rhwaparams.RhwaOperatorNs)
+			Expect(err).ToNot(HaveOccurred(), "Failed to get NHC deployment")
+			Expect(nhcDeployment.IsReady(rhwaparams.DefaultTimeout)).To(BeTrue(),
+				"NHC deployment is not Ready")
+
+			By("Creating BMC client for target node")
+
+			bmcClient = bmc.New(RHWAConfig.TargetWorkerBMC.Address).
+				WithRedfishUser(RHWAConfig.TargetWorkerBMC.Username,
+					RHWAConfig.TargetWorkerBMC.Password).
+				WithRedfishTimeout(nhcparams.BMCTimeout)
+
+			// Register all cleanup in BeforeAll so it runs after the last spec
+			// in this Ordered container (LIFO order).
+
+			DeferCleanup(func() {
+				By("Powering the node back on via BMC")
+
+				if bmcClient == nil {
+					return
+				}
+
+				err := bmcClient.SystemPowerOn()
+				if err != nil {
+					klog.Warningf("Failed to power on node: %v", err)
+
+					return
+				}
+
+				By("Waiting for node to become Ready")
+
+				klog.Infof("Waiting up to %s for node %s to recover to Ready state",
+					nhcparams.NodeRecoveryTimeout, targetNode)
+
+				node, pullErr := nodes.Pull(APIClient, targetNode)
+				if pullErr != nil {
+					klog.Warningf("Failed to pull node %s during cleanup: %v", targetNode, pullErr)
+
+					return
+				}
+
+				waitErr := node.WaitUntilReady(nhcparams.NodeRecoveryTimeout)
+				if waitErr != nil {
+					klog.Warningf("Node %s did not recover to Ready state: %v", targetNode, waitErr)
+				} else {
+					klog.Infof("Node %s recovered to Ready state", targetNode)
+				}
+			})
+
+			DeferCleanup(func() {
+				By("Restoring appworker label on nodes where it was temporarily removed")
+
+				restoreLabelPatch := []byte(
+					fmt.Sprintf(`{"metadata":{"labels":{%q:""}}}`, nhcparams.AppWorkerLabel))
+
+				for _, workerName := range unlabeledWorkers {
+					_, patchErr := APIClient.K8sClient.CoreV1().Nodes().Patch(
+						context.TODO(), workerName, types.MergePatchType,
+						restoreLabelPatch, metav1.PatchOptions{})
+					if patchErr != nil {
+						klog.Warningf("Failed to restore label on node %s: %v", workerName, patchErr)
+					}
+				}
+			})
+
+			DeferCleanup(func() {
+				By("Removing appworker label from nodes labeled by the test")
+
+				removeLabelPatch := []byte(
+					fmt.Sprintf(`{"metadata":{"labels":{%q:null}}}`, nhcparams.AppWorkerLabel))
+
+				for _, workerName := range labeledWorkers {
+					_, patchErr := APIClient.K8sClient.CoreV1().Nodes().Patch(
+						context.TODO(), workerName, types.MergePatchType,
+						removeLabelPatch, metav1.PatchOptions{})
+					if patchErr != nil {
+						klog.Warningf("Failed to remove label from node %s: %v", workerName, patchErr)
+					}
+				}
+			})
+
+			DeferCleanup(func() {
+				By("Deleting test namespace")
+
+				testNS := namespace.NewBuilder(APIClient, nhcparams.AppNamespace)
+
+				if deleteErr := testNS.DeleteAndWait(nhcparams.DeletionTimeout); deleteErr != nil {
+					klog.Warningf("Failed to delete test namespace: %v", deleteErr)
+				}
+			})
+		})
+
+		It("Step 1: Deploys stateful app on target node",
+			reportxml.ID("00001"), func() {
+				By("Ensuring only target node has appworker label")
+
+				removeLabelPatch := []byte(
+					fmt.Sprintf(`{"metadata":{"labels":{%q:null}}}`, nhcparams.AppWorkerLabel))
+				addLabelPatch := []byte(
+					fmt.Sprintf(`{"metadata":{"labels":{%q:""}}}`, nhcparams.AppWorkerLabel))
+
+				for _, workerName := range RHWAConfig.FailoverWorkers {
+					var workerNode *nodes.Builder
+
+					var pullErr error
+
+					for attempt := 1; attempt <= 3; attempt++ {
+						workerNode, pullErr = nodes.Pull(APIClient, workerName)
+						if pullErr == nil {
+							break
+						}
+
+						klog.Warningf("Failed to pull failover node %s (attempt %d/3): %v",
+							workerName, attempt, pullErr)
+						time.Sleep(nhcparams.PollingInterval)
+					}
+
+					if pullErr != nil {
+						klog.Warningf("Giving up on failover node %s after 3 attempts", workerName)
+
+						continue
+					}
+
+					if _, exists := workerNode.Object.Labels[nhcparams.AppWorkerLabel]; exists {
+						klog.Infof("Temporarily removing %s label from failover node %s before deployment",
+							nhcparams.AppWorkerLabel, workerName)
+
+						_, patchErr := APIClient.K8sClient.CoreV1().Nodes().Patch(
+							context.TODO(), workerName, types.MergePatchType,
+							removeLabelPatch, metav1.PatchOptions{})
+						Expect(patchErr).ToNot(HaveOccurred(),
+							fmt.Sprintf("Failed to remove label from node %s", workerName))
+
+						unlabeledWorkers = append(unlabeledWorkers, workerName)
+					}
+				}
+
+				targetWorkerNode, err := nodes.Pull(APIClient, targetNode)
+				Expect(err).ToNot(HaveOccurred(),
+					fmt.Sprintf("Failed to pull node %s", targetNode))
+
+				if _, exists := targetWorkerNode.Object.Labels[nhcparams.AppWorkerLabel]; !exists {
+					_, patchErr := APIClient.K8sClient.CoreV1().Nodes().Patch(
+						context.TODO(), targetNode, types.MergePatchType,
+						addLabelPatch, metav1.PatchOptions{})
+					Expect(patchErr).ToNot(HaveOccurred(),
+						fmt.Sprintf("Failed to label node %s", targetNode))
+
+					labeledWorkers = append(labeledWorkers, targetNode)
+				}
+
+				By("Creating test namespace")
+
+				testNS := namespace.NewBuilder(APIClient, nhcparams.AppNamespace)
+
+				_, err = testNS.Create()
+				Expect(err).ToNot(HaveOccurred(), "Failed to create test namespace")
+
+				By("Creating PersistentVolumeClaim")
+
+				pvcBuilder := storage.NewPVCBuilder(APIClient, nhcparams.PVCName, nhcparams.AppNamespace)
+
+				pvcBuilder, err = pvcBuilder.WithPVCAccessMode("ReadWriteOnce")
+				Expect(err).ToNot(HaveOccurred(), "Failed to set PVC access mode")
+
+				pvcBuilder, err = pvcBuilder.WithPVCCapacity(nhcparams.PVCSize)
+				Expect(err).ToNot(HaveOccurred(), "Failed to set PVC capacity")
+
+				pvcBuilder, err = pvcBuilder.WithStorageClass(RHWAConfig.StorageClass)
+				Expect(err).ToNot(HaveOccurred(), "Failed to set PVC storage class")
+
+				_, err = pvcBuilder.Create()
+				Expect(err).ToNot(HaveOccurred(), "Failed to create PVC")
+
+				By("Creating stateful app deployment")
+
+				appLabels := map[string]string{nhcparams.AppLabelKey: nhcparams.AppLabelValue}
+
+				containerCmd := []string{"/bin/sh", "-c",
+					`echo "Starting stateful app on $(hostname)" > /data/heartbeat.log; ` +
+						`while true; do echo "$(date -Iseconds) alive" >> /data/heartbeat.log; sleep 5; done`}
+
+				container := pod.NewContainerBuilder(nhcparams.AppName, RHWAConfig.AppImage, containerCmd).
+					WithVolumeMount(corev1.VolumeMount{
+						Name:      nhcparams.PVCName,
+						MountPath: "/data",
+					})
+
+				containerSpec, err := container.GetContainerCfg()
+				Expect(err).ToNot(HaveOccurred(), "Failed to build container spec")
+
+				containerSpec.SecurityContext = nil
+				containerSpec.ReadinessProbe = &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						Exec: &corev1.ExecAction{
+							Command: []string{"cat", "/data/heartbeat.log"},
+						},
+					},
+					InitialDelaySeconds: 5,
+					PeriodSeconds:       5,
+				}
+
+				deploy := deployment.NewBuilder(
+					APIClient, nhcparams.AppName, nhcparams.AppNamespace, appLabels, *containerSpec).
+					WithNodeSelector(map[string]string{nhcparams.AppWorkerLabel: ""}).
+					WithReplicas(int32(1)).
+					WithVolume(corev1.Volume{
+						Name: nhcparams.PVCName,
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: nhcparams.PVCName,
+							},
+						},
+					})
+
+				deploy.Definition.Spec.Strategy = appsv1.DeploymentStrategy{
+					Type: appsv1.RecreateDeploymentStrategyType,
+				}
+
+				_, err = deploy.CreateAndWaitUntilReady(nhcparams.DeploymentTimeout)
+				Expect(err).ToNot(HaveOccurred(), "Failed to create stateful app deployment")
+
+				By("Verifying app pod is running on the target node")
+
+				appPods, err := pod.List(APIClient, nhcparams.AppNamespace, metav1.ListOptions{
+					LabelSelector: fmt.Sprintf("%s=%s", nhcparams.AppLabelKey, nhcparams.AppLabelValue),
+					FieldSelector: "status.phase=Running",
+				})
+				Expect(err).ToNot(HaveOccurred(), "Failed to list app pods")
+				Expect(appPods).To(HaveLen(1), "Expected exactly 1 running app pod")
+
+				targetNode = appPods[0].Object.Spec.NodeName
+				klog.Infof("Stateful app is running on node %s", targetNode)
+
+				Expect(targetNode).To(Equal(RHWAConfig.TargetWorker),
+					"App pod should be pinned to the configured target node")
+
+				By("Labeling failover worker nodes")
+
+				addLabelPatchFO := []byte(
+					fmt.Sprintf(`{"metadata":{"labels":{%q:""}}}`, nhcparams.AppWorkerLabel))
+
+				for _, workerName := range RHWAConfig.FailoverWorkers {
+					if workerName == targetNode {
+						continue
+					}
+
+					workerNode, pullErr := nodes.Pull(APIClient, workerName)
+					Expect(pullErr).ToNot(HaveOccurred(),
+						fmt.Sprintf("Failed to pull node %s", workerName))
+
+					if _, exists := workerNode.Object.Labels[nhcparams.AppWorkerLabel]; exists {
+						klog.Infof("Node %s already has label %s, skipping", workerName, nhcparams.AppWorkerLabel)
+
+						continue
+					}
+
+					_, patchErr := APIClient.K8sClient.CoreV1().Nodes().Patch(
+						context.TODO(), workerName, types.MergePatchType,
+						addLabelPatchFO, metav1.PatchOptions{})
+					Expect(patchErr).ToNot(HaveOccurred(),
+						fmt.Sprintf("Failed to label node %s", workerName))
+
+					labeledWorkers = append(labeledWorkers, workerName)
+				}
+			})
+
+		It("Step 2: Powers off the target node via BMC",
+			reportxml.ID("00002"), func() {
+				By("Sending power-off command via BMC Redfish")
+
+				err := bmcClient.SystemPowerOff()
+				Expect(err).ToNot(HaveOccurred(), "Failed to power off node via BMC")
+
+				By("Waiting for node Ready condition to become Unknown (~40s expected)")
+
+				klog.Infof("Waiting up to %s for node %s Ready condition to become Unknown",
+					nhcparams.NodeReadyTimeout, targetNode)
+
+				targetNodeObj, err := nodes.Pull(APIClient, targetNode)
+				Expect(err).ToNot(HaveOccurred(),
+					fmt.Sprintf("Failed to pull node %s", targetNode))
+
+				err = targetNodeObj.WaitUntilNotReady(nhcparams.NodeReadyTimeout)
+				Expect(err).ToNot(HaveOccurred(),
+					fmt.Sprintf("Node %s Ready condition did not become NotReady/Unknown", targetNode))
+
+				klog.Infof("Node %s Ready condition is now NotReady/Unknown", targetNode)
+			})
+
+		It("Step 3: Verifies NHC marks node unhealthy and creates SNR resource",
+			reportxml.ID("00003"), func() {
+				By("Getting NodeHealthCheck resource")
+
+				nhcResource, err := APIClient.Resource(nhcparams.NhcGVR).Get(
+					context.TODO(), nhcparams.NHCResourceName, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred(), "Failed to get NodeHealthCheck resource")
+
+				By("Verifying minHealthy threshold is still satisfied")
+
+				spec, specOk := nhcResource.Object["spec"].(map[string]any)
+				Expect(specOk).To(BeTrue(), "NHC resource has no spec")
+
+				status, statusOk := nhcResource.Object["status"].(map[string]any)
+				Expect(statusOk).To(BeTrue(), "NHC resource has no status")
+
+				minHealthyStr := fmt.Sprintf("%v", spec["minHealthy"])
+				observedNodes := status["observedNodes"]
+				healthyNodes := status["healthyNodes"]
+
+				klog.Infof("NHC: minHealthy=%s, observedNodes=%v, healthyNodes=%v",
+					minHealthyStr, observedNodes, healthyNodes)
+
+				if pctStr, ok := strings.CutSuffix(minHealthyStr, "%"); ok {
+					pct, parseErr := strconv.ParseFloat(pctStr, 64)
+					Expect(parseErr).ToNot(HaveOccurred(), "Failed to parse minHealthy percentage")
+
+					observed, observedErr := toFloat64(observedNodes)
+					Expect(observedErr).ToNot(HaveOccurred(), "Failed to convert observedNodes to float64")
+
+					healthy, healthyErr := toFloat64(healthyNodes)
+					Expect(healthyErr).ToNot(HaveOccurred(), "Failed to convert healthyNodes to float64")
+
+					minRequired := math.Ceil(observed * pct / 100)
+
+					Expect(healthy).To(BeNumerically(">=", minRequired),
+						fmt.Sprintf("minHealthy threshold not satisfied: %v/%v healthy, minimum %v required",
+							healthy, observed, minRequired))
+				}
+
+				By("Waiting for NHC to mark node as unhealthy (~60s expected)")
+
+				Eventually(func() bool {
+					nhc, getErr := APIClient.Resource(nhcparams.NhcGVR).Get(
+						context.TODO(), nhcparams.NHCResourceName, metav1.GetOptions{})
+					if getErr != nil {
+						klog.Infof("  polling NHC: error getting resource: %v", getErr)
+
+						return false
+					}
+
+					nhcStatus, hasStatus := nhc.Object["status"].(map[string]any)
+					if !hasStatus {
+						klog.Infof("  polling NHC: no status yet")
+
+						return false
+					}
+
+					healthy := nhcStatus["healthyNodes"]
+					observed := nhcStatus["observedNodes"]
+
+					unhealthyNodes, hasUnhealthy := nhcStatus["unhealthyNodes"].([]any)
+					if !hasUnhealthy {
+						klog.Infof("  polling NHC: healthy=%v/%v, no unhealthy nodes yet", healthy, observed)
+
+						return false
+					}
+
+					var unhealthyNames []string
+
+					for _, node := range unhealthyNodes {
+						nodeMap, ok := node.(map[string]any)
+						if !ok {
+							continue
+						}
+
+						name := fmt.Sprintf("%v", nodeMap["name"])
+						unhealthyNames = append(unhealthyNames, name)
+
+						if name == targetNode {
+							klog.Infof("  polling NHC: %s is now unhealthy", targetNode)
+
+							return true
+						}
+					}
+
+					klog.Infof("  polling NHC: healthy=%v/%v, unhealthy=%v (waiting for %s)",
+						healthy, observed, unhealthyNames, targetNode)
+
+					return false
+				}).WithTimeout(nhcparams.NHCObserveTimeout).
+					WithPolling(nhcparams.PollingInterval).
+					Should(BeTrue(),
+						fmt.Sprintf("NHC did not mark %s as unhealthy", targetNode))
+
+				By("Waiting for SelfNodeRemediation resource to be created")
+
+				var snrResourceName string
+
+				Eventually(func() bool {
+					snrList, listErr := APIClient.Resource(rhwaparams.SnrGVR).
+						Namespace(rhwaparams.RhwaOperatorNs).
+						List(context.TODO(), metav1.ListOptions{})
+					if listErr != nil {
+						klog.Infof("  polling SNR: error listing resources: %v", listErr)
+
+						return false
+					}
+
+					klog.Infof("  polling SNR: found %d SelfNodeRemediation resources", len(snrList.Items))
+
+					for _, snr := range snrList.Items {
+						annotations := snr.GetAnnotations()
+						if annotations["remediation.medik8s.io/node-name"] == targetNode {
+							snrResourceName = snr.GetName()
+							klog.Infof("  polling SNR: found %s for %s", snrResourceName, targetNode)
+
+							return true
+						}
+					}
+
+					klog.Infof("  polling SNR: none yet for %s", targetNode)
+
+					return false
+				}).WithTimeout(nhcparams.NHCObserveTimeout).
+					WithPolling(nhcparams.PollingInterval).
+					Should(BeTrue(),
+						fmt.Sprintf("SelfNodeRemediation not created for %s", targetNode))
+
+				By("Verifying remediationStrategy is OutOfServiceTaint")
+
+				snrResource, err := APIClient.Resource(rhwaparams.SnrGVR).
+					Namespace(rhwaparams.RhwaOperatorNs).
+					Get(context.TODO(), snrResourceName, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred(), "Failed to get SelfNodeRemediation resource")
+
+				snrSpec, snrSpecOk := snrResource.Object["spec"].(map[string]any)
+				Expect(snrSpecOk).To(BeTrue(), "SNR resource has no spec")
+				Expect(snrSpec["remediationStrategy"]).To(Equal("OutOfServiceTaint"),
+					"Expected remediationStrategy=OutOfServiceTaint")
+			})
+
+		It("Step 4: Verifies SNR fences the node with out-of-service taint",
+			reportxml.ID("00004"), func() {
+				By("Waiting for SNR fencing to complete (~180s expected)")
+
+				Eventually(func() bool {
+					snrList, listErr := APIClient.Resource(rhwaparams.SnrGVR).
+						Namespace(rhwaparams.RhwaOperatorNs).
+						List(context.TODO(), metav1.ListOptions{})
+					if listErr != nil {
+						klog.Infof("  polling SNR fencing: error listing: %v", listErr)
+
+						return false
+					}
+
+					for _, snr := range snrList.Items {
+						annotations := snr.GetAnnotations()
+						if annotations["remediation.medik8s.io/node-name"] != targetNode {
+							continue
+						}
+
+						snrStatus, hasStatus := snr.Object["status"].(map[string]any)
+						if !hasStatus {
+							klog.Infof("  polling SNR fencing: no status yet on %s", snr.GetName())
+
+							return false
+						}
+
+						phase := fmt.Sprintf("%v", snrStatus["phase"])
+						lastErr := fmt.Sprintf("%v", snrStatus["lastError"])
+						timeAssumedRebooted := fmt.Sprintf("%v", snrStatus["timeAssumedRebooted"])
+
+						klog.Infof("  polling SNR fencing: phase=%s, lastError=%s, timeAssumedRebooted=%s",
+							phase, lastErr, timeAssumedRebooted)
+
+						if phase == "Fencing-Completed" || phase == "Fencing-CompletedSuccessfully" {
+							return true
+						}
+
+						conditions, ok := snrStatus["conditions"].([]any)
+						if ok {
+							for _, cond := range conditions {
+								condMap, ok := cond.(map[string]any)
+								if !ok {
+									continue
+								}
+
+								if fmt.Sprintf("%v", condMap["type"]) == "Succeeded" &&
+									fmt.Sprintf("%v", condMap["status"]) == "True" {
+									klog.Infof("  polling SNR fencing: Succeeded condition is True")
+
+									return true
+								}
+							}
+						}
+
+						return false
+					}
+
+					klog.Infof("  polling SNR fencing: no SNR resource found for %s", targetNode)
+
+					return false
+				}).WithTimeout(nhcparams.SNRFenceTimeout).
+					WithPolling(nhcparams.PollingInterval).
+					Should(BeTrue(),
+						fmt.Sprintf("SNR did not complete fencing for %s", targetNode))
+
+				By("Verifying out-of-service taint was applied (via AddOutOfService event)")
+				// Note: the out-of-service taint is transient — SNR removes it as part of completing
+				// fencing. By the time the SNR phase reaches "Fencing-Completed", the taint has already
+				// been removed. We verify the taint was applied by checking for the AddOutOfService event,
+				// which is a permanent record that the taint was added during the remediation cycle.
+
+				events, err := APIClient.CoreV1Interface.Events("default").List(
+					context.TODO(), metav1.ListOptions{
+						FieldSelector: fmt.Sprintf("involvedObject.name=%s,reason=AddOutOfService", targetNode),
+					})
+				Expect(err).ToNot(HaveOccurred(),
+					fmt.Sprintf("Failed to list events for node %s", targetNode))
+				Expect(events.Items).ToNot(BeEmpty(),
+					fmt.Sprintf("No AddOutOfService event found for node %s — "+
+						"out-of-service taint was never applied during remediation", targetNode))
+			})
+
+		It("Step 5: Verifies stateful app rescheduled to a healthy node",
+			reportxml.ID("00005"), func() {
+				var rescheduledNodeName string
+
+				By("Waiting for app pod to be Ready on a different node")
+
+				Eventually(func() bool {
+					// Check deployment status for diagnostics.
+					deploy, deployErr := deployment.Pull(
+						APIClient, nhcparams.AppName, nhcparams.AppNamespace)
+					if deployErr != nil {
+						klog.Infof("  polling reschedule: error pulling deployment: %v", deployErr)
+					} else {
+						status := deploy.Object.Status
+						klog.Infof("  polling reschedule: deployment replicas=%d ready=%d available=%d unavailable=%d",
+							status.Replicas, status.ReadyReplicas, status.AvailableReplicas, status.UnavailableReplicas)
+					}
+
+					// List ALL pods in the namespace for visibility.
+					allPods, allErr := pod.List(APIClient, nhcparams.AppNamespace, metav1.ListOptions{})
+					if allErr != nil {
+						klog.Infof("  polling reschedule: error listing all pods: %v", allErr)
+					} else {
+						klog.Infof("  polling reschedule: total pods in namespace: %d", len(allPods))
+
+						for idx := range allPods {
+							p := allPods[idx]
+							klog.Infof("  polling reschedule:   pod %s phase=%s node=%s",
+								p.Object.Name, p.Object.Status.Phase, p.Object.Spec.NodeName)
+
+							if p.Object.Status.Phase == corev1.PodPending {
+								for _, cond := range p.Object.Status.Conditions {
+									if cond.Status != corev1.ConditionTrue {
+										klog.Infof("  polling reschedule:     condition %s=%s: %s",
+											cond.Type, cond.Status, cond.Message)
+									}
+								}
+							}
+						}
+					}
+
+					// Check PVC status.
+					pvcObj, pvcErr := APIClient.K8sClient.CoreV1().PersistentVolumeClaims(nhcparams.AppNamespace).Get(
+						context.TODO(), nhcparams.PVCName, metav1.GetOptions{})
+					if pvcErr != nil {
+						klog.Infof("  polling reschedule: error getting PVC: %v", pvcErr)
+					} else {
+						klog.Infof("  polling reschedule: PVC %s phase=%s volume=%s",
+							pvcObj.Name, pvcObj.Status.Phase, pvcObj.Spec.VolumeName)
+					}
+
+					// Now check for the rescheduled app pod.
+					appPods, listErr := pod.List(APIClient, nhcparams.AppNamespace, metav1.ListOptions{
+						LabelSelector: fmt.Sprintf("%s=%s", nhcparams.AppLabelKey, nhcparams.AppLabelValue),
+					})
+					if listErr != nil {
+						klog.Infof("  polling reschedule: error listing app pods: %v", listErr)
+
+						return false
+					}
+
+					for idx := range appPods {
+						appPod := appPods[idx]
+						podReady := isPodReady(appPod)
+						klog.Infof("  polling reschedule: app pod %s phase=%s ready=%v node=%s",
+							appPod.Object.Name, appPod.Object.Status.Phase, podReady, appPod.Object.Spec.NodeName)
+
+						if podReady && appPod.Object.Spec.NodeName != targetNode {
+							rescheduledNodeName = appPod.Object.Spec.NodeName
+							klog.Infof("  polling reschedule: app rescheduled and Ready on %s", rescheduledNodeName)
+
+							return true
+						}
+					}
+
+					klog.Infof("  polling reschedule: no Ready app pod on a different node yet (found %d app pods)",
+						len(appPods))
+
+					return false
+				}).WithTimeout(nhcparams.RescheduleTimeout).
+					WithPolling(nhcparams.PollingInterval).
+					Should(BeTrue(), "App pod was not rescheduled to a healthy node")
+
+				By("Verifying PVC is Bound")
+
+				pvcList, err := storage.ListPVC(APIClient, nhcparams.AppNamespace, metav1.ListOptions{})
+				Expect(err).ToNot(HaveOccurred(), "Failed to list PVCs")
+
+				var appPVC *storage.PVCBuilder
+
+				for idx := range pvcList {
+					if pvcList[idx].Object.Name == nhcparams.PVCName {
+						appPVC = pvcList[idx]
+
+						break
+					}
+				}
+
+				Expect(appPVC).ToNot(BeNil(), "PVC not found")
+				Expect(appPVC.Object.Status.Phase).To(Equal(corev1.ClaimBound),
+					"PVC is not Bound")
+
+				pvName := appPVC.Object.Spec.VolumeName
+				klog.Infof("PVC %s is Bound to PV %s", nhcparams.PVCName, pvName)
+
+				By("Verifying VolumeAttachment to new node")
+
+				vaList, err := APIClient.StorageV1Interface.VolumeAttachments().List(
+					context.TODO(), metav1.ListOptions{})
+				Expect(err).ToNot(HaveOccurred(), "Failed to list VolumeAttachments")
+
+				foundOnNewNode := false
+				foundOnOldNode := false
+				hasVolumeAttachment := false
+
+				for idx := range vaList.Items {
+					attachment := &vaList.Items[idx]
+					if attachment.Spec.Source.PersistentVolumeName == nil || *attachment.Spec.Source.PersistentVolumeName != pvName {
+						continue
+					}
+
+					hasVolumeAttachment = true
+
+					if attachment.Spec.NodeName == rescheduledNodeName && attachment.Status.Attached {
+						foundOnNewNode = true
+					}
+
+					if attachment.Spec.NodeName == targetNode && attachment.Status.Attached {
+						foundOnOldNode = true
+					}
+				}
+
+				if hasVolumeAttachment {
+					Expect(foundOnNewNode).To(BeTrue(),
+						fmt.Sprintf("PV %s is not attached to rescheduled node %s", pvName, rescheduledNodeName))
+					Expect(foundOnOldNode).To(BeFalse(),
+						fmt.Sprintf("PV %s is still attached to shut-down node %s", pvName, targetNode))
+				} else {
+					klog.Infof("No VolumeAttachment found for PV %s — storage driver does not use CSI attachments (e.g. NFS)",
+						pvName)
+				}
+			})
+	})
+
+func isPodReady(podBuilder *pod.Builder) bool {
+	for _, condition := range podBuilder.Object.Status.Conditions {
+		if condition.Type == corev1.PodReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+
+	return false
+}
+
+func toFloat64(val any) (float64, error) {
+	switch value := val.(type) {
+	case float64:
+		return value, nil
+	case int64:
+		return float64(value), nil
+	case string:
+		return strconv.ParseFloat(value, 64)
+	default:
+		return 0, fmt.Errorf("cannot convert %T to float64", val)
+	}
+}

--- a/tests/rhwa/snr-operator/internal/snrparams/snrvars.go
+++ b/tests/rhwa/snr-operator/internal/snrparams/snrvars.go
@@ -1,8 +1,28 @@
 package snrparams
 
-import "github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/internal/rhwaparams"
+import (
+	"github.com/openshift-kni/k8sreporter"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/internal/rhwaparams"
+	corev1 "k8s.io/api/core/v1"
+)
 
 var (
 	// Labels represents the range of labels that can be used for test cases selection.
 	Labels = []string{rhwaparams.Label, Label}
+
+	// OperatorDeploymentName represents SNR deployment name.
+	OperatorDeploymentName = "self-node-remediation-controller-manager"
+
+	// OperatorControllerPodLabel is how the controller pod is labeled.
+	OperatorControllerPodLabel = "self-node-remediation-operator"
+
+	// ReporterNamespacesToDump tells to the reporter from where to collect logs.
+	ReporterNamespacesToDump = map[string]string{
+		rhwaparams.RhwaOperatorNs: rhwaparams.RhwaOperatorNs,
+	}
+
+	// ReporterCRDsToDump tells to the reporter what CRs to dump.
+	ReporterCRDsToDump = []k8sreporter.CRData{
+		{Cr: &corev1.PodList{}},
+	}
 )

--- a/tests/rhwa/snr-operator/snr_suite_test.go
+++ b/tests/rhwa/snr-operator/snr_suite_test.go
@@ -1,0 +1,34 @@
+package snr
+
+import (
+	"runtime"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/reporter"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/internal/rhwainittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/snr-operator/internal/snrparams"
+	_ "github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/snr-operator/tests"
+)
+
+var _, currentFile, _, _ = runtime.Caller(0)
+
+func TestSNR(t *testing.T) {
+	_, reporterConfig := GinkgoConfiguration()
+	reporterConfig.JUnitReport = RHWAConfig.GetJunitReportPath(currentFile)
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "SNR", Label(snrparams.Labels...), reporterConfig)
+}
+
+var _ = JustAfterEach(func() {
+	reporter.ReportIfFailed(
+		CurrentSpecReport(), currentFile, snrparams.ReporterNamespacesToDump, snrparams.ReporterCRDsToDump)
+})
+
+var _ = ReportAfterSuite("", func(report Report) {
+	reportxml.Create(
+		report, RHWAConfig.GetReportPath(), RHWAConfig.TCPrefix)
+})

--- a/tests/rhwa/snr-operator/tests/snr.go
+++ b/tests/rhwa/snr-operator/tests/snr.go
@@ -1,0 +1,54 @@
+package tests
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/deployment"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
+
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/internal/rhwainittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/internal/rhwaparams"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/rhwa/snr-operator/internal/snrparams"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe(
+	"SNR Post Deployment tests",
+	Ordered,
+	ContinueOnFailure,
+	Label(snrparams.Label), func() {
+		BeforeAll(func() {
+			By("Get SNR deployment object")
+
+			snrDeployment, err := deployment.Pull(
+				APIClient, snrparams.OperatorDeploymentName, rhwaparams.RhwaOperatorNs)
+			Expect(err).ToNot(HaveOccurred(), "Failed to get SNR deployment")
+
+			By("Verify SNR deployment is Ready")
+			Expect(snrDeployment.IsReady(rhwaparams.DefaultTimeout)).To(BeTrue(), "SNR deployment is not Ready")
+		})
+
+		It("Verify Self Node Remediation Operator pod is running", func() {
+			listOptions := metav1.ListOptions{
+				LabelSelector: snrparams.OperatorControllerPodLabel,
+			}
+
+			pods, err := pod.List(APIClient, rhwaparams.RhwaOperatorNs, listOptions)
+			Expect(err).ToNot(HaveOccurred(), "Failed to list pods")
+			Expect(pods).ToNot(BeEmpty(),
+				fmt.Sprintf("No pods found matching label %s", snrparams.OperatorControllerPodLabel))
+
+			allRunning, err := pod.WaitForAllPodsInNamespaceRunning(
+				APIClient,
+				rhwaparams.RhwaOperatorNs,
+				rhwaparams.DefaultTimeout,
+				listOptions,
+			)
+			Expect(err).ToNot(HaveOccurred(), "Error waiting for pods to be ready")
+			Expect(allRunning).To(BeTrue(), "Not all SNR operator pods are running")
+		})
+	})


### PR DESCRIPTION
Add a test suite that runs through the following scenario.

A healthy OpenShift cluster with a MNO topology experiences the sudden shutdown of a worker node that is running a stateful application (a simple Pod writing to a PV). The application is evicted and rescheduled to another healthy node in order to provide business continuity.

Assisted-by: Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added NHC and SNR readiness suites with lifecycle reporter hooks, JUnit/XML outputs, and ordered e2e coverage.
  * Added a comprehensive "sudden node loss" workflow exercising BMC power off, NHC detection, SNR fencing, PVC reattachment, and app failover.

* **Chores**
  * Expanded test configuration with explicit defaults for target worker, failover workers, storage class, app image, and BMC credentials.
  * Added operator identifiers, GVRs, reporter targets, and tuned timeouts/intervals for tests.

* **Documentation**
  * Added README detailing the sudden-node-loss scenario, prerequisites, env vars, and run instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->