### PR TITLE
system-tests: Use bootid to check reboot

### DIFF
--- a/tests/system-tests/rdscore/internal/rdscorecommon/hard-reboot.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/hard-reboot.go
@@ -183,7 +183,7 @@ func WaitAllDeploymentsAreAvailable(ctx SpecContext) {
 
 // VerifySoftReboot performs graceful reboot of a cluster with cordoning and draining of individual nodes.
 //
-//nolint:gocognit,funlen
+//nolint:funlen
 func VerifySoftReboot(ctx SpecContext) {
 	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("\t*** Starting Soft Reboot Test Suite ***")
 
@@ -202,6 +202,11 @@ func VerifySoftReboot(ctx SpecContext) {
 
 	for _, _node := range allNodes {
 		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Processing node %q", _node.Definition.Name)
+
+		bootIDBefore := _node.Object.Status.NodeInfo.BootID
+
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Node %q boot ID before reboot: %s",
+			_node.Definition.Name, bootIDBefore)
 
 		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Cordoning node %q", _node.Definition.Name)
 		err := _node.Cordon()
@@ -253,30 +258,7 @@ func VerifySoftReboot(ctx SpecContext) {
 		Expect(err).ToNot(HaveOccurred(),
 			fmt.Sprintf("Failed to reboot node %s", _node.Definition.Name))
 
-		By(fmt.Sprintf("Checking node %q got into NotReady", _node.Definition.Name))
-
-		Eventually(func(ctx SpecContext) bool {
-			currentNode, err := nodes.Pull(APIClient, _node.Definition.Name)
-			if err != nil {
-				klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to pull node: %v", err)
-
-				return false
-			}
-
-			for _, condition := range currentNode.Object.Status.Conditions {
-				if condition.Type == rdscoreparams.ConditionTypeReadyString {
-					if condition.Status != rdscoreparams.ConstantTrueString {
-						klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Node %q is notReady", currentNode.Definition.Name)
-						klog.V(rdscoreparams.RDSCoreLogLevel).Infof("  Reason: %s", condition.Reason)
-
-						return true
-					}
-				}
-			}
-
-			return false
-		}).WithTimeout(25*time.Minute).WithPolling(15*time.Second).WithContext(ctx).Should(BeTrue(),
-			"Node hasn't reached notReady state")
+		waitForBootIDChange(ctx, _node.Definition.Name, bootIDBefore, 25*time.Minute)
 
 		By(fmt.Sprintf("Checking node %q got into Ready", _node.Definition.Name))
 

--- a/tests/system-tests/rdscore/internal/rdscorecommon/hard-reboot.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/hard-reboot.go
@@ -203,11 +203,6 @@ func VerifySoftReboot(ctx SpecContext) {
 	for _, _node := range allNodes {
 		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Processing node %q", _node.Definition.Name)
 
-		bootIDBefore := _node.Object.Status.NodeInfo.BootID
-
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Node %q boot ID before reboot: %s",
-			_node.Definition.Name, bootIDBefore)
-
 		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Cordoning node %q", _node.Definition.Name)
 		err := _node.Cordon()
 		Expect(err).ToNot(HaveOccurred(),
@@ -221,6 +216,11 @@ func VerifySoftReboot(ctx SpecContext) {
 		err = _node.Drain()
 		Expect(err).ToNot(HaveOccurred(),
 			fmt.Sprintf("Failed to drain %q due to %v", _node.Definition.Name, err))
+
+		bootIDBefore := fetchNodeBootIDWithRetry(ctx, _node.Definition.Name)
+
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Node %q boot ID before reboot: %s",
+			_node.Definition.Name, bootIDBefore)
 
 		klog.V(rdscoreparams.RDSCoreLogLevel).Info(
 			fmt.Sprintf("NodesCredentialsMap:\n\t%#v", RDSCoreConfig.NodesCredentialsMap))

--- a/tests/system-tests/rdscore/internal/rdscorecommon/nmi-redfish.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/nmi-redfish.go
@@ -61,6 +61,13 @@ func triggerNMIRedfish(ctx SpecContext, nodeLabel string) {
 		By(fmt.Sprintf("Cleaning up /var/crash directory on node %q", node.Definition.Name))
 		cleanupVarCrashDirectory(ctx, node.Definition.Name)
 
+		By(fmt.Sprintf("Recording boot ID for node %q before NMI", node.Definition.Name))
+
+		bootIDBefore := node.Object.Status.NodeInfo.BootID
+
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Node %q boot ID before NMI: %s",
+			node.Definition.Name, bootIDBefore)
+
 		By(fmt.Sprintf("Trigger NMI via RedFish on node %q", node.Definition.Name))
 		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Triggering NMI via RedFish on %q",
 			node.Definition.Name)
@@ -103,7 +110,7 @@ func triggerNMIRedfish(ctx SpecContext, nodeLabel string) {
 		Expect(err).ToNot(HaveOccurred(),
 			fmt.Sprintf("Failed to trigger NMI on node %s", node.Definition.Name))
 
-		waitForNodeToBeNotReady(ctx, node.Definition.Name, 15*time.Second, 25*time.Minute)
+		waitForBootIDChange(ctx, node.Definition.Name, bootIDBefore, 25*time.Minute)
 
 		By(fmt.Sprintf("Waiting for node %q to return to Ready state", node.Definition.Name))
 

--- a/tests/system-tests/rdscore/internal/rdscorecommon/nmi-redfish.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/nmi-redfish.go
@@ -61,7 +61,7 @@ func triggerNMIRedfish(ctx SpecContext, nodeLabel string) {
 		By(fmt.Sprintf("Cleaning up /var/crash directory on node %q", node.Definition.Name))
 		cleanupVarCrashDirectory(ctx, node.Definition.Name)
 
-		bootIDBefore := node.Object.Status.NodeInfo.BootID
+		bootIDBefore := fetchNodeBootIDWithRetry(ctx, node.Definition.Name)
 
 		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Node %q boot ID before NMI: %s",
 			node.Definition.Name, bootIDBefore)

--- a/tests/system-tests/rdscore/internal/rdscorecommon/nmi-redfish.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/nmi-redfish.go
@@ -61,8 +61,6 @@ func triggerNMIRedfish(ctx SpecContext, nodeLabel string) {
 		By(fmt.Sprintf("Cleaning up /var/crash directory on node %q", node.Definition.Name))
 		cleanupVarCrashDirectory(ctx, node.Definition.Name)
 
-		By(fmt.Sprintf("Recording boot ID for node %q before NMI", node.Definition.Name))
-
 		bootIDBefore := node.Object.Status.NodeInfo.BootID
 
 		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Node %q boot ID before NMI: %s",


### PR DESCRIPTION
Updated hard-reboot.go and nmi-redfish.go to address the issue that master nodes reboot fast enough that the NotReady state is not observed. The issue is often observed on Dell R660 servers. The tests now check for a boot ID change as proof of reboot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced reboot and reset verification in system tests to use bootID-based detection for more reliable node state validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->