### PR TITLE
lca ibi: add support for vlan interfaces

### DIFF
--- a/tests/lca/imagebasedinstall/mgmt/deploy/internal/networkconfig/networkconfig_types.go
+++ b/tests/lca/imagebasedinstall/mgmt/deploy/internal/networkconfig/networkconfig_types.go
@@ -8,15 +8,22 @@ type NetworkConfig struct {
 	DNSResolver DNSResolver `yaml:"dns-resolver"`
 }
 
+// VlanConfig defines the VLAN configuration for an interface.
+type VlanConfig struct {
+	ID        int    `yaml:"id"`
+	BaseIface string `yaml:"base-iface"`
+}
+
 // Interface defines an nmstate interface and its properties.
 type Interface struct {
-	Name       string   `yaml:"name"`
-	Type       string   `yaml:"type"`
-	State      string   `yaml:"state"`
-	Identifier string   `yaml:"identifier"`
-	MACAddress string   `yaml:"mac-address"`
-	IPv4       IPConfig `yaml:"ipv4"`
-	IPv6       IPConfig `yaml:"ipv6"`
+	Name       string     `yaml:"name"`
+	Type       string     `yaml:"type"`
+	State      string     `yaml:"state"`
+	Identifier string     `yaml:"identifier,omitempty"`
+	MACAddress string     `yaml:"mac-address,omitempty"`
+	VLAN       VlanConfig `yaml:"vlan,omitempty"`
+	IPv4       IPConfig   `yaml:"ipv4"`
+	IPv6       IPConfig   `yaml:"ipv6"`
 }
 
 // Routes contains the route configuration portion of the nmstate configuration.

