### PR TITLE
tests/ocp/sriov: fix SR-IOV operator reinstallation test failures

### DIFF
--- a/tests/ocp/sriov/tests/reinstallation.go
+++ b/tests/ocp/sriov/tests/reinstallation.go
@@ -216,6 +216,28 @@ func removeSriovOperator(sriovNamespace *namespace.Builder) {
 		tsparams.DefaultTimeout)
 	Expect(err).ToNot(HaveOccurred(), "Failed to remove SR-IOV configuration")
 
+	By("Removing SR-IOV network pool configs")
+
+	// SriovNetworkPoolConfigs carry a finalizer set by the operator controller.
+	// They must be deleted while the operator is still running; otherwise the
+	// finalizer can never be removed and the namespace gets stuck in Terminating.
+	// This must happen before deleting SriovOperatorConfig so the controller is
+	// still active and can process the finalizer removal.
+	err = sriov.CleanAllPoolConfigs(APIClient, SriovOcpConfig.SriovOperatorNamespace)
+	Expect(err).ToNot(HaveOccurred(), "Failed to clean SR-IOV network pool configs")
+
+	By("Waiting for SR-IOV network pool configs to be fully removed")
+
+	Eventually(func() int {
+		poolConfigs, err := sriov.ListPoolConfigs(APIClient, SriovOcpConfig.SriovOperatorNamespace)
+		if err != nil {
+			return -1
+		}
+
+		return len(poolConfigs)
+	}, tsparams.DefaultTimeout, tsparams.RetryInterval).Should(Equal(0),
+		"SR-IOV network pool configs were not fully removed")
+
 	By("Remove SR-IOV operator config")
 
 	sriovOperatorConfig, err := sriov.PullOperatorConfig(APIClient, SriovOcpConfig.SriovOperatorNamespace)
@@ -241,14 +263,6 @@ func removeSriovOperator(sriovNamespace *namespace.Builder) {
 		return err
 	}, time.Minute, tsparams.RetryInterval).Should(HaveOccurred(),
 		"ValidatingWebhook sriov-operator-webhook-config was not removed")
-
-	By("Removing SR-IOV network pool configs")
-
-	// SriovNetworkPoolConfigs carry a finalizer set by the operator controller.
-	// They must be deleted while the operator is still running; otherwise the
-	// finalizer can never be removed and the namespace gets stuck in Terminating.
-	err = sriov.CleanAllPoolConfigs(APIClient, SriovOcpConfig.SriovOperatorNamespace)
-	Expect(err).ToNot(HaveOccurred(), "Failed to clean SR-IOV network pool configs")
 
 	By("Removing SR-IOV namespace")
 

