### PR TITLE
system-tests: update ipvlan-validation.go to support IPv6 single stack

### DIFF
--- a/tests/system-tests/rdscore/internal/rdscorecommon/ipvlan-validation.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/ipvlan-validation.go
@@ -158,33 +158,53 @@ func VerifyIPVlanOnDifferentNodes() {
 // VerifyIPVLANConnectivityBetweenDifferentNodes verifies connectivity between workloads,
 // using IPVLAN interfaces and running on different nodes.
 func VerifyIPVLANConnectivityBetweenDifferentNodes() {
-	verifySRIOVConnectivity(
-		RDSCoreConfig.IPVlanNSOne,
-		RDSCoreConfig.IPVlanNSOne,
-		ipvlanDeploy10Label,
-		ipvlanDeploy11Label,
-		RDSCoreConfig.IPVlanDeploy1TargetAddress)
+	Expect(RDSCoreConfig.IPVlanDeploy1TargetAddress != "" ||
+		RDSCoreConfig.IPVlanDeploy1TargetAddressIPv6 != "").To(BeTrue(),
+		"At least one target address (IPv4 or IPv6) must be configured for IPVlan Deploy1")
 
-	verifySRIOVConnectivity(
-		RDSCoreConfig.IPVlanNSOne,
-		RDSCoreConfig.IPVlanNSOne,
-		ipvlanDeploy11Label,
-		ipvlanDeploy10Label,
-		RDSCoreConfig.IPVlanDeploy2TargetAddress)
+	addressesList := []string{RDSCoreConfig.IPVlanDeploy1TargetAddress,
+		RDSCoreConfig.IPVlanDeploy1TargetAddressIPv6}
 
-	verifySRIOVConnectivity(
-		RDSCoreConfig.IPVlanNSOne,
-		RDSCoreConfig.IPVlanNSOne,
-		ipvlanDeploy10Label,
-		ipvlanDeploy11Label,
-		RDSCoreConfig.IPVlanDeploy1TargetAddressIPv6)
+	for _, targetAddress := range addressesList {
+		if targetAddress == "" {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Skipping empty address %q", targetAddress)
 
-	verifySRIOVConnectivity(
-		RDSCoreConfig.IPVlanNSOne,
-		RDSCoreConfig.IPVlanNSOne,
-		ipvlanDeploy11Label,
-		ipvlanDeploy10Label,
-		RDSCoreConfig.IPVlanDeploy2TargetAddressIPv6)
+			continue
+		}
+
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Access workload via %q", targetAddress)
+
+		verifySRIOVConnectivity(
+			RDSCoreConfig.IPVlanNSOne,
+			RDSCoreConfig.IPVlanNSOne,
+			ipvlanDeploy10Label,
+			ipvlanDeploy11Label,
+			targetAddress)
+	}
+
+	Expect(RDSCoreConfig.IPVlanDeploy2TargetAddress != "" ||
+		RDSCoreConfig.IPVlanDeploy2TargetAddressIPv6 != "").To(BeTrue(),
+		"At least one target address (IPv4 or IPv6) must be configured for IPVlan Deploy2")
+
+	addressesList = []string{RDSCoreConfig.IPVlanDeploy2TargetAddress,
+		RDSCoreConfig.IPVlanDeploy2TargetAddressIPv6}
+
+	for _, targetAddress := range addressesList {
+		if targetAddress == "" {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Skipping empty address %q", targetAddress)
+
+			continue
+		}
+
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Access workload via %q", targetAddress)
+
+		verifySRIOVConnectivity(
+			RDSCoreConfig.IPVlanNSOne,
+			RDSCoreConfig.IPVlanNSOne,
+			ipvlanDeploy11Label,
+			ipvlanDeploy10Label,
+			targetAddress)
+	}
 }
 
 // VerifyIPVlanOnSameNode verifies connectivity between freshly deployed workloads that use
@@ -291,35 +311,56 @@ func VerifyIPVlanOnSameNode() {
 
 // VerifyIPVLANConnectivityOnSameNode verifies connectivity between workloads that use IPVLAN net.
 func VerifyIPVLANConnectivityOnSameNode() {
-	verifySRIOVConnectivity(
-		RDSCoreConfig.IPVlanNSOne,
-		RDSCoreConfig.IPVlanNSOne,
-		ipvlanDeploy20Label,
-		ipvlanDeploy21Label,
-		RDSCoreConfig.IPVlanDeploy3TargetAddress)
+	Expect(RDSCoreConfig.IPVlanDeploy3TargetAddress != "" ||
+		RDSCoreConfig.IPVlanDeploy3TargetAddressIPv6 != "").To(BeTrue(),
+		"At least one target address (IPv4 or IPv6) must be configured for IPVlan Deploy3")
 
-	verifySRIOVConnectivity(
-		RDSCoreConfig.IPVlanNSOne,
-		RDSCoreConfig.IPVlanNSOne,
-		ipvlanDeploy21Label,
-		ipvlanDeploy20Label,
-		RDSCoreConfig.IPVlanDeploy4TargetAddress)
+	addressesList := []string{RDSCoreConfig.IPVlanDeploy3TargetAddress,
+		RDSCoreConfig.IPVlanDeploy3TargetAddressIPv6}
 
-	verifySRIOVConnectivity(
-		RDSCoreConfig.IPVlanNSOne,
-		RDSCoreConfig.IPVlanNSOne,
-		ipvlanDeploy20Label,
-		ipvlanDeploy21Label,
-		RDSCoreConfig.IPVlanDeploy3TargetAddressIPv6)
+	for _, targetAddress := range addressesList {
+		if targetAddress == "" {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Skipping empty address %q", targetAddress)
 
-	verifySRIOVConnectivity(
-		RDSCoreConfig.IPVlanNSOne,
-		RDSCoreConfig.IPVlanNSOne,
-		ipvlanDeploy21Label,
-		ipvlanDeploy20Label,
-		RDSCoreConfig.IPVlanDeploy4TargetAddressIPv6)
+			continue
+		}
+
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Access workload via %q", targetAddress)
+
+		verifySRIOVConnectivity(
+			RDSCoreConfig.IPVlanNSOne,
+			RDSCoreConfig.IPVlanNSOne,
+			ipvlanDeploy20Label,
+			ipvlanDeploy21Label,
+			targetAddress)
+	}
+
+	Expect(RDSCoreConfig.IPVlanDeploy4TargetAddress != "" ||
+		RDSCoreConfig.IPVlanDeploy4TargetAddressIPv6 != "").To(BeTrue(),
+		"At least one target address (IPv4 or IPv6) must be configured for IPVlan Deploy4")
+
+	addressesList = []string{RDSCoreConfig.IPVlanDeploy4TargetAddress,
+		RDSCoreConfig.IPVlanDeploy4TargetAddressIPv6}
+
+	for _, targetAddress := range addressesList {
+		if targetAddress == "" {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Skipping empty address %q", targetAddress)
+
+			continue
+		}
+
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Access workload via %q", targetAddress)
+
+		verifySRIOVConnectivity(
+			RDSCoreConfig.IPVlanNSOne,
+			RDSCoreConfig.IPVlanNSOne,
+			ipvlanDeploy21Label,
+			ipvlanDeploy20Label,
+			targetAddress)
+	}
 }
 
+// defineIPVlanDeployment creates an IPVLAN deployment builder with the specified configuration.
 func defineIPVlanDeployment(dName, nsName, dLabels, netDefName, volName string,
 	dContainer *corev1.Container,
 	nodeSelector map[string]string) *deployment.Builder {

--- a/tests/system-tests/rdscore/internal/rdscorecommon/ipvlan-validation.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/ipvlan-validation.go
@@ -155,56 +155,40 @@ func VerifyIPVlanOnDifferentNodes() {
 	VerifyIPVLANConnectivityBetweenDifferentNodes()
 }
 
+// verifyIPVLANTargets runs verifySRIOVConnectivity between srcPodLabel and dstPodLabel in namespace
+// for each non-empty address.
+func verifyIPVLANTargets(namespace, srcPodLabel, dstPodLabel, ipv4Target, ipv6Target, expectMsg string) {
+	Expect(ipv4Target != "" || ipv6Target != "").To(BeTrue(), expectMsg)
+
+	for _, targetAddress := range []string{ipv4Target, ipv6Target} {
+		if targetAddress == "" {
+			continue
+		}
+
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Access workload via %q", targetAddress)
+
+		verifySRIOVConnectivity(namespace, namespace, srcPodLabel, dstPodLabel, targetAddress)
+	}
+}
+
 // VerifyIPVLANConnectivityBetweenDifferentNodes verifies connectivity between workloads,
 // using IPVLAN interfaces and running on different nodes.
 func VerifyIPVLANConnectivityBetweenDifferentNodes() {
-	Expect(RDSCoreConfig.IPVlanDeploy1TargetAddress != "" ||
-		RDSCoreConfig.IPVlanDeploy1TargetAddressIPv6 != "").To(BeTrue(),
+	verifyIPVLANTargets(
+		RDSCoreConfig.IPVlanNSOne,
+		ipvlanDeploy10Label,
+		ipvlanDeploy11Label,
+		RDSCoreConfig.IPVlanDeploy1TargetAddress,
+		RDSCoreConfig.IPVlanDeploy1TargetAddressIPv6,
 		"At least one target address (IPv4 or IPv6) must be configured for IPVlan Deploy1")
 
-	addressesList := []string{RDSCoreConfig.IPVlanDeploy1TargetAddress,
-		RDSCoreConfig.IPVlanDeploy1TargetAddressIPv6}
-
-	for _, targetAddress := range addressesList {
-		if targetAddress == "" {
-			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Skipping empty address %q", targetAddress)
-
-			continue
-		}
-
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Access workload via %q", targetAddress)
-
-		verifySRIOVConnectivity(
-			RDSCoreConfig.IPVlanNSOne,
-			RDSCoreConfig.IPVlanNSOne,
-			ipvlanDeploy10Label,
-			ipvlanDeploy11Label,
-			targetAddress)
-	}
-
-	Expect(RDSCoreConfig.IPVlanDeploy2TargetAddress != "" ||
-		RDSCoreConfig.IPVlanDeploy2TargetAddressIPv6 != "").To(BeTrue(),
+	verifyIPVLANTargets(
+		RDSCoreConfig.IPVlanNSOne,
+		ipvlanDeploy11Label,
+		ipvlanDeploy10Label,
+		RDSCoreConfig.IPVlanDeploy2TargetAddress,
+		RDSCoreConfig.IPVlanDeploy2TargetAddressIPv6,
 		"At least one target address (IPv4 or IPv6) must be configured for IPVlan Deploy2")
-
-	addressesList = []string{RDSCoreConfig.IPVlanDeploy2TargetAddress,
-		RDSCoreConfig.IPVlanDeploy2TargetAddressIPv6}
-
-	for _, targetAddress := range addressesList {
-		if targetAddress == "" {
-			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Skipping empty address %q", targetAddress)
-
-			continue
-		}
-
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Access workload via %q", targetAddress)
-
-		verifySRIOVConnectivity(
-			RDSCoreConfig.IPVlanNSOne,
-			RDSCoreConfig.IPVlanNSOne,
-			ipvlanDeploy11Label,
-			ipvlanDeploy10Label,
-			targetAddress)
-	}
 }
 
 // VerifyIPVlanOnSameNode verifies connectivity between freshly deployed workloads that use
@@ -311,53 +295,21 @@ func VerifyIPVlanOnSameNode() {
 
 // VerifyIPVLANConnectivityOnSameNode verifies connectivity between workloads that use IPVLAN net.
 func VerifyIPVLANConnectivityOnSameNode() {
-	Expect(RDSCoreConfig.IPVlanDeploy3TargetAddress != "" ||
-		RDSCoreConfig.IPVlanDeploy3TargetAddressIPv6 != "").To(BeTrue(),
+	verifyIPVLANTargets(
+		RDSCoreConfig.IPVlanNSOne,
+		ipvlanDeploy20Label,
+		ipvlanDeploy21Label,
+		RDSCoreConfig.IPVlanDeploy3TargetAddress,
+		RDSCoreConfig.IPVlanDeploy3TargetAddressIPv6,
 		"At least one target address (IPv4 or IPv6) must be configured for IPVlan Deploy3")
 
-	addressesList := []string{RDSCoreConfig.IPVlanDeploy3TargetAddress,
-		RDSCoreConfig.IPVlanDeploy3TargetAddressIPv6}
-
-	for _, targetAddress := range addressesList {
-		if targetAddress == "" {
-			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Skipping empty address %q", targetAddress)
-
-			continue
-		}
-
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Access workload via %q", targetAddress)
-
-		verifySRIOVConnectivity(
-			RDSCoreConfig.IPVlanNSOne,
-			RDSCoreConfig.IPVlanNSOne,
-			ipvlanDeploy20Label,
-			ipvlanDeploy21Label,
-			targetAddress)
-	}
-
-	Expect(RDSCoreConfig.IPVlanDeploy4TargetAddress != "" ||
-		RDSCoreConfig.IPVlanDeploy4TargetAddressIPv6 != "").To(BeTrue(),
+	verifyIPVLANTargets(
+		RDSCoreConfig.IPVlanNSOne,
+		ipvlanDeploy21Label,
+		ipvlanDeploy20Label,
+		RDSCoreConfig.IPVlanDeploy4TargetAddress,
+		RDSCoreConfig.IPVlanDeploy4TargetAddressIPv6,
 		"At least one target address (IPv4 or IPv6) must be configured for IPVlan Deploy4")
-
-	addressesList = []string{RDSCoreConfig.IPVlanDeploy4TargetAddress,
-		RDSCoreConfig.IPVlanDeploy4TargetAddressIPv6}
-
-	for _, targetAddress := range addressesList {
-		if targetAddress == "" {
-			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Skipping empty address %q", targetAddress)
-
-			continue
-		}
-
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Access workload via %q", targetAddress)
-
-		verifySRIOVConnectivity(
-			RDSCoreConfig.IPVlanNSOne,
-			RDSCoreConfig.IPVlanNSOne,
-			ipvlanDeploy21Label,
-			ipvlanDeploy20Label,
-			targetAddress)
-	}
 }
 
 // defineIPVlanDeployment creates an IPVLAN deployment builder with the specified configuration.

--- a/tests/system-tests/rdscore/internal/rdscorecommon/ipvlan-validation.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/ipvlan-validation.go
@@ -155,9 +155,10 @@ func VerifyIPVlanOnDifferentNodes() {
 	VerifyIPVLANConnectivityBetweenDifferentNodes()
 }
 
-// verifyIPVLANTargets runs verifySRIOVConnectivity between srcPodLabel and dstPodLabel in namespace
-// for each non-empty address.
-func verifyIPVLANTargets(namespace, srcPodLabel, dstPodLabel, ipv4Target, ipv6Target, expectMsg string) {
+// verifyIPVLANTargets runs verifySRIOVConnectivity between srcPodLabel and dstPodLabel for
+// each non-empty target address.
+func verifyIPVLANTargets(srcNamespace, dstNamespace, srcPodLabel, dstPodLabel,
+	ipv4Target, ipv6Target, expectMsg string) {
 	Expect(ipv4Target != "" || ipv6Target != "").To(BeTrue(), expectMsg)
 
 	for _, targetAddress := range []string{ipv4Target, ipv6Target} {
@@ -167,7 +168,7 @@ func verifyIPVLANTargets(namespace, srcPodLabel, dstPodLabel, ipv4Target, ipv6Ta
 
 		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Access workload via %q", targetAddress)
 
-		verifySRIOVConnectivity(namespace, namespace, srcPodLabel, dstPodLabel, targetAddress)
+		verifySRIOVConnectivity(srcNamespace, dstNamespace, srcPodLabel, dstPodLabel, targetAddress)
 	}
 }
 
@@ -176,6 +177,7 @@ func verifyIPVLANTargets(namespace, srcPodLabel, dstPodLabel, ipv4Target, ipv6Ta
 func VerifyIPVLANConnectivityBetweenDifferentNodes() {
 	verifyIPVLANTargets(
 		RDSCoreConfig.IPVlanNSOne,
+		RDSCoreConfig.IPVlanNSOne,
 		ipvlanDeploy10Label,
 		ipvlanDeploy11Label,
 		RDSCoreConfig.IPVlanDeploy1TargetAddress,
@@ -183,6 +185,7 @@ func VerifyIPVLANConnectivityBetweenDifferentNodes() {
 		"At least one target address (IPv4 or IPv6) must be configured for IPVlan Deploy1")
 
 	verifyIPVLANTargets(
+		RDSCoreConfig.IPVlanNSOne,
 		RDSCoreConfig.IPVlanNSOne,
 		ipvlanDeploy11Label,
 		ipvlanDeploy10Label,
@@ -297,6 +300,7 @@ func VerifyIPVlanOnSameNode() {
 func VerifyIPVLANConnectivityOnSameNode() {
 	verifyIPVLANTargets(
 		RDSCoreConfig.IPVlanNSOne,
+		RDSCoreConfig.IPVlanNSOne,
 		ipvlanDeploy20Label,
 		ipvlanDeploy21Label,
 		RDSCoreConfig.IPVlanDeploy3TargetAddress,
@@ -304,6 +308,7 @@ func VerifyIPVLANConnectivityOnSameNode() {
 		"At least one target address (IPv4 or IPv6) must be configured for IPVlan Deploy3")
 
 	verifyIPVLANTargets(
+		RDSCoreConfig.IPVlanNSOne,
 		RDSCoreConfig.IPVlanNSOne,
 		ipvlanDeploy21Label,
 		ipvlanDeploy20Label,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved IPVLAN connectivity tests to iterate over configured IPv4/IPv6 targets instead of hard-coded permutations.
  * Enforces that at least one target address is configured and skips empty targets.
  * Preserves source/destination directionality across checks.
  * Adds clearer per-deploy expectation messages and enhanced logging for diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->