### PR TITLE
system-tests: configure whereabouts reconciler in deployment tests

### DIFF
--- a/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-deployment.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-deployment.go
@@ -553,6 +553,8 @@ func CreateWhereaboutsDeployment(ctx SpecContext, config WhereaboutsDeploymentCo
 
 	By(fmt.Sprintf("Setting up deployment with %s", config.Description))
 
+	configureWhereaboutsIPReconciler()
+
 	cleanupDeployment(config.Name, RDSCoreConfig.WhereaboutNS, config.Label)
 
 	waBuilder := createDeploymentBuilder(config)


### PR DESCRIPTION
Add configureWhereaboutsIPReconciler() call to CreateWhereaboutsDeployment() function to ensure deployment tests use the accelerated 3-minute reconciler schedule instead of the default daily schedule at 4:30 AM.

This change aligns deployment test behavior with statefulset tests, which already configure the reconciler. The reconciler runs every 3 minutes (*/3 * * * *) to speed up IP address cleanup testing.


(cherry picked from commit fe63d23d17b1be5c2aa97e1ffd7d14c6eba4cfe0) (#1328)