### PR TITLE
system-tests: update whereabouts-statefulset for IPv6 single stack

### DIFF
--- a/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-statefulset.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-statefulset.go
@@ -21,14 +21,13 @@ import (
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/bmc"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/configmap"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nad"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nodes"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/service"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/statefulset"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 )
@@ -228,21 +227,14 @@ func createStatefulsetAndWaitReplicasReady(stName, namespace string, stBuilder *
 // determineIPFamilyPolicy fetches the NAD and inspects the IPAM range fields to determine
 // whether to use RequireDualStack, or SingleStack with IPv4 or IPv6.
 func determineIPFamilyPolicy(nadName, namespace string) ([]corev1.IPFamily, corev1.IPFamilyPolicy) {
-	nadObj, err := APIClient.Resource(
-		schema.GroupVersionResource{
-			Group:    "k8s.cni.cncf.io",
-			Version:  "v1",
-			Resource: "network-attachment-definitions",
-		}).Namespace(namespace).Get(context.TODO(), nadName, metav1.GetOptions{})
+	nadBuilder, err := nad.Pull(APIClient, nadName, namespace)
 
 	Expect(err).ToNot(HaveOccurred(),
 		fmt.Sprintf("Failed to get NAD %q in %q namespace", nadName, namespace))
+	Expect(nadBuilder.Definition.Spec.Config).ToNot(BeEmpty(),
+		fmt.Sprintf("NAD %q has empty spec.config field", nadName))
 
-	config, found, err := unstructured.NestedString(nadObj.Object, "spec", "config")
-	Expect(err).ToNot(HaveOccurred(),
-		fmt.Sprintf("Failed to read config from NAD %q", nadName))
-	Expect(found).To(BeTrue(),
-		fmt.Sprintf("NAD %q has no spec.config field", nadName))
+	config := nadBuilder.Definition.Spec.Config
 
 	ranges := extractIPAMRanges(config)
 	Expect(len(ranges)).ToNot(Equal(0),
@@ -261,9 +253,10 @@ func determineIPFamilyPolicy(nadName, namespace string) ([]corev1.IPFamily, core
 	case hasIPv4:
 		return []corev1.IPFamily{corev1.IPv4Protocol}, corev1.IPFamilyPolicySingleStack
 	default:
-		Fail(fmt.Sprintf("NAD %q IPAM ranges contain no detectable IPv4 or IPv6 CIDR: %v", nadName, ranges))
+		msg := fmt.Sprintf("NAD %q IPAM ranges contain no detectable IPv4 or IPv6 CIDR: %v", nadName, ranges)
+		Fail(msg)
 
-		return nil, ""
+		return nil, "" // Unreachable in Ginkgo: Fail panics.
 	}
 }
 
@@ -391,6 +384,12 @@ func setupHeadlessService(svcName, namespace, svcLabel, svcPort, nadName string)
 	svcOne = defineHeadlessService(svcName, namespace, svcLabelsMap, svcPortCr)
 
 	ipFamilies, ipFamilyPolicy := determineIPFamilyPolicy(nadName, namespace)
+	Expect(ipFamilies).ToNot(BeNil(),
+		"determineIPFamilyPolicy returned nil ipFamilies for NAD %q in %q namespace",
+		nadName, namespace)
+	Expect(string(ipFamilyPolicy)).ToNot(BeEmpty(),
+		"determineIPFamilyPolicy returned empty ipFamilyPolicy for NAD %q in %q namespace",
+		nadName, namespace)
 
 	By(fmt.Sprintf("Setting ipFamilyPolicy to %q for NAD %q", ipFamilyPolicy, nadName))
 

--- a/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-statefulset.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-statefulset.go
@@ -284,9 +284,28 @@ func extractIPAMRanges(nadName, config string) []string {
 }
 
 // extractRangesFromIPAM extracts range strings from an object's ipam field.
+//
+//nolint:funlen
 func extractRangesFromIPAM(obj map[string]interface{}) []string {
-	ipam, ok := obj["ipam"].(map[string]interface{})
+	ipamRaw, hasIPAM := obj["ipam"]
+	if !hasIPAM {
+		keys := make([]string, 0, len(obj))
+		for k := range obj {
+			keys = append(keys, k)
+		}
+
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+			"extractRangesFromIPAM: ipam field missing, skipping (object keys: %v)", keys)
+
+		return nil
+	}
+
+	ipam, ok := ipamRaw.(map[string]interface{})
 	if !ok {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+			"extractRangesFromIPAM: ipam has unexpected type %T (want map[string]interface{}), value=%v",
+			ipamRaw, ipamRaw)
+
 		return nil
 	}
 
@@ -296,11 +315,17 @@ func extractRangesFromIPAM(obj map[string]interface{}) []string {
 	appendRangeFromStartEnd := func(rangeObj map[string]interface{}) (string, bool) {
 		rangeStart, hasStart := rangeObj["range_start"].(string)
 		if !hasStart {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+				"appendRangeFromStartEnd: range_start field missing or not a string, skipping")
+
 			return "", false
 		}
 
 		rangeStart = strings.TrimSpace(rangeStart)
 		if rangeStart == "" {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+				"appendRangeFromStartEnd: range_start is empty after trimming, skipping")
+
 			return "", false
 		}
 
@@ -308,26 +333,42 @@ func extractRangesFromIPAM(obj map[string]interface{}) []string {
 		rangeEnd = strings.TrimSpace(rangeEnd)
 
 		if hasEnd && rangeEnd != "" {
-			return fmt.Sprintf("%s-%s", rangeStart, rangeEnd), true
+			result := fmt.Sprintf("%s-%s", rangeStart, rangeEnd)
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+				"appendRangeFromStartEnd: built range from start/end: %q", result)
+
+			return result, true
 		}
+
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+			"appendRangeFromStartEnd: no valid range_end found, returning start only: %q", rangeStart)
 
 		return rangeStart, true
 	}
 
 	if rangeStr, ok := ipam["range"].(string); ok {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+			"extractRangesFromIPAM: found top-level range field: %q", rangeStr)
 		ranges = append(ranges, rangeStr)
 	} else if rangeFromStartEnd, found := appendRangeFromStartEnd(ipam); found {
 		ranges = append(ranges, rangeFromStartEnd)
 	}
 
 	if subnet, ok := ipam["subnet"].(string); ok {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+			"extractRangesFromIPAM: found subnet field: %q", subnet)
 		ranges = append(ranges, subnet)
 	}
 
 	if ipRanges, ok := ipam["ipRanges"].([]interface{}); ok {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+			"extractRangesFromIPAM: found ipRanges array with %d entries", len(ipRanges))
