### PR TITLE
cnf ran: add ORAN Metal3 hardware plugin tests

### DIFF
--- a/tests/cnf/ran/oran/internal/helper/helper.go
+++ b/tests/cnf/ran/oran/internal/helper/helper.go
@@ -42,6 +42,26 @@ func NewProvisioningRequest(client runtimeclient.Client, templateVersion string)
 	return prBuilder
 }
 
+// NewSecondaryProvisioningRequest creates a ProvisioningRequest builder for a secondary PR using TestPRName2 and
+// distinct cluster/node names so the request does not fail on clusterName ownership before hardware allocation is
+// attempted.
+func NewSecondaryProvisioningRequest(
+	client runtimeclient.Client, templateVersion string) *oran.ProvisioningRequestBuilder {
+	versionWithAffix := RANConfig.ClusterTemplateAffix + "-" + templateVersion
+	prBuilder := oran.NewPRBuilder(client, tsparams.TestPRName2, tsparams.ClusterTemplateName, versionWithAffix).
+		WithTemplateParameter("nodeClusterName", tsparams.TestName2).
+		WithTemplateParameter("oCloudSiteId", tsparams.OCloudSiteID).
+		WithTemplateParameter("policyTemplateParameters", map[string]any{}).
+		WithTemplateParameter("clusterInstanceParameters", map[string]any{
+			"clusterName": tsparams.TestName2,
+			"nodes": []map[string]any{{
+				"hostName": tsparams.TestName2,
+			}},
+		})
+
+	return prBuilder
+}
+
 // NewInlineBMCPR creates a ProvisioningRequest builder for ClusterTemplates that omit hwMgmtDefaults and rely on inline
 // BMC details in clusterInstanceParameters. All required parameters and the affix are set from RANConfig. The BMC and
 // network data are incorrect so that a ClusterInstance is generated but will not provision.