--- a/tests/lca/imagebasedinstall/mgmt/deploy/tests/common.go
+++ b/tests/lca/imagebasedinstall/mgmt/deploy/tests/common.go
@@ -37,8 +37,6 @@ import (
 )
 
 const (
-	interfaceName = "enp1s0"
-
 	extraManifestNamespace = "extranamespace"
 	extraManifestConfigmap = "extra-configmap"
 
@@ -450,91 +448,181 @@ func createNetworkConfig(config mgmtconfig.Cluster) networkconfig.NetworkConfig 
 
 	Expect(len(config.Info.Hosts)).To(Equal(1), "error: can only support SNO deployments")
 
-	for _, info := range MGMTConfig.Cluster.Info.Hosts {
+	for _, info := range config.Info.Hosts {
 		Expect(len(info.Network.Interfaces)).To(Equal(1), "error: can only support nodes with single network interface")
 
-		for _, iface := range info.Network.Interfaces {
+		for baseIfaceName, iface := range info.Network.Interfaces {
 			var routes []networkconfig.RouteConfig
 
 			var dnsServers []string
 
-			// Initialize interface
+			var networkConfigInterfaces []networkconfig.Interface
+
 			interfaceConfig := networkconfig.Interface{
-				Name:       interfaceName,
+				Name:       baseIfaceName,
 				Type:       "ethernet",
 				State:      "up",
 				Identifier: "mac-address",
 				MACAddress: iface.MACAddress,
 			}
 
-			// Configure IPv4
-			if hasIPv4AddressFamily() {
-				nodeIPAddr, nodeIPNetwork, err := net.ParseCIDR(info.Network.Address.IPv4)
-				Expect(err).NotTo(HaveOccurred(), "error gathering IPv4 network info from provided address")
+			if info.Network.VLANID == "" {
+				// Configure IPv4 without VLAN
+				if hasIPv4AddressFamily() {
+					nodeIPAddr, nodeIPNetwork, err := net.ParseCIDR(info.Network.Address.IPv4)
+					Expect(err).NotTo(HaveOccurred(), "error gathering IPv4 network info from provided address")
 
-				cidr, _ := nodeIPNetwork.Mask.Size()
+					cidr, _ := nodeIPNetwork.Mask.Size()
 
-				interfaceConfig.IPv4 = networkconfig.IPConfig{
-					DHCP: false,
-					Address: []networkconfig.IPAddress{
-						{
-							IP:           nodeIPAddr.String(),
-							PrefixLength: strconv.Itoa(cidr),
+					interfaceConfig.IPv4 = networkconfig.IPConfig{
+						DHCP: false,
+						Address: []networkconfig.IPAddress{
+							{
+								IP:           nodeIPAddr.String(),
+								PrefixLength: strconv.Itoa(cidr),
+							},
 						},
-					},
-					Enabled: true,
+						Enabled: true,
+					}
+
+					routes = append(routes, networkconfig.RouteConfig{
+						Destination:      "0.0.0.0/0",
+						NextHopAddress:   info.Network.Gateway.IPv4,
+						NextHopInterface: baseIfaceName,
+					})
+
+					dnsServers = append(dnsServers, info.Network.DNS.IPv4)
+				} else {
+					interfaceConfig.IPv4 = networkconfig.IPConfig{
+						Enabled: false,
+					}
 				}
 
-				routes = append(routes, networkconfig.RouteConfig{
-					Destination:      "0.0.0.0/0",
-					NextHopAddress:   info.Network.Gateway.IPv4,
-					NextHopInterface: interfaceName,
-				})
+				// Configure IPv6 without VLAN
+				if hasIPv6AddressFamily() {
+					nodeIPAddr, nodeIPNetwork, err := net.ParseCIDR(info.Network.Address.IPv6)
+					Expect(err).NotTo(HaveOccurred(), "error gathering IPv6 network info from provided address")
 
-				dnsServers = append(dnsServers, info.Network.DNS.IPv4)
-			} else {
-				interfaceConfig.IPv4 = networkconfig.IPConfig{
-					Enabled: false,
-				}
-			}
+					cidr, _ := nodeIPNetwork.Mask.Size()
 
-			// Configure IPv6
-			if hasIPv6AddressFamily() {
-				nodeIPAddr, nodeIPNetwork, err := net.ParseCIDR(info.Network.Address.IPv6)
-				Expect(err).NotTo(HaveOccurred(), "error gathering IPv6 network info from provided address")
-
-				cidr, _ := nodeIPNetwork.Mask.Size()
-
-				autoconfFalse := false
-				interfaceConfig.IPv6 = networkconfig.IPConfig{
-					DHCP:     false,
-					Autoconf: &autoconfFalse,
-					Address: []networkconfig.IPAddress{
-						{
-							IP:           nodeIPAddr.String(),
-							PrefixLength: strconv.Itoa(cidr),
+					autoconfFalse := false
+					interfaceConfig.IPv6 = networkconfig.IPConfig{
+						DHCP:     false,
+						Autoconf: &autoconfFalse,
+						Address: []networkconfig.IPAddress{
+							{
+								IP:           nodeIPAddr.String(),
+								PrefixLength: strconv.Itoa(cidr),
+							},
 						},
-					},
-					Enabled: true,
+						Enabled: true,
+					}
+
+					routes = append(routes, networkconfig.RouteConfig{
+						Destination:      "::/0",
+						NextHopAddress:   info.Network.Gateway.IPv6,
+						NextHopInterface: baseIfaceName,
+					})
+
+					dnsServers = append(dnsServers, info.Network.DNS.IPv6)
+				} else {
+					interfaceConfig.IPv6 = networkconfig.IPConfig{
+						Enabled: false,
+					}
 				}
 
-				routes = append(routes, networkconfig.RouteConfig{
-					Destination:      "::/0",
-					NextHopAddress:   info.Network.Gateway.IPv6,
-					NextHopInterface: interfaceName,
-				})
-
-				dnsServers = append(dnsServers, info.Network.DNS.IPv6)
+				networkConfigInterfaces = append(networkConfigInterfaces, interfaceConfig)
 			} else {
-				interfaceConfig.IPv6 = networkconfig.IPConfig{
-					Enabled: false,
+				interfaceConfig.IPv4 = networkconfig.IPConfig{Enabled: false}
+				interfaceConfig.IPv6 = networkconfig.IPConfig{Enabled: false}
+
+				vlanID, err := strconv.ParseUint(info.Network.VLANID, 10, 16)
+				Expect(err).NotTo(HaveOccurred(), "network.vlan_id must be an unsigned integer")
+				Expect(vlanID).To(BeNumerically(">=", 1), "network.vlan_id must be between 1 and 4094")
+				Expect(vlanID).To(BeNumerically("<=", 4094), "network.vlan_id must be between 1 and 4094")
+
+				vlanIfaceName := fmt.Sprintf("%s.%s", baseIfaceName, info.Network.VLANID)
+
+				vlanIface := networkconfig.Interface{
+					Name:       vlanIfaceName,
+					Type:       "vlan",
+					State:      "up",
+					MACAddress: iface.MACAddress,
+					VLAN: networkconfig.VlanConfig{
+						ID:        int(vlanID),
+						BaseIface: baseIfaceName,
+					},
 				}
+
+				// Configure IPv4 with VLAN
+				if hasIPv4AddressFamily() {
+					nodeIPAddr, nodeIPNetwork, err := net.ParseCIDR(info.Network.Address.IPv4)
+					Expect(err).NotTo(HaveOccurred(), "error gathering IPv4 network info from provided address")
+
+					cidr, _ := nodeIPNetwork.Mask.Size()
+
+					vlanIface.IPv4 = networkconfig.IPConfig{
+						DHCP: false,
+						Address: []networkconfig.IPAddress{
+							{
+								IP:           nodeIPAddr.String(),
+								PrefixLength: strconv.Itoa(cidr),
+							},
+						},
+						Enabled: true,
+					}
+
+					routes = append(routes, networkconfig.RouteConfig{
+						Destination:      "0.0.0.0/0",
+						NextHopAddress:   info.Network.Gateway.IPv4,
+						NextHopInterface: vlanIfaceName,
+					})
+
+					dnsServers = append(dnsServers, info.Network.DNS.IPv4)
+				} else {
+					vlanIface.IPv4 = networkconfig.IPConfig{
+						Enabled: false,
+					}
+				}
+
+				// Configure IPv6 with VLAN
+				if hasIPv6AddressFamily() {
+					nodeIPAddr, nodeIPNetwork, err := net.ParseCIDR(info.Network.Address.IPv6)
+					Expect(err).NotTo(HaveOccurred(), "error gathering IPv6 network info from provided address")
+
+					cidr, _ := nodeIPNetwork.Mask.Size()
+
+					autoconfFalse := false
+					vlanIface.IPv6 = networkconfig.IPConfig{
+						DHCP:     false,
+						Autoconf: &autoconfFalse,
+						Address: []networkconfig.IPAddress{
+							{
+								IP:           nodeIPAddr.String(),
+								PrefixLength: strconv.Itoa(cidr),
+							},
+						},
+						Enabled: true,
+					}
+
+					routes = append(routes, networkconfig.RouteConfig{
+						Destination:      "::/0",
+						NextHopAddress:   info.Network.Gateway.IPv6,
+						NextHopInterface: vlanIfaceName,
+					})
+
+					dnsServers = append(dnsServers, info.Network.DNS.IPv6)
+				} else {
+					vlanIface.IPv6 = networkconfig.IPConfig{
+						Enabled: false,
+					}
+				}
+
+				networkConfigInterfaces = append(networkConfigInterfaces, interfaceConfig, vlanIface)
 			}
 
 			nodeNetworkingConfig = networkconfig.NetworkConfig{
-				Interfaces: []networkconfig.Interface{
-					interfaceConfig,
-				},
+				Interfaces: networkConfigInterfaces,
 				Routes: networkconfig.Routes{
 					Config: routes,
 				},

--- a/tests/lca/imagebasedinstall/mgmt/internal/mgmtconfig/config.go
+++ b/tests/lca/imagebasedinstall/mgmt/internal/mgmtconfig/config.go
@@ -12,6 +12,11 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+// ClusterHostNetworkInterface is one spoke host NIC entry under network.interfaces (map key = Linux iface name).
+type ClusterHostNetworkInterface struct {
+	MACAddress string `yaml:"mac_address"`
+}
+
 // Cluster contains resources information that make up the cluster to be installed.
 type Cluster struct {
 	Info struct {
@@ -24,9 +29,7 @@ type Cluster struct {
 		} `yaml:"machine_cidr"`
 		Hosts map[string]struct {
 			Network struct {
-				Interfaces map[string]struct {
-					MACAddress string `yaml:"mac_address"`
-				} `yaml:"interfaces"`
+				Interfaces map[string]ClusterHostNetworkInterface `yaml:"interfaces"`
 				BondConfig struct {
 					Interfaces string `yaml:"interfaces"`
 					Options    struct {
@@ -34,6 +37,7 @@ type Cluster struct {
 						MIIMON string `yaml:"miimon"`
 					} `yaml:"options"`
 				} `yaml:"bond_config"`
+				VLANID  string `yaml:"vlan_id"`
 				Address struct {
 					IPv4 string `yaml:"ipv4"`
 					IPv6 string `yaml:"ipv6"`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added VLAN (Virtual LAN) support for network interface configuration, enabling networks to be configured with specific VLAN IDs.
  * Network interfaces can now be set up dynamically with optional MAC addresses and identifiers.
  * Enhanced network configuration to handle both standard and VLAN-tagged interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->