+
 		for _, entry := range ipRanges {
 			if rangeMap, ok := entry.(map[string]interface{}); ok {
 				if rangeStr, ok := rangeMap["range"].(string); ok {
+					klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+						"extractRangesFromIPAM: ipRanges entry range field: %q", rangeStr)
 					ranges = append(ranges, rangeStr)
 				} else if rangeFromStartEnd, found := appendRangeFromStartEnd(rangeMap); found {
 					ranges = append(ranges, rangeFromStartEnd)
@@ -336,23 +377,35 @@ func extractRangesFromIPAM(obj map[string]interface{}) []string {
 		}
 	}
 
+	klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+		"extractRangesFromIPAM: returning %d range(s): %v", len(ranges), ranges)
+
 	return ranges
 }
 
 // detectIPFamiliesFromRanges inspects a list of CIDR range strings and returns
 // whether IPv4 and/or IPv6 ranges are present.
 func detectIPFamiliesFromRanges(ranges []string) (hasIPv4, hasIPv6 bool) {
-	markFamily := func(ip net.IP) {
-		if len(ip) == 0 {
+	markFamily := func(ipAddr net.IP) {
+		if len(ipAddr) == 0 {
 			return
 		}
 
-		if ip.To4() != nil {
+		if ipAddr.To4() != nil {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+				"detectIPFamiliesFromRanges: detected IPv4 address: %s", ipAddr)
+
 			hasIPv4 = true
 		} else {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+				"detectIPFamiliesFromRanges: detected IPv6 address: %s", ipAddr)
+
 			hasIPv6 = true
 		}
 	}
+
+	klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+		"detectIPFamiliesFromRanges: inspecting %d range(s): %v", len(ranges), ranges)
 
 	for _, rangeStr := range ranges {
 		rangeValue := strings.TrimSpace(rangeStr)
@@ -369,9 +422,13 @@ func detectIPFamiliesFromRanges(ranges []string) (hasIPv4, hasIPv6 bool) {
 		ipCandidate := rangeValue
 		if parts := strings.SplitN(rangeValue, "-", 2); len(parts) == 2 {
 			ipCandidate = strings.TrimSpace(parts[0])
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+				"detectIPFamiliesFromRanges: %q is not a CIDR, extracted start IP %q from start-end range", rangeValue, ipCandidate)
 		}
 
 		if parsedFallbackIP := net.ParseIP(ipCandidate); parsedFallbackIP != nil {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+				"detectIPFamiliesFromRanges: parsed %q as plain IP: %s", ipCandidate, parsedFallbackIP)
 			markFamily(parsedFallbackIP)
 
 			continue
@@ -379,6 +436,9 @@ func detectIPFamiliesFromRanges(ranges []string) (hasIPv4, hasIPv6 bool) {
 
 		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Skipping invalid IPAM range %q: %v", rangeStr, err)
 	}
+
+	klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+		"detectIPFamiliesFromRanges: result — hasIPv4=%v, hasIPv6=%v", hasIPv4, hasIPv6)
 
 	return hasIPv4, hasIPv6
 }