--- a/tests/cnf/ran/oran/internal/tsparams/consts.go
+++ b/tests/cnf/ran/oran/internal/tsparams/consts.go
@@ -12,6 +12,9 @@ const (
 	LabelProvision = "provision"
 	// LabelPostProvision is the label applied to just the post-provision test cases.
 	LabelPostProvision = "post-provision"
+	// LabelMetal3Day2 is the label applied to just the day-2 Metal3 test cases. It is designed to be run after the
+	// post-provision tests.
+	LabelMetal3Day2 = "metal3-day2"
 	// LabelTemplateInventory is the label applied to just the template inventory test cases.
 	LabelTemplateInventory = "template-inventory"
 	// LabelAlarms is the label applied to just the alarms test cases.
@@ -50,6 +53,12 @@ const (
 	// PRFulfilledDetailsSubstring is a substring of status.provisioningStatus.provisioningDetails when
 	// provisioning completes successfully.
 	PRFulfilledDetailsSubstring = "Provisioning request has completed successfully"
+	// PRNoHardwareMatchDetailsSubstring is a substring of provisioningDetails when no free hardware matches the
+	// resource selector. The operator uses the same message when matching hardware exists but is already allocated.
+	PRNoHardwareMatchDetailsSubstring = "not enough free resources matching"
+	// PRMissingBootInterfaceDetailsSubstring is a substring of provisioningDetails when no NIC in the
+	// ClusterInstance defaults matches the boot interface label value.
+	PRMissingBootInterfaceDetailsSubstring = "no NIC found matching boot interface label value"
 )
 
 const (
@@ -69,6 +78,20 @@ const (
 	TemplateInlineBMCMissingSchema = "v12"
 	// TemplateInlineBMC is the ClusterTemplate version for the successful inline BMC provisioning test (78246).
 	TemplateInlineBMC = "v13"
+	// TemplateBMCFirmwareUpdate is the ClusterTemplate version for BMC firmware upgrade test.
+	TemplateBMCFirmwareUpdate = "v14"
+	// TemplateBIOSFirmwareUpdate is the ClusterTemplate version for BIOS firmware upgrade test.
+	TemplateBIOSFirmwareUpdate = "v15"
+	// TemplateBIOSSettingsUpdate is the ClusterTemplate version for BIOS settings update test.
+	TemplateBIOSSettingsUpdate = "v16"
+	// TemplateNoHardwareMatch is the ClusterTemplate version for no hardware matching test.
+	TemplateNoHardwareMatch = "v17"
+	// TemplateMissingBootInterface is the ClusterTemplate version for missing boot interface test.
+	TemplateMissingBootInterface = "v18"
+	// TemplateNonexistentHWProfile is the ClusterTemplate version for nonexistent hardware profile test.
+	TemplateNonexistentHWProfile = "v19"
+	// TemplateHardwareAllocated is the ClusterTemplate version for allocated hardware test.
+	TemplateHardwareAllocated = "v20"
 )
 
 const (
@@ -86,6 +109,9 @@ const (
 	// TestPRName is the UUID used for naming ProvisioningRequests. Since metadata.name must be a UUID, just use a
 	// constant one for consistency.
 	TestPRName = "9c5372f3-ea1d-4a96-8157-b3b874a55cf9"
+	// TestPRName2 is the second UUID used for naming ProvisioningRequests. Metal3 tests require a second PR applied
+	// to verify the case of all hardware already allocated.
+	TestPRName2 = "a1b2c3d4-e5f6-7890-1234-567890abcdef"
 	// TestBase64Credential is a base64 encoded version of the string "wrongpassword" for when an obviously invalid
 	// credential is needed.
 	TestBase64Credential = "d3JvbmdwYXNzd29yZA=="

--- a/tests/cnf/ran/oran/tests/oran-day2-metal3.go
+++ b/tests/cnf/ran/oran/tests/oran-day2-metal3.go
@@ -1,0 +1,290 @@
+package tests
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	hardwaremanagementv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
+	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/bmh"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/oran"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/siteconfig"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/raninittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/auth"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/helper"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/oran/internal/tsparams"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Metal3 day2 tests run in their own file so they do not inherit the PR-restore AfterEach from the standard
+// post-provision tests. Rolling back each change would require firmware changes and a reboot, which is extra time we do
+// not need to spend.
+var _ = Describe("ORAN Metal3 Day2 Tests", Label(tsparams.LabelMetal3Day2), Ordered, ContinueOnFailure, func() {
+	var o2imsAPIClient runtimeclient.Client
+
+	BeforeEach(func() {
+		By("creating the O2IMS API client")
+
+		clientBuilder, err := auth.NewClientBuilderForConfig(RANConfig)
+		Expect(err).ToNot(HaveOccurred(), "Failed to create the O2IMS API client builder")
+
+		o2imsAPIClient, err = clientBuilder.BuildProvisioning()
+		Expect(err).ToNot(HaveOccurred(), "Failed to create the O2IMS API client")
+
+		By("verifying ProvisioningRequest is fulfilled to start")
+
+		prBuilder, err := oran.PullPR(o2imsAPIClient, tsparams.TestPRName)
+		Expect(err).ToNot(HaveOccurred(), "Failed to pull spoke 1 ProvisioningRequest")
+
+		_, err = prBuilder.WaitUntilFulfilled(3 * time.Minute)
+		Expect(err).ToNot(HaveOccurred(), "Failed to verify spoke 1 ProvisioningRequest is fulfilled")
+	})
+
+	// 83883 - Failed provisioning due to all matching hardware already allocated
+	It("fails when all matching hardware is already allocated", reportxml.ID("83883"), func() {
+		By("creating a second ProvisioningRequest when hardware is already allocated")
+
+		prBuilder2 := helper.NewSecondaryProvisioningRequest(o2imsAPIClient, tsparams.TemplateHardwareAllocated)
+		prBuilder2, err := prBuilder2.Create()
+		Expect(err).ToNot(HaveOccurred(), "Failed to create second ProvisioningRequest when hardware is allocated")
+
+		DeferCleanup(func() {
+			By("cleaning up the second ProvisioningRequest")
+
+			if prBuilder2 != nil {
+				err := prBuilder2.DeleteAndWait(10 * time.Minute)
+				Expect(err).ToNot(HaveOccurred(), "Failed to delete the second ProvisioningRequest")
+			}
+
+			By("waiting for the primary ProvisioningRequest to return to fulfilled after second PR cleanup")
+
+			primaryPR, err := oran.PullPR(o2imsAPIClient, tsparams.TestPRName)
+			Expect(err).ToNot(HaveOccurred(), "Failed to pull primary ProvisioningRequest after second PR cleanup")
+			_, err = primaryPR.WaitUntilFulfilled(5 * time.Minute)
+			Expect(err).ToNot(HaveOccurred(),
+				"Failed to wait for primary ProvisioningRequest to return to fulfilled after second PR cleanup")
+		})
+
+		By("waiting for second ProvisioningRequest to fail due to allocated hardware")
+
+		err = prBuilder2.WaitForPhaseAfter(provisioningv1alpha1.StateFailed, time.Time{}, 5*time.Minute)
+		Expect(err).ToNot(HaveOccurred(), "Failed to wait for second ProvisioningRequest to fail due to allocated hardware")
+
+		By("verifying failure reason indicates all matching hardware is allocated")
+
+		currentPR, err := oran.PullPR(o2imsAPIClient, tsparams.TestPRName2)
+		Expect(err).ToNot(HaveOccurred(), "Failed to get second ProvisioningRequest status")
+		Expect(currentPR.Definition.Status.ProvisioningStatus.ProvisioningPhase).
+			To(Equal(provisioningv1alpha1.StateFailed))
+		Expect(currentPR.Definition.Status.ProvisioningStatus.ProvisioningDetails).
+			To(ContainSubstring(tsparams.PRNoHardwareMatchDetailsSubstring),
+				"Expected provisioning details to report no free hardware matching the resource selector")
+	})
+
+	// 83877 - Successful day2 upgrade of BMC firmware
+	It("successfully upgrades BMC firmware", reportxml.ID("83877"), func() {
+		By("pulling the ProvisioningRequest for BMC firmware update")
+
+		prBuilder, err := oran.PullPR(o2imsAPIClient, tsparams.TestPRName)
+		Expect(err).ToNot(HaveOccurred(), "Failed to pull spoke 1 ProvisioningRequest")
+
+		By("updating the ProvisioningRequest to reference new ClusterTemplate with BMC firmware update")
+
+		updateTime := getStartTime()
+		newTemplateVersion := RANConfig.ClusterTemplateAffix + "-" + tsparams.TemplateBMCFirmwareUpdate
+		prBuilder.Definition.Spec.TemplateVersion = newTemplateVersion
+		prBuilder, err = prBuilder.Update()
+		Expect(err).ToNot(HaveOccurred(), "Failed to update ProvisioningRequest with new BMC firmware template")
+
+		By("waiting for ProvisioningRequest to progress through update")
+
+		err = prBuilder.WaitForPhaseAfter(provisioningv1alpha1.StateProgressing, updateTime, 2*time.Minute)
+		Expect(err).ToNot(HaveOccurred(), "Failed to wait for ProvisioningRequest to enter progressing state")
+
+		By("waiting for ProvisioningRequest to be fulfilled after BMC firmware update")
+
+		err = prBuilder.WaitForPhaseAfter(provisioningv1alpha1.StateFulfilled, updateTime, 120*time.Minute)
+		Expect(err).ToNot(HaveOccurred(), "Failed to wait for ProvisioningRequest to be fulfilled after BMC firmware update")
+
+		By("verifying BMC firmware has been updated")
+		verifyFirmwareUpdate(prBuilder, "bmc")
+	})
+
+	// 83878 - Successful day2 upgrade of BIOS firmware
+	It("successfully upgrades BIOS firmware", reportxml.ID("83878"), func() {
+		By("pulling the ProvisioningRequest for BIOS firmware update")
+
+		prBuilder, err := oran.PullPR(o2imsAPIClient, tsparams.TestPRName)
+		Expect(err).ToNot(HaveOccurred(), "Failed to pull spoke 1 ProvisioningRequest")
+
+		By("updating the ProvisioningRequest to reference new ClusterTemplate with BIOS firmware update")
+
+		updateTime := getStartTime()
+		newTemplateVersion := RANConfig.ClusterTemplateAffix + "-" + tsparams.TemplateBIOSFirmwareUpdate
+		prBuilder.Definition.Spec.TemplateVersion = newTemplateVersion
+		prBuilder, err = prBuilder.Update()
+		Expect(err).ToNot(HaveOccurred(), "Failed to update ProvisioningRequest with new BIOS firmware template")
+
+		By("waiting for ProvisioningRequest to progress through update")
+
+		err = prBuilder.WaitForPhaseAfter(provisioningv1alpha1.StateProgressing, updateTime, 2*time.Minute)
+		Expect(err).ToNot(HaveOccurred(), "Failed to wait for ProvisioningRequest to enter progressing state")
+
+		By("waiting for ProvisioningRequest to be fulfilled after BIOS firmware update")
+
+		err = prBuilder.WaitForPhaseAfter(provisioningv1alpha1.StateFulfilled, updateTime, 120*time.Minute)
+		Expect(err).ToNot(HaveOccurred(),
+			"Failed to wait for ProvisioningRequest to be fulfilled after BIOS firmware update")
+
+		By("verifying BIOS firmware has been updated")
+		verifyFirmwareUpdate(prBuilder, "bios")
+	})
+
+	// 83879 - Successful day2 configuration of BIOS settings
+	It("successfully configures BIOS settings", reportxml.ID("83879"), func() {
+		By("pulling the ProvisioningRequest for BIOS settings update")
+
+		prBuilder, err := oran.PullPR(o2imsAPIClient, tsparams.TestPRName)
+		Expect(err).ToNot(HaveOccurred(), "Failed to pull spoke 1 ProvisioningRequest")
+
+		By("updating the ProvisioningRequest to reference new ClusterTemplate with BIOS settings update")
+
+		updateTime := getStartTime()
+		newTemplateVersion := RANConfig.ClusterTemplateAffix + "-" + tsparams.TemplateBIOSSettingsUpdate
+		prBuilder.Definition.Spec.TemplateVersion = newTemplateVersion
+		prBuilder, err = prBuilder.Update()
+		Expect(err).ToNot(HaveOccurred(), "Failed to update ProvisioningRequest with new BIOS settings template")
+
+		By("waiting for ProvisioningRequest to be fulfilled after BIOS settings update")
+
+		err = prBuilder.WaitForPhaseAfter(provisioningv1alpha1.StateFulfilled, updateTime, 120*time.Minute)
+		Expect(err).ToNot(HaveOccurred(),
+			"Failed to wait for ProvisioningRequest to be fulfilled after BIOS settings update")
+
+		By("verifying BIOS settings have been updated")
+		verifyBIOSSettingsUpdate(prBuilder)
+	})
+})
+
+// getMetal3HostRef returns the BareMetalHost key from the spoke ClusterInstance node HostRef. It uses Spoke1Name to get
+// the ClusterInstance and node. The returned pointer is nil if and only if an error occurs.
+func getMetal3HostRef() (*runtimeclient.ObjectKey, error) {
+	clusterInstance, err := siteconfig.PullClusterInstance(HubAPIClient, RANConfig.Spoke1Name, RANConfig.Spoke1Name)
+	if err != nil {
+		return nil, fmt.Errorf("pull spoke 1 ClusterInstance: %w", err)
+	}
+
+	if len(clusterInstance.Definition.Spec.Nodes) == 0 {
+		return nil, fmt.Errorf("cluster instance %s has no nodes", RANConfig.Spoke1Name)
+	}
+
+	node := clusterInstance.Definition.Spec.Nodes[0]
+	if node.HostRef == nil || node.HostRef.Name == "" || node.HostRef.Namespace == "" {
+		return nil, fmt.Errorf("cluster instance %s node has no BareMetalHost hostRef", RANConfig.Spoke1Name)
+	}
+
+	return &runtimeclient.ObjectKey{Name: node.HostRef.Name, Namespace: node.HostRef.Namespace}, nil
+}
+
+// getHardwareProfileFromPR returns the HardwareProfileBuilder for the HardwareProfile referenced by the
+// ProvisioningRequest's ClusterTemplate hwMgmtDefaults.
+func getHardwareProfileFromPR(prBuilder *oran.ProvisioningRequestBuilder) *oran.HardwareProfileBuilder {
+	By("getting the ClusterTemplate for hardware profile verification")
+
+	clusterTemplateName := fmt.Sprintf("%s.%s",
+		prBuilder.Definition.Spec.TemplateName, prBuilder.Definition.Spec.TemplateVersion)
+	clusterTemplateNamespace := prBuilder.Definition.Spec.TemplateName + "-" + RANConfig.ClusterTemplateAffix
+
+	clusterTemplate, err := oran.PullClusterTemplate(HubAPIClient, clusterTemplateName, clusterTemplateNamespace)
+	Expect(err).ToNot(HaveOccurred(), "Failed to pull ClusterTemplate %s", clusterTemplateName)
+
+	nodeGroupData := clusterTemplate.Object.Spec.TemplateDefaults.HwMgmtDefaults.NodeGroupData
+	Expect(nodeGroupData).ToNot(BeEmpty(),
+		"ClusterTemplate hwMgmtDefaults must include nodeGroupData")
+
+	hwProfileName := nodeGroupData[0].HwProfile
+	Expect(hwProfileName).ToNot(BeEmpty(),
+		"ClusterTemplate hwMgmtDefaults nodeGroupData must specify hwProfile")
+
+	By(fmt.Sprintf("getting the HardwareProfile %s for verification", hwProfileName))
+
+	hwProfileBuilder, err := oran.PullHardwareProfile(HubAPIClient, hwProfileName, tsparams.O2IMSNamespace)
+	Expect(err).ToNot(HaveOccurred(), "Failed to pull HardwareProfile %s", hwProfileName)
+	Expect(hwProfileBuilder.Object).ToNot(BeNil(), "HardwareProfile object should not be nil")
+
+	return hwProfileBuilder
+}
+
+// verifyFirmwareUpdate verifies that the firmware component (bmc or bios) has been updated according to the
+// HardwareProfile specified in the ClusterTemplate referenced by the ProvisioningRequest.
+func verifyFirmwareUpdate(prBuilder *oran.ProvisioningRequestBuilder, componentType string) {
+	hwProfileBuilder := getHardwareProfileFromPR(prBuilder)
+
+	var expectedFirmware hardwaremanagementv1alpha1.Firmware
+	if componentType == "bmc" {
+		expectedFirmware = hwProfileBuilder.Object.Spec.BmcFirmware
+	} else {
+		expectedFirmware = hwProfileBuilder.Object.Spec.BiosFirmware
+	}
+
+	Expect(expectedFirmware.IsEmpty()).To(BeFalse(),
+		"No %s firmware specification in HardwareProfile", componentType)
+
+	By(fmt.Sprintf("verifying HostFirmwareComponents for %s firmware", componentType))
+
+	hostRef, err := getMetal3HostRef()
+	Expect(err).ToNot(HaveOccurred(), "Failed to get Metal3 BareMetalHost from ClusterInstance")
+
+	hfc, err := bmh.PullHFC(HubAPIClient, hostRef.Name, hostRef.Namespace)
+	Expect(err).ToNot(HaveOccurred(),
+		"Failed to pull HostFirmwareComponents for %s in namespace %s", hostRef.Name, hostRef.Namespace)
+
+	var componentFound bool
+
+	for _, component := range hfc.Object.Status.Components {
+		if component.Component == componentType {
+			componentFound = true
+
+			Expect(component.CurrentVersion).To(Equal(expectedFirmware.Version),
+				"Expected %s firmware version %s, but found %s",
+				componentType, expectedFirmware.Version, component.CurrentVersion)
+
+			break
+		}
+	}
+
+	Expect(componentFound).To(BeTrue(), "Component %s not found in HostFirmwareComponents", componentType)
+}
+
+// verifyBIOSSettingsUpdate verifies that the BIOS settings have been updated according to the HardwareProfile specified
+// in the ClusterTemplate referenced by the ProvisioningRequest.
+func verifyBIOSSettingsUpdate(prBuilder *oran.ProvisioningRequestBuilder) {
+	hwProfileBuilder := getHardwareProfileFromPR(prBuilder)
+
+	expectedBIOSSettings := hwProfileBuilder.Object.Spec.Bios.Attributes
+	Expect(expectedBIOSSettings).ToNot(BeEmpty(),
+		"HardwareProfile must include BIOS attributes")
+
+	By("verifying HostFirmwareSettings for BIOS settings")
+
+	hostRef, err := getMetal3HostRef()
+	Expect(err).ToNot(HaveOccurred(), "Failed to get Metal3 BareMetalHost from ClusterInstance")
+
+	hfs, err := bmh.PullHFS(HubAPIClient, hostRef.Name, hostRef.Namespace)
+	Expect(err).ToNot(HaveOccurred(),
+		"Failed to pull HostFirmwareSettings for %s in namespace %s", hostRef.Name, hostRef.Namespace)
+
+	for settingName, expectedValue := range expectedBIOSSettings {
+		actualValue, exists := hfs.Object.Status.Settings[settingName]
+		Expect(exists).To(BeTrue(), "BIOS setting %s not found in HostFirmwareSettings", settingName)
+
+		// To make the comparison easier, convert IntOrString to string.
+		expectedValueStr := expectedValue.String()
+		Expect(actualValue).To(Equal(expectedValueStr),
+			"Expected BIOS setting %s to be %s, but found %s",
+			settingName, expectedValueStr, actualValue)
+	}
+}

--- a/tests/cnf/ran/oran/tests/oran-post-provision.go
+++ b/tests/cnf/ran/oran/tests/oran-post-provision.go
@@ -314,8 +314,10 @@ func waitForLabels() {
 func getStartTime() time.Time {
 	startTime := time.Now()
 
-	// Truncating then adding is equivalent to rounding up the second.
-	time.Sleep(time.Until(startTime.Truncate(time.Second).Add(time.Second)))
+	// Since we cannot verify that a second starts at the same time on the cluster versus the test executor, it is
+	// most reliable to wait for two seconds to ensure that the time we count as starting is almost certainly not
+	// the same time this function returns on both machines.
+	time.Sleep(2 * time.Second)
 
 	return startTime
 }

--- a/tests/cnf/ran/oran/tests/oran-pre-provision.go
+++ b/tests/cnf/ran/oran/tests/oran-pre-provision.go
@@ -105,5 +105,65 @@ var _ = Describe("ORAN Pre-provision Tests", Label(tsparams.LabelPreProvision), 
 			Expect(err).ToNot(HaveOccurred(),
 				"Failed to wait for ClusterInstance to be created and have its templates applied")
 		})
+
+		// 83880 - Failed provisioning due to no hardware matching resource selector
+		It("fails when no hardware matches resource selector", reportxml.ID("83880"), func() {
+			By("creating a ProvisioningRequest with non-matching resource selector")
+
+			prBuilder := helper.NewProvisioningRequest(o2imsAPIClient, tsparams.TemplateNoHardwareMatch)
+			_, err := prBuilder.Create()
+			Expect(err).ToNot(HaveOccurred(), "Failed to create ProvisioningRequest with non-matching resource selector")
+
+			By("waiting for ProvisioningRequest to fail due to no matching hardware")
+
+			err = prBuilder.WaitForPhaseAfter(provisioningv1alpha1.StateFailed, time.Time{}, 5*time.Minute)
+			Expect(err).ToNot(HaveOccurred(), "Failed to wait for ProvisioningRequest to fail due to no matching hardware")
+
+			By("verifying failure reason indicates no suitable hardware found")
+
+			currentPR, err := oran.PullPR(o2imsAPIClient, tsparams.TestPRName)
+			Expect(err).ToNot(HaveOccurred(), "Failed to get ProvisioningRequest status")
+			Expect(currentPR.Definition.Status.ProvisioningStatus.ProvisioningPhase).
+				To(Equal(provisioningv1alpha1.StateFailed))
+			Expect(currentPR.Definition.Status.ProvisioningStatus.ProvisioningDetails).
+				To(ContainSubstring(tsparams.PRNoHardwareMatchDetailsSubstring),
+					"Expected provisioning details to report no matching free hardware")
+		})
+
+		// 83881 - Failed provisioning due to missing boot interface label
+		It("fails when boot interface label is missing", reportxml.ID("83881"), func() {
+			By("creating a ProvisioningRequest with missing boot interface label")
+
+			prBuilder := helper.NewProvisioningRequest(o2imsAPIClient, tsparams.TemplateMissingBootInterface)
+			_, err := prBuilder.Create()
+			Expect(err).ToNot(HaveOccurred(), "Failed to create ProvisioningRequest with missing boot interface label")
+
+			By("waiting for ProvisioningRequest to fail due to missing boot interface")
+
+			err = prBuilder.WaitForPhaseAfter(provisioningv1alpha1.StateFailed, time.Time{}, 5*time.Minute)
+			Expect(err).ToNot(HaveOccurred(), "Failed to wait for ProvisioningRequest to fail due to missing boot interface")
+
+			By("verifying failure reason indicates missing boot interface label")
+
+			currentPR, err := oran.PullPR(o2imsAPIClient, tsparams.TestPRName)
+			Expect(err).ToNot(HaveOccurred(), "Failed to get ProvisioningRequest status")
+			Expect(currentPR.Definition.Status.ProvisioningStatus.ProvisioningPhase).
+				To(Equal(provisioningv1alpha1.StateFailed))
+			Expect(currentPR.Definition.Status.ProvisioningStatus.ProvisioningDetails).
+				To(ContainSubstring(tsparams.PRMissingBootInterfaceDetailsSubstring),
+					"Expected provisioning details to report a missing boot interface MAC assignment")
+		})
+
+		// 83882 - Failed provisioning due to nonexistent hardware profile
+		It("fails when hardware profile does not exist", reportxml.ID("83882"), func() {
+			By("attempting to create a ProvisioningRequest with nonexistent hardware profile")
+
+			prBuilder := helper.NewProvisioningRequest(o2imsAPIClient, tsparams.TemplateNonexistentHWProfile)
+			_, err := prBuilder.Create()
+			Expect(err).To(HaveOccurred(),
+				"Creating a ProvisioningRequest with a nonexistent hardware profile should be rejected by the admission webhook")
+			Expect(err.Error()).To(ContainSubstring("does not exist"),
+				"Admission webhook error should indicate the hardware profile does not exist")
+		})
 	})
 })

