### PR TITLE
Add MCM modprobe webhook tests (OCP-62605, OCP-62606, OCP-62607)

### DIFF
--- a/tests/hw-accel/kmm/mcm/tests/webhook-test.go
+++ b/tests/hw-accel/kmm/mcm/tests/webhook-test.go
@@ -1,10 +1,13 @@
 package tests
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/kmm"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	moduleV1Beta1 "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/kmm/v1beta1"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/kmmparams"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/mcm/internal/tsparams"
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/internal/inittools"
@@ -179,6 +182,122 @@ var _ = Describe("KMM-HUB", Ordered, Label(tsparams.LabelSuite), func() {
 				WithSelector(kmmparams.KmmHubSelector).Create()
 			Expect(mcm.Definition.Spec.SpokeNamespace).To(Equal(""))
 			Expect(err.Error()).To(ContainSubstring("admission webhook \"vmanagedclustermodule.kb.io\" denied the request"))
+		})
+	})
+
+	Context("Modprobe", Label("mcm-webhook"), func() {
+		It("should fail creating MCM with both moduleName and rawargs", reportxml.ID("62607"), func() {
+			By("Create KernelMapping")
+
+			image := fmt.Sprintf("%s/%s/%s:$KERNEL_FULL_VERSION",
+				kmmparams.LocalImageRegistry, kmmparams.KmmHubOperatorNamespace, "my-kmod")
+			kernelMapping, err := kmm.NewRegExKernelMappingBuilder("^.+$").
+				WithContainerImage(image).
+				BuildKernelMappingConfig()
+			Expect(err).ToNot(HaveOccurred(), "error creating kernel mapping")
+
+			By("Create ModuleLoaderContainer")
+
+			moduleLoader, err := kmm.NewModLoaderContainerBuilder("kmod-a").
+				WithModprobeSpec("", "", nil, nil, []string{"defined"}, nil).
+				WithKernelMapping(kernelMapping).
+				BuildModuleLoaderContainerCfg()
+			Expect(err).ToNot(HaveOccurred(), "error creating moduleloadercontainer")
+
+			By("Build Module")
+
+			moduleSpec, err := kmm.NewModuleBuilder(APIClient, "mcm-modulename-rawargs", "default").
+				WithNodeSelector(GeneralConfig.WorkerLabelMap).
+				WithModuleLoaderContainer(moduleLoader).
+				BuildModuleSpec()
+			Expect(err).ToNot(HaveOccurred(), "error building module spec")
+
+			By("Create ManagedClusterModule")
+
+			_, err = kmm.NewManagedClusterModuleBuilder(APIClient, "mcm-modulename-rawargs",
+				kmmparams.KmmHubOperatorNamespace).
+				WithModuleSpec(moduleSpec).
+				WithSpokeNamespace(kmmparams.KmmOperatorNamespace).
+				WithSelector(kmmparams.KmmHubSelector).Create()
+			Expect(err).To(HaveOccurred(), "MCM should have been rejected by webhook")
+			Expect(err.Error()).To(ContainSubstring("rawArgs cannot be set when moduleName is set"))
+		})
+
+		It("should require rawargs when moduleName is not set in MCM", reportxml.ID("62606"), func() {
+			By("Preparing module spec without moduleName and without rawArgs")
+
+			moduleSpec := moduleV1Beta1.ModuleSpec{}
+			moduleSpec.Selector = GeneralConfig.WorkerLabelMap
+			kerMap := moduleV1Beta1.KernelMapping{Regexp: "^.+$", ContainerImage: "something:latest"}
+			moduleSpec.ModuleLoader = &moduleV1Beta1.ModuleLoaderSpec{}
+			moduleSpec.ModuleLoader.Container.KernelMappings = []moduleV1Beta1.KernelMapping{kerMap}
+
+			By("Create ManagedClusterModule")
+
+			_, err := kmm.NewManagedClusterModuleBuilder(APIClient, "mcm-no-rawargs",
+				kmmparams.KmmHubOperatorNamespace).
+				WithModuleSpec(moduleSpec).
+				WithSpokeNamespace(kmmparams.KmmOperatorNamespace).
+				WithSelector(kmmparams.KmmHubSelector).Create()
+			Expect(err).To(HaveOccurred(), "MCM should have been rejected by webhook")
+			Expect(err.Error()).To(ContainSubstring("load and unload rawArgs must be set when moduleName is unset"))
+		})
+
+		It("should fail to update an existing MCM with something that is wrong", reportxml.ID("62605"), func() {
+			By("Create valid KernelMapping")
+
+			image := fmt.Sprintf("%s/%s/%s:$KERNEL_FULL_VERSION",
+				kmmparams.LocalImageRegistry, kmmparams.KmmHubOperatorNamespace, "my-kmod")
+			kernelMapping, err := kmm.NewRegExKernelMappingBuilder("^.+$").
+				WithContainerImage(image).
+				BuildKernelMappingConfig()
+			Expect(err).ToNot(HaveOccurred(), "error creating kernel mapping")
+
+			By("Create valid ModuleLoaderContainer")
+
+			moduleLoader, err := kmm.NewModLoaderContainerBuilder("kmod-valid").
+				WithKernelMapping(kernelMapping).
+				BuildModuleLoaderContainerCfg()
+			Expect(err).ToNot(HaveOccurred(), "error creating moduleloadercontainer")
+
+			By("Build valid Module spec")
+
+			moduleSpec, err := kmm.NewModuleBuilder(APIClient, "mcm-update-invalid", "default").
+				WithNodeSelector(GeneralConfig.WorkerLabelMap).
+				WithModuleLoaderContainer(moduleLoader).
+				BuildModuleSpec()
+			Expect(err).ToNot(HaveOccurred(), "error building module spec")
+
+			By("Create valid ManagedClusterModule")
+
+			mcm, err := kmm.NewManagedClusterModuleBuilder(APIClient, "mcm-update-invalid",
+				kmmparams.KmmHubOperatorNamespace).
+				WithModuleSpec(moduleSpec).
+				WithSpokeNamespace(kmmparams.KmmOperatorNamespace).
+				WithSelector(kmmparams.KmmHubSelector).Create()
+			Expect(err).ToNot(HaveOccurred(), "error creating valid MCM")
+
+			DeferCleanup(func() { _, _ = mcm.Delete() })
+
+			By("Create invalid KernelMapping (missing containerImage)")
+
+			invalidKernelMapping, err := kmm.NewRegExKernelMappingBuilder("^.+$").BuildKernelMappingConfig()
+			Expect(err).ToNot(HaveOccurred(), "error creating invalid kernel mapping")
+
+			By("Create invalid ModuleLoaderContainer")
+
+			invalidModuleLoader, err := kmm.NewModLoaderContainerBuilder("webhook").
+				WithKernelMapping(invalidKernelMapping).
+				BuildModuleLoaderContainerCfg()
+			Expect(err).ToNot(HaveOccurred(), "error creating invalid moduleloadercontainer")
+
+			By("Update MCM with invalid spec")
+
+			mcm.Definition.Spec.ModuleSpec.ModuleLoader.Container = *invalidModuleLoader
+			_, err = mcm.Update()
+			Expect(err).To(HaveOccurred(), "MCM update should have been rejected by webhook")
+			Expect(err.Error()).To(ContainSubstring("missing spec.moduleLoader.container.kernelMappings"))
+			Expect(err.Error()).To(ContainSubstring(".containerImage"))
 		})
 	})
 })


### PR DESCRIPTION
## Summary
- Add three MCM webhook validation tests mirroring existing Module-side tests:
  - **OCP-62607**: moduleName vs rawArgs mutual exclusion (mirrors OCP-62600)
  - **OCP-62606**: rawArgs required when moduleName is unset (mirrors OCP-62599)
  - **OCP-62605**: update valid MCM with invalid spec (mirrors OCP-62598)
- All tests validated on OCP 4.18.35 cluster with KMM-Hub 2.6.0 — 7/7 webhook tests pass (4 existing + 3 new)

## Test plan
- [x] Ran `mcm-webhook` label filter on cluster — all 7 tests pass
- [x] Verified no leftover MCM resources after test run
- [x] No eco-goinfra changes needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened webhook validation test coverage for module configurations, including validation of parameter constraints, container specifications, and module update operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->