--- a/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-statefulset.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-statefulset.go
@@ -294,8 +294,8 @@ func extractRangesFromIPAM(obj map[string]interface{}) []string {
 
 	var ranges []string
 
-	if r, ok := ipam["range"].(string); ok {
-		ranges = append(ranges, r)
+	if rangeStr, ok := ipam["range"].(string); ok {
+		ranges = append(ranges, rangeStr)
 	}
 
 	if subnet, ok := ipam["subnet"].(string); ok {
@@ -305,8 +305,8 @@ func extractRangesFromIPAM(obj map[string]interface{}) []string {
 	if ipRanges, ok := ipam["ipRanges"].([]interface{}); ok {
 		for _, entry := range ipRanges {
 			if rangeMap, ok := entry.(map[string]interface{}); ok {
-				if r, ok := rangeMap["range"].(string); ok {
-					ranges = append(ranges, r)
+				if rangeStr, ok := rangeMap["range"].(string); ok {
+					ranges = append(ranges, rangeStr)
 				}
 			}
 		}
@@ -330,9 +330,7 @@ func detectIPFamiliesFromRanges(ranges []string) (hasIPv4, hasIPv6 bool) {
 
 		if parsedIP.To4() != nil {
 			hasIPv4 = true
-		}
-
-		if parsedIP.To4() == nil && parsedIP.To16() != nil {
+		} else {
 			hasIPv6 = true
 		}
 	}

--- a/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-statefulset.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-statefulset.go
@@ -237,7 +237,7 @@ func determineIPFamilyPolicy(nadName, namespace string) ([]corev1.IPFamily, core
 	config := nadBuilder.Definition.Spec.Config
 
 	ranges := extractIPAMRanges(config)
-	Expect(len(ranges)).ToNot(Equal(0),
+	Expect(ranges).ToNot(BeEmpty(),
 		fmt.Sprintf("NAD %q has no IPAM range entries in spec.config", nadName))
 
 	hasIPv4, hasIPv6 := detectIPFamiliesFromRanges(ranges)
@@ -260,9 +260,8 @@ func determineIPFamilyPolicy(nadName, namespace string) ([]corev1.IPFamily, core
 	}
 }
 
-// extractIPAMRanges parses the NAD spec.config JSON and returns all IPAM range strings.
-// It supports both top-level ipam config and plugins[*].ipam config,
-// with both ipam.range (single) and ipam.ipRanges[*].range (multiple).
+// extractIPAMRanges parses NAD spec.config and returns IPAM ranges
+// from ipam.range, ipam.subnet, and ipam.ipRanges[*].range.
 func extractIPAMRanges(config string) []string {
 	var parsed map[string]interface{}
 	if err := json.Unmarshal([]byte(config), &parsed); err != nil {
@@ -299,6 +298,10 @@ func extractRangesFromIPAM(obj map[string]interface{}) []string {
 		ranges = append(ranges, r)
 	}
 
+	if subnet, ok := ipam["subnet"].(string); ok {
+		ranges = append(ranges, subnet)
+	}
+
 	if ipRanges, ok := ipam["ipRanges"].([]interface{}); ok {
 		for _, entry := range ipRanges {
 			if rangeMap, ok := entry.(map[string]interface{}); ok {
@@ -317,9 +320,6 @@ func extractRangesFromIPAM(obj map[string]interface{}) []string {
 func detectIPFamiliesFromRanges(ranges []string) (hasIPv4, hasIPv6 bool) {
 	for _, rangeStr := range ranges {
 		cidr := strings.TrimSpace(rangeStr)
-		if dashIndex := strings.LastIndex(cidr, "-"); dashIndex >= 0 {
-			cidr = strings.TrimSpace(cidr[dashIndex+1:])
-		}
 
 		parsedIP, _, err := net.ParseCIDR(cidr)
 		if err != nil {
@@ -384,12 +384,6 @@ func setupHeadlessService(svcName, namespace, svcLabel, svcPort, nadName string)
 	svcOne = defineHeadlessService(svcName, namespace, svcLabelsMap, svcPortCr)
 
 	ipFamilies, ipFamilyPolicy := determineIPFamilyPolicy(nadName, namespace)
-	Expect(ipFamilies).ToNot(BeNil(),
-		"determineIPFamilyPolicy returned nil ipFamilies for NAD %q in %q namespace",
-		nadName, namespace)
-	Expect(string(ipFamilyPolicy)).ToNot(BeEmpty(),
-		"determineIPFamilyPolicy returned empty ipFamilyPolicy for NAD %q in %q namespace",
-		nadName, namespace)
 
 	By(fmt.Sprintf("Setting ipFamilyPolicy to %q for NAD %q", ipFamilyPolicy, nadName))
 

--- a/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-statefulset.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-statefulset.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"regexp"
+	"net"
 	"strconv"
 	"strings"
 	"time"
@@ -322,15 +322,24 @@ func extractRangesFromIPAM(obj map[string]interface{}) []string {
 // detectIPFamiliesFromRanges inspects a list of CIDR range strings and returns
 // whether IPv4 and/or IPv6 ranges are present.
 func detectIPFamiliesFromRanges(ranges []string) (hasIPv4, hasIPv6 bool) {
-	ipv4Re := regexp.MustCompile(`\d+\.\d+\.\d+\.\d+/\d+`)
-	ipv6Re := regexp.MustCompile(`([0-9a-fA-F]{0,4}:){2,}[0-9a-fA-F]{0,4}/\d+`)
-
 	for _, r := range ranges {
-		if ipv4Re.MatchString(r) {
+		cidr := strings.TrimSpace(r)
+		if dashIndex := strings.LastIndex(cidr, "-"); dashIndex >= 0 {
+			cidr = strings.TrimSpace(cidr[dashIndex+1:])
+		}
+
+		ip, _, err := net.ParseCIDR(cidr)
+		if err != nil {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Skipping invalid IPAM range %q: %v", r, err)
+
+			continue
+		}
+
+		if ip.To4() != nil {
 			hasIPv4 = true
 		}
 
-		if ipv6Re.MatchString(r) {
+		if ip.To4() == nil && ip.To16() != nil {
 			hasIPv6 = true
 		}
 	}

--- a/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-statefulset.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-statefulset.go
@@ -230,15 +230,15 @@ func determineIPFamilyPolicy(nadName, namespace string) ([]corev1.IPFamily, core
 	nadBuilder, err := nad.Pull(APIClient, nadName, namespace)
 
 	Expect(err).ToNot(HaveOccurred(),
-		fmt.Sprintf("Failed to get NAD %q in %q namespace", nadName, namespace))
+		"Failed to get NAD %q in %q namespace", nadName, namespace)
 	Expect(nadBuilder.Definition.Spec.Config).ToNot(BeEmpty(),
-		fmt.Sprintf("NAD %q has empty spec.config field", nadName))
+		"NAD %q has empty spec.config field", nadName)
 
 	config := nadBuilder.Definition.Spec.Config
 
 	ranges := extractIPAMRanges(config)
 	Expect(ranges).ToNot(BeEmpty(),
-		fmt.Sprintf("NAD %q has no IPAM range entries in spec.config", nadName))
+		"NAD %q has no IPAM range entries in spec.config", nadName)
 
 	hasIPv4, hasIPv6 := detectIPFamiliesFromRanges(ranges)
 
@@ -253,15 +253,14 @@ func determineIPFamilyPolicy(nadName, namespace string) ([]corev1.IPFamily, core
 	case hasIPv4:
 		return []corev1.IPFamily{corev1.IPv4Protocol}, corev1.IPFamilyPolicySingleStack
 	default:
-		msg := fmt.Sprintf("NAD %q IPAM ranges contain no detectable IPv4 or IPv6 CIDR: %v", nadName, ranges)
-		Fail(msg)
+		Fail(fmt.Sprintf("NAD %q IPAM ranges contain no detectable IPv4 or IPv6 CIDR: %v", nadName, ranges))
 
 		return nil, "" // Unreachable in Ginkgo: Fail panics.
 	}
 }
 
-// extractIPAMRanges parses NAD spec.config and returns IPAM ranges
-// from ipam.range, ipam.subnet, and ipam.ipRanges[*].range.
+// extractIPAMRanges returns IPAM range strings from NAD spec.config
+// (from top-level ipam and plugins[*].ipam: range, subnet, ipRanges, range_start/range_end if no range).
 func extractIPAMRanges(config string) []string {
 	var parsed map[string]interface{}
 	if err := json.Unmarshal([]byte(config), &parsed); err != nil {
@@ -294,8 +293,32 @@ func extractRangesFromIPAM(obj map[string]interface{}) []string {
 
 	var ranges []string
 
+	// Convert optional range_start/range_end into a single range string.
+	appendRangeFromStartEnd := func(rangeObj map[string]interface{}) (string, bool) {
+		rangeStart, hasStart := rangeObj["range_start"].(string)
+		if !hasStart {
+			return "", false
+		}
+
+		rangeStart = strings.TrimSpace(rangeStart)
+		if rangeStart == "" {
+			return "", false
+		}
+
+		rangeEnd, hasEnd := rangeObj["range_end"].(string)
+		rangeEnd = strings.TrimSpace(rangeEnd)
+
+		if hasEnd && rangeEnd != "" {
+			return fmt.Sprintf("%s-%s", rangeStart, rangeEnd), true
+		}
+
+		return rangeStart, true
+	}
+
 	if rangeStr, ok := ipam["range"].(string); ok {
 		ranges = append(ranges, rangeStr)
+	} else if rangeFromStartEnd, found := appendRangeFromStartEnd(ipam); found {
+		ranges = append(ranges, rangeFromStartEnd)
 	}
 
 	if subnet, ok := ipam["subnet"].(string); ok {
@@ -307,6 +330,8 @@ func extractRangesFromIPAM(obj map[string]interface{}) []string {
 			if rangeMap, ok := entry.(map[string]interface{}); ok {
 				if rangeStr, ok := rangeMap["range"].(string); ok {
 					ranges = append(ranges, rangeStr)
+				} else if rangeFromStartEnd, found := appendRangeFromStartEnd(rangeMap); found {
+					ranges = append(ranges, rangeFromStartEnd)
 				}
 			}
 		}
@@ -318,21 +343,42 @@ func extractRangesFromIPAM(obj map[string]interface{}) []string {
 // detectIPFamiliesFromRanges inspects a list of CIDR range strings and returns
 // whether IPv4 and/or IPv6 ranges are present.
 func detectIPFamiliesFromRanges(ranges []string) (hasIPv4, hasIPv6 bool) {
-	for _, rangeStr := range ranges {
-		cidr := strings.TrimSpace(rangeStr)
-
-		parsedIP, _, err := net.ParseCIDR(cidr)
-		if err != nil {
-			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Skipping invalid IPAM range %q: %v", rangeStr, err)
-
-			continue
+	markFamily := func(ip net.IP) {
+		if len(ip) == 0 {
+			return
 		}
 
-		if parsedIP.To4() != nil {
+		if ip.To4() != nil {
 			hasIPv4 = true
 		} else {
 			hasIPv6 = true
 		}
+	}
+
+	for _, rangeStr := range ranges {
+		rangeValue := strings.TrimSpace(rangeStr)
+
+		parsedIP, _, err := net.ParseCIDR(rangeValue)
+		if err == nil {
+			markFamily(parsedIP)
+
+			continue
+		}
+
+		// Fallback for Whereabouts range_start/range_end values emitted as "start-end"
+		// and for single IP values without a CIDR prefix.
+		ipCandidate := rangeValue
+		if parts := strings.SplitN(rangeValue, "-", 2); len(parts) == 2 {
+			ipCandidate = strings.TrimSpace(parts[0])
+		}
+
+		if parsedFallbackIP := net.ParseIP(ipCandidate); parsedFallbackIP != nil {
+			markFamily(parsedFallbackIP)
+
+			continue
+		}
+
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Skipping invalid IPAM range %q: %v", rangeStr, err)
 	}
 
 	return hasIPv4, hasIPv6

--- a/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-statefulset.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-statefulset.go
@@ -236,7 +236,7 @@ func determineIPFamilyPolicy(nadName, namespace string) ([]corev1.IPFamily, core
 
 	config := nadBuilder.Definition.Spec.Config
 
-	ranges := extractIPAMRanges(config)
+	ranges := extractIPAMRanges(nadName, config)
 	Expect(ranges).ToNot(BeEmpty(),
 		"NAD %q has no IPAM range entries in spec.config", nadName)
 
@@ -261,13 +261,12 @@ func determineIPFamilyPolicy(nadName, namespace string) ([]corev1.IPFamily, core
 
 // extractIPAMRanges returns IPAM range strings from NAD spec.config
 // (from top-level ipam and plugins[*].ipam: range, subnet, ipRanges, range_start/range_end if no range).
-func extractIPAMRanges(config string) []string {
+func extractIPAMRanges(nadName, config string) []string {
 	var parsed map[string]interface{}
-	if err := json.Unmarshal([]byte(config), &parsed); err != nil {
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to parse NAD config JSON: %v", err)
 
-		return nil
-	}
+	err := json.Unmarshal([]byte(config), &parsed)
+	Expect(err).ToNot(HaveOccurred(),
+		"Failed to parse NAD %q spec.config JSON", nadName)
 
 	var ranges []string
 

--- a/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-statefulset.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-statefulset.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -26,6 +27,8 @@ import (
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/statefulset"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 )
@@ -67,8 +70,8 @@ const (
 	WhereaboutsReconcilerKey = "reconciler_cron_expression"
 	// WhereaboutsReconcilerNamespace is the namespace for the whereabouts reconciler.
 	WhereaboutsReconcilerNamespace = "openshift-multus"
-	// WhereaboutsReconcilcerCMName is the name of the whereabouts reconciler configmap.
-	WhereaboutsReconcilcerCMName = "whereabouts-config"
+	// WhereaboutsReconcilerCMName is the name of the whereabouts reconciler configmap.
+	WhereaboutsReconcilerCMName = "whereabouts-config"
 
 	myHeadlessSvcOne            = "rds-st-one-headless-1"
 	myStatefulsetOne            = "rds-st-one"
@@ -143,6 +146,7 @@ var (
 	}
 )
 
+// cleanupStatefulset removes a statefulset and waits for its pods to be deleted.
 func cleanupStatefulset(stName, namespace, stLabel string) {
 	By(fmt.Sprintf("Checking that statefulset %q doesn't exist in %q namespace",
 		stName, namespace))
@@ -167,7 +171,7 @@ func cleanupStatefulset(stName, namespace, stLabel string) {
 			stName, namespace))
 
 		Eventually(func() bool {
-			pods, err := pod.List(APIClient, RDSCoreConfig.WhereaboutNS, metav1.ListOptions{
+			pods, err := pod.List(APIClient, namespace, metav1.ListOptions{
 				LabelSelector: stLabel,
 			})
 			if err != nil {
@@ -183,6 +187,7 @@ func cleanupStatefulset(stName, namespace, stLabel string) {
 	}
 }
 
+// createStatefulsetAndWaitReplicasReady creates a statefulset and waits for all replicas to become ready.
 func createStatefulsetAndWaitReplicasReady(stName, namespace string, stBuilder *statefulset.Builder) {
 	By(fmt.Sprintf("Creating statefulset %q in %q namespace", stName, namespace))
 
@@ -220,7 +225,121 @@ func createStatefulsetAndWaitReplicasReady(stName, namespace string, stBuilder *
 		"Statefulset %q in %q namespace is not ready", stName, namespace)
 }
 
-func setupHeadlessService(svcName, namespace, svcLabel, svcPort string) {
+// determineIPFamilyPolicy fetches the NAD and inspects the IPAM range fields to determine
+// whether to use RequireDualStack, or SingleStack with IPv4 or IPv6.
+func determineIPFamilyPolicy(nadName, namespace string) ([]corev1.IPFamily, corev1.IPFamilyPolicy) {
+	nadObj, err := APIClient.Resource(
+		schema.GroupVersionResource{
+			Group:    "k8s.cni.cncf.io",
+			Version:  "v1",
+			Resource: "network-attachment-definitions",
+		}).Namespace(namespace).Get(context.TODO(), nadName, metav1.GetOptions{})
+
+	Expect(err).ToNot(HaveOccurred(),
+		fmt.Sprintf("Failed to get NAD %q in %q namespace", nadName, namespace))
+
+	config, found, err := unstructured.NestedString(nadObj.Object, "spec", "config")
+	Expect(err).ToNot(HaveOccurred(),
+		fmt.Sprintf("Failed to read config from NAD %q", nadName))
+	Expect(found).To(BeTrue(),
+		fmt.Sprintf("NAD %q has no spec.config field", nadName))
+
+	ranges := extractIPAMRanges(config)
+	Expect(len(ranges)).ToNot(Equal(0),
+		fmt.Sprintf("NAD %q has no IPAM range entries in spec.config", nadName))
+
+	hasIPv4, hasIPv6 := detectIPFamiliesFromRanges(ranges)
+
+	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("NAD %q IP family detection: hasIPv4=%v, hasIPv6=%v (ranges: %v)",
+		nadName, hasIPv4, hasIPv6, ranges)
+
+	switch {
+	case hasIPv4 && hasIPv6:
+		return []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}, corev1.IPFamilyPolicyRequireDualStack
+	case hasIPv6:
+		return []corev1.IPFamily{corev1.IPv6Protocol}, corev1.IPFamilyPolicySingleStack
+	case hasIPv4:
+		return []corev1.IPFamily{corev1.IPv4Protocol}, corev1.IPFamilyPolicySingleStack
+	default:
+		Fail(fmt.Sprintf("NAD %q IPAM ranges contain no detectable IPv4 or IPv6 CIDR: %v", nadName, ranges))
+
+		return nil, ""
+	}
+}
+
+// extractIPAMRanges parses the NAD spec.config JSON and returns all IPAM range strings.
+// It supports both top-level ipam config and plugins[*].ipam config,
+// with both ipam.range (single) and ipam.ipRanges[*].range (multiple).
+func extractIPAMRanges(config string) []string {
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(config), &parsed); err != nil {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to parse NAD config JSON: %v", err)
+
+		return nil
+	}
+
+	var ranges []string
+
+	ranges = append(ranges, extractRangesFromIPAM(parsed)...)
+
+	if plugins, ok := parsed["plugins"].([]interface{}); ok {
+		for _, p := range plugins {
+			if plugin, ok := p.(map[string]interface{}); ok {
+				ranges = append(ranges, extractRangesFromIPAM(plugin)...)
+			}
+		}
+	}
+
+	return ranges
+}
+
+// extractRangesFromIPAM extracts range strings from an object's ipam field.
+func extractRangesFromIPAM(obj map[string]interface{}) []string {
+	ipam, ok := obj["ipam"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	var ranges []string
+
+	if r, ok := ipam["range"].(string); ok {
+		ranges = append(ranges, r)
+	}
+
+	if ipRanges, ok := ipam["ipRanges"].([]interface{}); ok {
+		for _, entry := range ipRanges {
+			if rangeMap, ok := entry.(map[string]interface{}); ok {
+				if r, ok := rangeMap["range"].(string); ok {
+					ranges = append(ranges, r)
+				}
+			}
+		}
+	}
+
+	return ranges
+}
+
+// detectIPFamiliesFromRanges inspects a list of CIDR range strings and returns
+// whether IPv4 and/or IPv6 ranges are present.
+func detectIPFamiliesFromRanges(ranges []string) (hasIPv4, hasIPv6 bool) {
+	ipv4Re := regexp.MustCompile(`\d+\.\d+\.\d+\.\d+/\d+`)
+	ipv6Re := regexp.MustCompile(`([0-9a-fA-F]{0,4}:){2,}[0-9a-fA-F]{0,4}/\d+`)
+
+	for _, r := range ranges {
+		if ipv4Re.MatchString(r) {
+			hasIPv4 = true
+		}
+
+		if ipv6Re.MatchString(r) {
+			hasIPv6 = true
+		}
+	}
+
+	return hasIPv4, hasIPv6
+}
+
+// setupHeadlessService creates a headless service with ipFamilyPolicy determined from the NAD configuration.
+func setupHeadlessService(svcName, namespace, svcLabel, svcPort, nadName string) {
 	By(fmt.Sprintf("Checking that service %q doesn't exist in %q namespace",
 		svcName, namespace))
 
@@ -262,12 +381,14 @@ func setupHeadlessService(svcName, namespace, svcLabel, svcPort string) {
 
 	svcOne = defineHeadlessService(svcName, namespace, svcLabelsMap, svcPortCr)
 
-	By("Setting ipFamilyPolicy to 'RequireDualStack'")
+	ipFamilies, ipFamilyPolicy := determineIPFamilyPolicy(nadName, namespace)
 
-	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Setting ipFamilyPolicy to 'RequireDualStack'")
+	By(fmt.Sprintf("Setting ipFamilyPolicy to %q for NAD %q", ipFamilyPolicy, nadName))
 
-	svcOne = svcOne.WithIPFamily([]corev1.IPFamily{"IPv4", "IPv6"},
-		corev1.IPFamilyPolicyRequireDualStack)
+	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("NAD %q: ipFamilies=%v, ipFamilyPolicy=%s",
+		nadName, ipFamilies, ipFamilyPolicy)
+
+	svcOne = svcOne.WithIPFamily(ipFamilies, ipFamilyPolicy)
 
 	By(fmt.Sprintf("Creating headless service %q in %q namespace",
 		svcName, namespace))
@@ -287,6 +408,7 @@ func setupHeadlessService(svcName, namespace, svcLabel, svcPort string) {
 		"Failed to create headless service %q in %q namespace", svcName, namespace)
 }
 
+// verifyInterPodCommunication validates network connectivity between all active pods via their whereabouts IPs.
 func verifyInterPodCommunication(
 	activePods []*pod.Builder,
 	podWhereaboutsIPs map[string][]NetworkInterface,
@@ -817,6 +939,7 @@ func checkInterPodCommunicationWithError(
 	return nil
 }
 
+// ensurePodConnectivityAfterPodTermination verifies inter-pod connectivity is restored after terminating a pod.
 func ensurePodConnectivityAfterPodTermination(stLabel, namespace, targetPort string, stReplicas int) {
 	By("Getting list of active pods")
 
@@ -896,6 +1019,8 @@ func ensurePodConnectivityAfterPodTermination(stLabel, namespace, targetPort str
 		"Inter-pod connectivity verification failed after pod termination")
 }
 
+// ensurePodConnectivityAfterNodeDrain verifies inter-pod connectivity is restored after draining a node.
+//
 //nolint:funlen
 func ensurePodConnectivityAfterNodeDrain(stLabel, namespace, targetPort string, stReplicas int, sameNode bool) {
 	By("Getting list of active pods")
@@ -1015,6 +1140,7 @@ func ensurePodConnectivityAfterNodeDrain(stLabel, namespace, targetPort string, 
 		"Inter-pod connectivity verification failed after node drain")
 }
 
+// powerOnNodeWaitReady powers on a node via BMC and waits for it to reach Ready state.
 func powerOnNodeWaitReady(bmcClient *bmc.BMC, nodeToPowerOff string, stopCh chan bool) {
 	By("Stopping keepNodePoweredOff goroutine")
 
@@ -1083,6 +1209,7 @@ func powerOnNodeWaitReady(bmcClient *bmc.BMC, nodeToPowerOff string, stopCh chan
 	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Successfully powered on %q", nodeToPowerOff)
 }
 
+// keepNodePoweredOff continuously monitors and powers off a node via BMC until signaled to stop.
 func keepNodePoweredOff(bmcClient *bmc.BMC, nodeToPowerOff string, timeout time.Duration, stopCh chan bool) {
 	By(fmt.Sprintf("Keeping node %q powered off", nodeToPowerOff))
 
@@ -1136,6 +1263,8 @@ func keepNodePoweredOff(bmcClient *bmc.BMC, nodeToPowerOff string, timeout time.
 	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("keepNodePoweredOff finished")
 }
 
+// ensurePodConnectivityAfterNodePowerOff verifies inter-pod connectivity is restored after powering off a node.
+//
 //nolint:gocognit,funlen
 func ensurePodConnectivityAfterNodePowerOff(stLabel, namespace, targetPort string, stReplicas int, sameNode bool) {
 	By("Getting list of active pods")
@@ -1410,7 +1539,7 @@ func CreateWhereaboutsStatefulset(ctx SpecContext, config StatefulsetConfig) {
 	configureWhereaboutsIPReconciler()
 
 	// Setup headless service
-	setupHeadlessService(config.ServiceName, RDSCoreConfig.WhereaboutNS, config.Label, config.Port)
+	setupHeadlessService(config.ServiceName, RDSCoreConfig.WhereaboutNS, config.Label, config.Port, config.NAD)
 
 	// Cleanup existing statefulset
 	cleanupStatefulset(config.Name, RDSCoreConfig.WhereaboutNS, config.Label)
@@ -1444,46 +1573,46 @@ func CreateWhereaboutsStatefulset(ctx SpecContext, config StatefulsetConfig) {
 // configureWhereaboutsIPReconciler configures whereabouts IP reconciler to run every 3 minutes.
 func configureWhereaboutsIPReconciler() {
 	By(fmt.Sprintf("Checking if configmap %q exists in %q namespace",
-		WhereaboutsReconcilcerCMName, WhereaboutsReconcilerNamespace))
+		WhereaboutsReconcilerCMName, WhereaboutsReconcilerNamespace))
 
 	var ctx SpecContext
 
-	cmWhereabouts, err := configmap.Pull(APIClient, WhereaboutsReconcilcerCMName, WhereaboutsReconcilerNamespace)
+	cmWhereabouts, err := configmap.Pull(APIClient, WhereaboutsReconcilerCMName, WhereaboutsReconcilerNamespace)
 	if err == nil {
 		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Configmap %q exists in %q namespace, updating it",
-			WhereaboutsReconcilcerCMName, WhereaboutsReconcilerNamespace)
+			WhereaboutsReconcilerCMName, WhereaboutsReconcilerNamespace)
 
 		if oldSchedule, ok := cmWhereabouts.Object.Data[WhereaboutsReconcilerKey]; ok {
 			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Key %q already exists in configmap %q in %q namespace, updating it",
-				WhereaboutsReconcilerKey, WhereaboutsReconcilcerCMName, WhereaboutsReconcilerNamespace)
+				WhereaboutsReconcilerKey, WhereaboutsReconcilerCMName, WhereaboutsReconcilerNamespace)
 
 			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Old schedule: %q", oldSchedule)
 
 			cmWhereabouts.Object.Data[WhereaboutsReconcilerKey] = WhereaboutsReconcilerSchedule
 		} else {
 			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Key %q does not exist in configmap %q in %q namespace, adding it",
-				WhereaboutsReconcilerKey, WhereaboutsReconcilcerCMName, WhereaboutsReconcilerNamespace)
+				WhereaboutsReconcilerKey, WhereaboutsReconcilerCMName, WhereaboutsReconcilerNamespace)
 
 			cmWhereabouts.Object.Data[WhereaboutsReconcilerKey] = WhereaboutsReconcilerSchedule
 		}
 
 		By(fmt.Sprintf("Updating configmap %q in %q namespace",
-			WhereaboutsReconcilcerCMName, WhereaboutsReconcilerNamespace))
+			WhereaboutsReconcilerCMName, WhereaboutsReconcilerNamespace))
 
 		Eventually(func() error {
 			_, err := cmWhereabouts.Update()
 
 			return err
 		}).WithContext(ctx).WithPolling(15*time.Second).WithTimeout(1*time.Minute).Should(Succeed(),
-			"Failed to update configmap %q in %q namespace", WhereaboutsReconcilcerCMName, WhereaboutsReconcilerNamespace)
+			"Failed to update configmap %q in %q namespace", WhereaboutsReconcilerCMName, WhereaboutsReconcilerNamespace)
 	} else {
 		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Configmap %q does not exist in %q namespace, creating it",
-			WhereaboutsReconcilcerCMName, WhereaboutsReconcilerNamespace)
+			WhereaboutsReconcilerCMName, WhereaboutsReconcilerNamespace)
 
 		By(fmt.Sprintf("Configuring whereabouts reconciler with configmap %q in %q namespace",
-			WhereaboutsReconcilcerCMName, WhereaboutsReconcilerNamespace))
+			WhereaboutsReconcilerCMName, WhereaboutsReconcilerNamespace))
 
-		createConfigMap(WhereaboutsReconcilcerCMName, WhereaboutsReconcilerNamespace, map[string]string{
+		createConfigMap(WhereaboutsReconcilerCMName, WhereaboutsReconcilerNamespace, map[string]string{
 			WhereaboutsReconcilerKey: WhereaboutsReconcilerSchedule,
 		})
 	}

--- a/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-statefulset.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-statefulset.go
@@ -1641,6 +1641,9 @@ func setupServiceAccountAndRBAC(config StatefulsetConfig) {
 func CreateWhereaboutsStatefulset(ctx SpecContext, config StatefulsetConfig) {
 	By(fmt.Sprintf("Setting up statefulset with %s", config.Description))
 
+	Expect(config.NAD).ToNot(BeEmpty(),
+		"NetworkAttachmentDefinition must be set for statefulset %q", config.Name)
+
 	configureWhereaboutsIPReconciler()
 
 	// Setup headless service

--- a/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-statefulset.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-statefulset.go
@@ -322,24 +322,24 @@ func extractRangesFromIPAM(obj map[string]interface{}) []string {
 // detectIPFamiliesFromRanges inspects a list of CIDR range strings and returns
 // whether IPv4 and/or IPv6 ranges are present.
 func detectIPFamiliesFromRanges(ranges []string) (hasIPv4, hasIPv6 bool) {
-	for _, r := range ranges {
-		cidr := strings.TrimSpace(r)
+	for _, rangeStr := range ranges {
+		cidr := strings.TrimSpace(rangeStr)
 		if dashIndex := strings.LastIndex(cidr, "-"); dashIndex >= 0 {
 			cidr = strings.TrimSpace(cidr[dashIndex+1:])
 		}
 
-		ip, _, err := net.ParseCIDR(cidr)
+		parsedIP, _, err := net.ParseCIDR(cidr)
 		if err != nil {
-			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Skipping invalid IPAM range %q: %v", r, err)
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Skipping invalid IPAM range %q: %v", rangeStr, err)
 
 			continue
 		}
 
-		if ip.To4() != nil {
+		if parsedIP.To4() != nil {
 			hasIPv4 = true
 		}
 
-		if ip.To4() == nil && ip.To16() != nil {
+		if parsedIP.To4() == nil && parsedIP.To16() != nil {
 			hasIPv6 = true
 		}
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic IP-family selection for headless Services driven by the configured network attachment; supports multiple IPAM formats and CIDR/non‑CIDR fallbacks to detect IPv4, IPv6, or dual‑stack.

* **Bug Fixes**
  * Pod cleanup now lists pods within the provided namespace to ensure correct deletion scope.
  * Headless service creation now validates and uses the specified network attachment for accurate address‑family handling.

* **Documentation**
  * Minor comment and spelling corrections for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->