--- a/tests/cnf/ran/oran/tests/oran-provision.go
+++ b/tests/cnf/ran/oran/tests/oran-provision.go
@@ -228,9 +228,9 @@ func saveSpoke1Secret(suffix, key, fileName string) error {
 	return os.WriteFile(fileName, value, 0644)
 }
 
-// verifySpokeProvisioning ensures that for a provisioned spoke, its NodeAllocationRequest exists, its BMC details are
-// correct, the pull-secret and extra-manifests exist, and finally that its policies are compliant, in that order.
-// Errors are accumulated for each validation and returned so that every one of the validations will run and be logged.
+// verifySpokeProvisioning ensures that for a provisioned spoke, the pull-secret and extra-manifests exist, and finally
+// that its policies are compliant, in that order. Errors are accumulated for each validation and returned so that every
+// one of the validations will run and be logged.
 func verifySpokeProvisioning() error {
 	var accumulatedErrors []error
 


### PR DESCRIPTION
Add pre-provision negative cases (no hardware match, missing boot interface, nonexistent profile), post-provision day-2 firmware/BIOS and allocated- hardware coverage, and provision verification for NodeAllocationRequest plus BMC details. Extend tsparams with hwmgr namespace, template versions v14–v20, and TestPRName2 for a second ProvisioningRequest.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added ORAN Metal3 day-two validation for hardware allocation, BMC firmware, BIOS firmware, and BIOS settings updates.
  - Added coverage for provisioning requests using secondary cluster identities.

- **Bug Fixes**
  - Added validation for provisioning failures caused by unavailable hardware, missing boot interfaces, or nonexistent hardware profiles.
  - Improved test timing to provide more reliable provisioning status verification.

- **Documentation**
  - Updated provisioning verification guidance to reflect current validation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->