--- a/tests/ocp/sriov/tests/reinstallation.go
+++ b/tests/ocp/sriov/tests/reinstallation.go
@@ -144,10 +144,10 @@ var _ = Describe("SRIOV Operator re-installation", Ordered, Label(tsparams.Label
 				By("Deploy SR-IOV operator")
 				installSriovOperator(sriovNamespace, sriovOperatorgroup, sriovSubscription)
 
-				Eventually(sriovoperator.IsSriovDeployed,
-					time.Minute, tsparams.RetryInterval).
-					WithArguments(APIClient, SriovOcpConfig.OcpSriovOperatorNamespace).
-					ShouldNot(HaveOccurred(), "SR-IOV operator is not installed")
+			Eventually(sriovoperator.IsSriovDeployed,
+				5*time.Minute, tsparams.RetryInterval).
+				WithArguments(APIClient, SriovOcpConfig.OcpSriovOperatorNamespace).
+				ShouldNot(HaveOccurred(), "SR-IOV operator is not installed")
 
 				By("Applying SR-IOV NetworkNodePolicy")
 
@@ -241,6 +241,14 @@ func removeSriovOperator(sriovNamespace *namespace.Builder) {
 	}, time.Minute, tsparams.RetryInterval).Should(HaveOccurred(),
 		"ValidatingWebhook sriov-operator-webhook-config was not removed")
 
+	By("Removing SR-IOV network pool configs")
+
+	// SriovNetworkPoolConfigs carry a finalizer set by the operator controller.
+	// They must be deleted while the operator is still running; otherwise the
+	// finalizer can never be removed and the namespace gets stuck in Terminating.
+	err = sriov.CleanAllPoolConfigs(APIClient, SriovOcpConfig.SriovOperatorNamespace)
+	Expect(err).ToNot(HaveOccurred(), "Failed to clean SR-IOV network pool configs")
+
 	By("Removing SR-IOV namespace")
 
 	err = sriovNamespace.DeleteAndWait(tsparams.DefaultTimeout)
@@ -275,6 +283,22 @@ func installSriovOperator(sriovNamespace *namespace.Builder,
 		sriovSubscription.Definition.Spec.Package).Create()
 	Expect(err).ToNot(HaveOccurred(),
 		fmt.Sprintf("Failed to create SR-IOV Subscription %s", sriovSubscription.Definition.Name))
+
+	By("Waiting for SR-IOV operator CSV to succeed")
+
+	// Mirror deploy_cluster.sh's create_default_soc: wait for CSV Succeeded before
+	// creating SriovOperatorConfig so the operator controller is up and can handle it.
+	Eventually(func() bool {
+		csvList, err := olm.ListClusterServiceVersion(APIClient, sriovNamespace.Definition.Name)
+		if err != nil || len(csvList) == 0 {
+			return false
+		}
+
+		succeeded, err := csvList[0].IsSuccessful()
+
+		return err == nil && succeeded
+	}, 5*time.Minute, tsparams.RetryInterval).Should(BeTrue(),
+		"SR-IOV operator CSV did not reach Succeeded phase within timeout")
 
 	By("Creating SR-IOV operator default configuration")
 

--- a/tests/ocp/sriov/tests/reinstallation.go
+++ b/tests/ocp/sriov/tests/reinstallation.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -294,9 +295,17 @@ func installSriovOperator(sriovNamespace *namespace.Builder,
 			return false
 		}
 
-		succeeded, err := csvList[0].IsSuccessful()
+		for _, csv := range csvList {
+			if !strings.Contains(csv.Definition.Name, "sriov") {
+				continue
+			}
 
-		return err == nil && succeeded
+			succeeded, err := csv.IsSuccessful()
+
+			return err == nil && succeeded
+		}
+
+		return false
 	}, 5*time.Minute, tsparams.RetryInterval).Should(BeTrue(),
 		"SR-IOV operator CSV did not reach Succeeded phase within timeout")
 

