### PR TITLE
system-tests: Update macvlan-validation.go to support IPv6 single stack

### DIFF
--- a/tests/system-tests/rdscore/internal/rdscorecommon/macvlan-validation.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/macvlan-validation.go
@@ -200,9 +200,10 @@ func VerifyMacVlanOnDifferentNodes() {
 	VerifyMACVLANConnectivityBetweenDifferentNodes()
 }
 
-// verifyMACVLANTargets runs verifySRIOVConnectivity between srcPodLabel and dstPodLabel in namespace
-// for each non-empty address.
-func verifyMACVLANTargets(namespace, srcPodLabel, dstPodLabel, ipv4Target, ipv6Target, expectMsg string) {
+// verifyMACVLANTargets runs verifySRIOVConnectivity between srcPodLabel and dstPodLabel for
+// each non-empty target address.
+func verifyMACVLANTargets(srcNamespace, dstNamespace, srcPodLabel, dstPodLabel,
+	ipv4Target, ipv6Target, expectMsg string) {
 	Expect(ipv4Target != "" || ipv6Target != "").To(BeTrue(), expectMsg)
 
 	for _, targetAddress := range []string{ipv4Target, ipv6Target} {
@@ -212,7 +213,7 @@ func verifyMACVLANTargets(namespace, srcPodLabel, dstPodLabel, ipv4Target, ipv6T
 
 		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Access workload via %q", targetAddress)
 
-		verifySRIOVConnectivity(namespace, namespace, srcPodLabel, dstPodLabel, targetAddress)
+		verifySRIOVConnectivity(srcNamespace, dstNamespace, srcPodLabel, dstPodLabel, targetAddress)
 	}
 }
 
@@ -221,6 +222,7 @@ func verifyMACVLANTargets(namespace, srcPodLabel, dstPodLabel, ipv4Target, ipv6T
 func VerifyMACVLANConnectivityBetweenDifferentNodes() {
 	verifyMACVLANTargets(
 		RDSCoreConfig.MCVlanNSOne,
+		RDSCoreConfig.MCVlanNSOne,
 		macvlanDeploy10Label,
 		macvlanDeploy11Label,
 		RDSCoreConfig.MCVlanDeploy1TargetAddress,
@@ -228,6 +230,7 @@ func VerifyMACVLANConnectivityBetweenDifferentNodes() {
 		"At least one target address (IPv4 or IPv6) must be configured for MCVlan Deploy1")
 
 	verifyMACVLANTargets(
+		RDSCoreConfig.MCVlanNSOne,
 		RDSCoreConfig.MCVlanNSOne,
 		macvlanDeploy11Label,
 		macvlanDeploy10Label,
@@ -342,6 +345,7 @@ func VerifyMacVlanOnSameNode() {
 func VerifyMACVLANConnectivityOnSameNode() {
 	verifyMACVLANTargets(
 		RDSCoreConfig.MCVlanNSOne,
+		RDSCoreConfig.MCVlanNSOne,
 		macvlanDeploy20Label,
 		macvlanDeploy21Label,
 		RDSCoreConfig.MCVlanDeploy3TargetAddress,
@@ -349,6 +353,7 @@ func VerifyMACVLANConnectivityOnSameNode() {
 		"At least one target address (IPv4 or IPv6) must be configured for MCVlan Deploy3")
 
 	verifyMACVLANTargets(
+		RDSCoreConfig.MCVlanNSOne,
 		RDSCoreConfig.MCVlanNSOne,
 		macvlanDeploy21Label,
 		macvlanDeploy20Label,

--- a/tests/system-tests/rdscore/internal/rdscorecommon/macvlan-validation.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/macvlan-validation.go
@@ -200,36 +200,40 @@ func VerifyMacVlanOnDifferentNodes() {
 	VerifyMACVLANConnectivityBetweenDifferentNodes()
 }
 
+// verifyMACVLANTargets runs verifySRIOVConnectivity between srcPodLabel and dstPodLabel in namespace
+// for each non-empty address.
+func verifyMACVLANTargets(namespace, srcPodLabel, dstPodLabel, ipv4Target, ipv6Target, expectMsg string) {
+	Expect(ipv4Target != "" || ipv6Target != "").To(BeTrue(), expectMsg)
+
+	for _, targetAddress := range []string{ipv4Target, ipv6Target} {
+		if targetAddress == "" {
+			continue
+		}
+
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Access workload via %q", targetAddress)
+
+		verifySRIOVConnectivity(namespace, namespace, srcPodLabel, dstPodLabel, targetAddress)
+	}
+}
+
 // VerifyMACVLANConnectivityBetweenDifferentNodes verifies connectivity between workloads,
 // using MACVLAN interfaces and running on different nodes.
 func VerifyMACVLANConnectivityBetweenDifferentNodes() {
-	verifySRIOVConnectivity(
-		RDSCoreConfig.MCVlanNSOne,
+	verifyMACVLANTargets(
 		RDSCoreConfig.MCVlanNSOne,
 		macvlanDeploy10Label,
 		macvlanDeploy11Label,
-		RDSCoreConfig.MCVlanDeploy1TargetAddress)
+		RDSCoreConfig.MCVlanDeploy1TargetAddress,
+		RDSCoreConfig.MCVlanDeploy1TargetAddressIPv6,
+		"At least one target address (IPv4 or IPv6) must be configured for MCVlan Deploy1")
 
-	verifySRIOVConnectivity(
-		RDSCoreConfig.MCVlanNSOne,
-		RDSCoreConfig.MCVlanNSOne,
-		macvlanDeploy11Label,
-		macvlanDeploy10Label,
-		RDSCoreConfig.MCVlanDeploy2TargetAddress)
-
-	verifySRIOVConnectivity(
-		RDSCoreConfig.MCVlanNSOne,
-		RDSCoreConfig.MCVlanNSOne,
-		macvlanDeploy10Label,
-		macvlanDeploy11Label,
-		RDSCoreConfig.MCVlanDeploy1TargetAddressIPv6)
-
-	verifySRIOVConnectivity(
-		RDSCoreConfig.MCVlanNSOne,
+	verifyMACVLANTargets(
 		RDSCoreConfig.MCVlanNSOne,
 		macvlanDeploy11Label,
 		macvlanDeploy10Label,
-		RDSCoreConfig.MCVlanDeploy2TargetAddressIPv6)
+		RDSCoreConfig.MCVlanDeploy2TargetAddress,
+		RDSCoreConfig.MCVlanDeploy2TargetAddressIPv6,
+		"At least one target address (IPv4 or IPv6) must be configured for MCVlan Deploy2")
 }
 
 // VerifyMacVlanOnSameNode verifies connectivity between freshly deployed workloads that use
@@ -336,33 +340,21 @@ func VerifyMacVlanOnSameNode() {
 
 // VerifyMACVLANConnectivityOnSameNode verifies connectivity between workloads that use MACVLAN net.
 func VerifyMACVLANConnectivityOnSameNode() {
-	verifySRIOVConnectivity(
-		RDSCoreConfig.MCVlanNSOne,
+	verifyMACVLANTargets(
 		RDSCoreConfig.MCVlanNSOne,
 		macvlanDeploy20Label,
 		macvlanDeploy21Label,
-		RDSCoreConfig.MCVlanDeploy3TargetAddress)
+		RDSCoreConfig.MCVlanDeploy3TargetAddress,
+		RDSCoreConfig.MCVlanDeploy3TargetAddressIPv6,
+		"At least one target address (IPv4 or IPv6) must be configured for MCVlan Deploy3")
 
-	verifySRIOVConnectivity(
-		RDSCoreConfig.MCVlanNSOne,
-		RDSCoreConfig.MCVlanNSOne,
-		macvlanDeploy21Label,
-		macvlanDeploy20Label,
-		RDSCoreConfig.MCVlanDeploy4TargetAddress)
-
-	verifySRIOVConnectivity(
-		RDSCoreConfig.MCVlanNSOne,
-		RDSCoreConfig.MCVlanNSOne,
-		macvlanDeploy20Label,
-		macvlanDeploy21Label,
-		RDSCoreConfig.MCVlanDeploy3TargetAddressIPv6)
-
-	verifySRIOVConnectivity(
-		RDSCoreConfig.MCVlanNSOne,
+	verifyMACVLANTargets(
 		RDSCoreConfig.MCVlanNSOne,
 		macvlanDeploy21Label,
 		macvlanDeploy20Label,
-		RDSCoreConfig.MCVlanDeploy4TargetAddressIPv6)
+		RDSCoreConfig.MCVlanDeploy4TargetAddress,
+		RDSCoreConfig.MCVlanDeploy4TargetAddressIPv6,
+		"At least one target address (IPv4 or IPv6) must be configured for MCVlan Deploy4")
 }
 
 func defineMacVlanDeployment(dName, nsName, dLabels, netDefName, volName string,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Consolidated MACVLAN connectivity test validation logic to improve maintainability and reduce code duplication in test infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->