--- a/tests/ocp/sriov/tests/reinstallation.go
+++ b/tests/ocp/sriov/tests/reinstallation.go
@@ -144,10 +144,10 @@ var _ = Describe("SRIOV Operator re-installation", Ordered, Label(tsparams.Label
 				By("Deploy SR-IOV operator")
 				installSriovOperator(sriovNamespace, sriovOperatorgroup, sriovSubscription)
 
-			Eventually(sriovoperator.IsSriovDeployed,
-				5*time.Minute, tsparams.RetryInterval).
-				WithArguments(APIClient, SriovOcpConfig.OcpSriovOperatorNamespace).
-				ShouldNot(HaveOccurred(), "SR-IOV operator is not installed")
+				Eventually(sriovoperator.IsSriovDeployed,
+					5*time.Minute, tsparams.RetryInterval).
+					WithArguments(APIClient, SriovOcpConfig.OcpSriovOperatorNamespace).
+					ShouldNot(HaveOccurred(), "SR-IOV operator is not installed")
 
 				By("Applying SR-IOV NetworkNodePolicy")
 

--- a/tests/ocp/sriov/tests/reinstallation.go
+++ b/tests/ocp/sriov/tests/reinstallation.go
@@ -336,8 +336,9 @@ func installSriovOperator(sriovNamespace *namespace.Builder,
 			}
 
 			succeeded, err := csv.IsSuccessful()
-
-			return err == nil && succeeded
+			if err == nil && succeeded {
+				return true
+			}
 		}
 
 		return false

--- a/tests/ocp/sriov/tests/reinstallation.go
+++ b/tests/ocp/sriov/tests/reinstallation.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nad"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/namespace"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nodes"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/olm"
@@ -95,6 +96,13 @@ var _ = Describe("SRIOV Operator re-installation", Ordered, Label(tsparams.Label
 				tsparams.TestNamespaceName, sriovTestResourceName).WithStaticIpam().WithMacAddressSupport().WithIPAddressSupport().
 				WithLogLevel("debug").Create()
 			Expect(err).ToNot(HaveOccurred(), "Failed to create SR-IOV network")
+
+			By("Waiting for SR-IOV NetworkAttachmentDefinition to be created in test namespace")
+
+			Eventually(func() bool {
+				return nad.NewBuilder(APIClient, sriovTestResourceName, tsparams.TestNamespaceName).Exists()
+			}, tsparams.DefaultTimeout, tsparams.RetryInterval).Should(BeTrue(),
+				"SR-IOV NetworkAttachmentDefinition was not created in test namespace")
 		})
 
 		It("Operator re-installation. Verify SR-IOV operator data plane is operational before removal",
@@ -174,6 +182,13 @@ var _ = Describe("SRIOV Operator re-installation", Ordered, Label(tsparams.Label
 					tsparams.TestNamespaceName, sriovTestResourceName).WithStaticIpam().WithMacAddressSupport().WithIPAddressSupport().
 					WithLogLevel("debug").Create()
 				Expect(err).ToNot(HaveOccurred(), "Failed to create SR-IOV network")
+
+				By("Waiting for SR-IOV NetworkAttachmentDefinition to be created in test namespace")
+
+				Eventually(func() bool {
+					return nad.NewBuilder(APIClient, sriovTestResourceName, tsparams.TestNamespaceName).Exists()
+				}, tsparams.DefaultTimeout, tsparams.RetryInterval).Should(BeTrue(),
+					"SR-IOV NetworkAttachmentDefinition was not created in test namespace")
 			})
 
 		It("Operator re-installation. Validate that re-installed SR-IOV operator’s data plane is up and running",
@@ -290,12 +305,18 @@ func installSriovOperator(sriovNamespace *namespace.Builder,
 
 	By("Creating SR-IOV operator Subscription")
 
-	_, err = olm.NewSubscriptionBuilder(
+	subBuilder := olm.NewSubscriptionBuilder(
 		APIClient, sriovSubscription.Definition.Name,
 		sriovSubscription.Definition.Namespace,
 		sriovSubscription.Definition.Spec.CatalogSource,
 		sriovSubscription.Definition.Spec.CatalogSourceNamespace,
-		sriovSubscription.Definition.Spec.Package).Create()
+		sriovSubscription.Definition.Spec.Package)
+
+	if sriovSubscription.Definition.Spec.StartingCSV != "" {
+		subBuilder = subBuilder.WithStartingCSV(sriovSubscription.Definition.Spec.StartingCSV)
+	}
+
+	_, err = subBuilder.Create()
 	Expect(err).ToNot(HaveOccurred(),
 		fmt.Sprintf("Failed to create SR-IOV Subscription %s", sriovSubscription.Definition.Name))
 


### PR DESCRIPTION
## Summary

Fixes three bugs in `reinstallation.go` that caused tests 46530–46532 to fail consistently.

### Root causes

**Test 46530 — namespace stuck `Terminating`**

`removeSriovOperator()` calls `sriovNamespace.DeleteAndWait()` while a `SriovNetworkPoolConfig` (created by the lab's `enable_offload()` step) still exists with a finalizer `poolconfig.finalizers.sriovnetwork.openshift`. Once namespace deletion starts, the operator controller that would remove the finalizer is also being deleted — a deadlock that leaves the namespace stuck in `Terminating` indefinitely.

**Fix:** Add `sriov.CleanAllPoolConfigs()` _before_ `DeleteAndWait()`, while the operator is still running and can process the finalizer removal.

**Tests 46531 — cascades from 46530** — no independent fix needed.

**Test 46532 — daemonsets never start after reinstall**

`installSriovOperator()` created the `SriovOperatorConfig` immediately after the `Subscription`, before the operator CSV reached `Succeeded` and before any controller was running to act on it. As a result the daemonsets (`sriov-network-config-daemon`, `network-resources-injector`, `operator-webhook`) never started.

**Fix:** Add an `Eventually` poll for CSV `Succeeded` before creating `SriovOperatorConfig`, mirroring the `create_default_soc` step in the lab's `deploy_cluster.sh`.

**Test 46532 — `IsSriovDeployed` timeout too short**

The `Eventually(sriovoperator.IsSriovDeployed, time.Minute, ...)` check gave only 1 minute. Daemonsets take 60–90+ seconds to come up after `SriovOperatorConfig` is created.

**Fix:** Increase timeout from `time.Minute` to `5*time.Minute`.

## Test plan

- [ ] Run `--label-filter="sriovreinstall"` against `tests/ocp/sriov` on a cluster with the lab's `test-operator-catalog` CatalogSource in place
- [ ] All 6 reinstallation tests (46528–46533) should pass


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Increased SR-IOV operator deployment verification timeout to improve reliability during slower installs.
  * Added validation that waits for a network attachment to appear after creating an SR‑IOV network.
  * Ensured pool configurations are fully removed before cleanup proceeds.
  * Added a pre-install gate that waits for the operator's ClusterServiceVersion to report success before creating the default configuration.
  * Subscription creation now honors an optional starting CSV when present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->