### PR TITLE
cnf:network add sriov bond mode test cases

### DIFF
--- a/tests/cnf/core/network/internal/cmd/switchcmd.go
+++ b/tests/cnf/core/network/internal/cmd/switchcmd.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"encoding/xml"
 	"errors"
 	"fmt"
@@ -194,6 +195,28 @@ func (j *Junos) RunCommand(cmd string) (string, error) {
 	}
 
 	return reply.Data, nil
+}
+
+// IsSwitchInterfaceUp reports whether the given switch interface oper-status is up.
+func (j *Junos) IsSwitchInterfaceUp(switchInterface string) (bool, error) {
+	jsonOutput, err := j.RunCommand(fmt.Sprintf("show interfaces %s", switchInterface))
+	if err != nil {
+		return false, err
+	}
+
+	var interfaceStatus InterfaceStatus
+
+	if err := json.Unmarshal([]byte(jsonOutput), &interfaceStatus); err != nil {
+		return false, err
+	}
+
+	if len(interfaceStatus.InterfaceInformation) == 0 ||
+		len(interfaceStatus.InterfaceInformation[0].PhysicalInterface) == 0 ||
+		len(interfaceStatus.InterfaceInformation[0].PhysicalInterface[0].OperStatus) == 0 {
+		return false, fmt.Errorf("no oper-status for switch interface %s", switchInterface)
+	}
+
+	return interfaceStatus.InterfaceInformation[0].PhysicalInterface[0].OperStatus[0].Data == "up", nil
 }
 
 // GetInterfaceConfig returns configuration for given interface.

--- a/tests/cnf/core/network/sriov/internal/sriovenv/bond.go
+++ b/tests/cnf/core/network/sriov/internal/sriovenv/bond.go
@@ -1,0 +1,286 @@
+package sriovenv
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nad"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netinittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/sriov/internal/tsparams"
+)
+
+// Bond CNI mode strings for CreateBondNAD. Must match eco-goinfra/pkg/nad validModes
+// (balance-rr, active-backup, balance-xor, balance-tlb, balance-alb). NMState-only modes
+// such as 802.3ad are defined in the LACP test suite.
+const (
+	BondModeActiveBackup = "active-backup"
+	BondModeBalanceRR    = "balance-rr"
+	BondModeBalanceXOR   = "balance-xor"
+
+	// BondInterfaceName is the default bond master interface created by the Bond CNI plugin.
+	BondInterfaceName = "bond0"
+	// BondSlave1IfName and BondSlave2IfName are the default first two slave links in a 2-slave bond NAD.
+	BondSlave1IfName = "net1"
+	BondSlave2IfName = "net2"
+
+	// BondActiveSlavePollInterval is the poll interval when waiting for bond slave state changes.
+	BondActiveSlavePollInterval = 100 * time.Millisecond
+	// BondActiveSlaveChangeTimeout is the maximum wait for bond active_slave or MII state transitions.
+	BondActiveSlaveChangeTimeout = 30 * time.Second
+)
+
+// CreateBondNAD builds a Bond CNI NAD builder in the SR-IOV test namespace.
+// The caller is responsible for calling .Create() on the returned builder.
+func CreateBondNAD(
+	nadName,
+	mode,
+	ipamType string,
+	mtu,
+	slaveCount int,
+) (*nad.Builder, error) {
+	if slaveCount < 2 {
+		return nil, fmt.Errorf("slaveCount must be >= 2, got %d", slaveCount)
+	}
+
+	var links []nad.Link
+
+	for idx := 1; idx <= slaveCount; idx++ {
+		links = append(links, nad.Link{Name: fmt.Sprintf("net%d", idx)})
+	}
+
+	plugin := nad.NewMasterBondPlugin(nadName, mode).
+		WithFailOverMac(1).
+		WithLinksInContainer(true).
+		WithMiimon(100).
+		WithLinks(links).
+		WithCapabilities(&nad.Capability{IPs: true}).
+		WithIPAM(&nad.IPAM{Type: ipamType})
+
+	masterPlugin, err := plugin.GetMasterPluginConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	if mtu > 0 {
+		masterPlugin.Mtu = mtu
+	}
+
+	return nad.NewBuilder(APIClient, nadName, tsparams.TestNamespaceName).
+		WithMasterPlugin(masterPlugin), nil
+}
+
+// GetBondActiveSlave reads the current active_slave from sysfs for the given bond interface.
+func GetBondActiveSlave(clientPod *pod.Builder, bondName string) (string, error) {
+	out, err := clientPod.ExecCommand([]string{"bash", "-c",
+		fmt.Sprintf("cat /sys/class/net/%s/bonding/active_slave", bondName)})
+	if err != nil {
+		return "", fmt.Errorf("failed to read bond active_slave: %w (out=%s)", err, out.String())
+	}
+
+	return strings.TrimSpace(out.String()), nil
+}
+
+// WaitForBondActiveSlaveChange polls active_slave until it differs from previousSlave or times out.
+func WaitForBondActiveSlaveChange(clientPod *pod.Builder, bondName, previousSlave string) (string, error) {
+	deadline := time.Now().Add(BondActiveSlaveChangeTimeout)
+
+	var last string
+
+	for {
+		slave, err := GetBondActiveSlave(clientPod, bondName)
+		if err != nil {
+			return "", err
+		}
+
+		last = slave
+
+		if slave != "" && slave != previousSlave {
+			return slave, nil
+		}
+
+		if time.Now().After(deadline) {
+			return last, fmt.Errorf(
+				"bond did not switch active slave from %q within %v (last active_slave=%q)",
+				previousSlave, BondActiveSlaveChangeTimeout, last)
+		}
+
+		time.Sleep(BondActiveSlavePollInterval)
+	}
+}
+
+// WaitForBondSlaveMIIDown polls until the given slave is MII-down, the bond is still up,
+// and at least one other slave remains MII-up (degraded but operational).
+func WaitForBondSlaveMIIDown(clientPod *pod.Builder, bondName, downSlave string) error {
+	deadline := time.Now().Add(BondActiveSlaveChangeTimeout)
+
+	var lastSlaves map[string]string
+
+	for {
+		bondUp, err := isBondInterfaceUp(clientPod, bondName)
+		if err != nil {
+			return err
+		}
+
+		slaves, err := getBondSlaveMIIStatuses(clientPod, bondName)
+		if err != nil {
+			return err
+		}
+
+		lastSlaves = slaves
+
+		if bondUp && slaves[downSlave] == "down" && countBondSlavesWithMII(slaves, "up") >= 1 {
+			return nil
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf(
+				"bond %q did not stabilize with slave %q MII down within %v (bondUp=%t, slaves=%v)",
+				bondName, downSlave, BondActiveSlaveChangeTimeout, bondUp, lastSlaves)
+		}
+
+		time.Sleep(BondActiveSlavePollInterval)
+	}
+}
+
+// WaitForBondSlavesMIIUp polls until all bond slaves report MII up and the bond is up.
+func WaitForBondSlavesMIIUp(clientPod *pod.Builder, bondName string) error {
+	deadline := time.Now().Add(BondActiveSlaveChangeTimeout)
+
+	var lastSlaves map[string]string
+
+	for {
+		bondUp, err := isBondInterfaceUp(clientPod, bondName)
+		if err != nil {
+			return err
+		}
+
+		slaves, err := getBondSlaveMIIStatuses(clientPod, bondName)
+		if err != nil {
+			return err
+		}
+
+		lastSlaves = slaves
+
+		if bondUp &&
+			len(slaves) >= 2 &&
+			countBondSlavesWithMII(slaves, "up") >= 2 &&
+			countBondSlavesWithMII(slaves, "down") == 0 {
+			return nil
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf(
+				"bond %q did not recover all slaves to MII up within %v (bondUp=%t, slaves=%v)",
+				bondName, BondActiveSlaveChangeTimeout, bondUp, lastSlaves)
+		}
+
+		time.Sleep(BondActiveSlavePollInterval)
+	}
+}
+
+// SetLinkStatus sets a network interface operstate to up or down inside a pod.
+func SetLinkStatus(podBuilder *pod.Builder, nic, status string) error {
+	out, err := podBuilder.ExecCommand([]string{"bash", "-c", fmt.Sprintf("ip link set dev %s %s", nic, status)})
+	if err != nil {
+		return fmt.Errorf("failed to set interface %s %s: %w (out=%s)", nic, status, err, out.String())
+	}
+
+	return nil
+}
+
+// VerifyBondInterfaceState checks that the bond interface is up, has the expected mode, and slave count.
+func VerifyBondInterfaceState(podBuilder *pod.Builder, bondName, expectedMode string, expectedSlaveCount int) error {
+	out, err := podBuilder.ExecCommand([]string{"bash", "-c",
+		fmt.Sprintf("cat /sys/class/net/%s/operstate", bondName)})
+	if err != nil {
+		return fmt.Errorf("failed to read bond operstate: %w (out=%s)", err, out.String())
+	}
+
+	if strings.TrimSpace(out.String()) != "up" {
+		return fmt.Errorf("bond interface %s is not up (operstate=%q)", bondName, strings.TrimSpace(out.String()))
+	}
+
+	out, err = podBuilder.ExecCommand([]string{"bash", "-c",
+		fmt.Sprintf("cat /sys/class/net/%s/bonding/mode", bondName)})
+	if err != nil {
+		return fmt.Errorf("failed to read bond mode: %w (out=%s)", err, out.String())
+	}
+
+	if !strings.Contains(out.String(), expectedMode) {
+		return fmt.Errorf("bond mode mismatch: expected %q, got %q", expectedMode, strings.TrimSpace(out.String()))
+	}
+
+	out, err = podBuilder.ExecCommand([]string{"bash", "-c",
+		fmt.Sprintf("cat /sys/class/net/%s/bonding/slaves | wc -w", bondName)})
+	if err != nil {
+		return fmt.Errorf("failed to read bond slaves: %w (out=%s)", err, out.String())
+	}
+
+	got := strings.TrimSpace(out.String())
+	if got != fmt.Sprintf("%d", expectedSlaveCount) {
+		return fmt.Errorf("bond slave count mismatch: expected %d, got %s", expectedSlaveCount, got)
+	}
+
+	return nil
+}
+
+func isBondInterfaceUp(clientPod *pod.Builder, bondName string) (bool, error) {
+	out, err := clientPod.ExecCommand([]string{"bash", "-c",
+		fmt.Sprintf("cat /sys/class/net/%s/operstate", bondName)})
+	if err != nil {
+		return false, fmt.Errorf("failed to read bond operstate: %w (out=%s)", err, out.String())
+	}
+
+	return strings.TrimSpace(out.String()) == "up", nil
+}
+
+func getBondSlaveMIIStatuses(clientPod *pod.Builder, bondName string) (map[string]string, error) {
+	out, err := clientPod.ExecCommand([]string{"cat", fmt.Sprintf("/proc/net/bonding/%s", bondName)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to read bond status: %w (out=%s)", err, out.String())
+	}
+
+	return parseBondSlaveMIIStatuses(out.String()), nil
+}
+
+func parseBondSlaveMIIStatuses(bondingOutput string) map[string]string {
+	slaves := make(map[string]string)
+
+	var currentSlave string
+
+	for _, line := range strings.Split(bondingOutput, "\n") {
+		line = strings.TrimSpace(line)
+
+		if strings.HasPrefix(line, "Slave Interface:") {
+			parts := strings.SplitN(line, ":", 2)
+			if len(parts) >= 2 {
+				currentSlave = strings.TrimSpace(parts[1])
+			}
+
+			continue
+		}
+
+		if strings.HasPrefix(line, "MII Status:") && currentSlave != "" {
+			parts := strings.SplitN(line, ":", 2)
+			if len(parts) >= 2 {
+				slaves[currentSlave] = strings.TrimSpace(parts[1])
+			}
+		}
+	}
+
+	return slaves
+}
+
+func countBondSlavesWithMII(slaves map[string]string, status string) int {
+	count := 0
+
+	for _, slaveStatus := range slaves {
+		if slaveStatus == status {
+			count++
+		}
+	}
+
+	return count
+}

--- a/tests/cnf/core/network/sriov/internal/sriovenv/sriovenv.go
+++ b/tests/cnf/core/network/sriov/internal/sriovenv/sriovenv.go
@@ -76,6 +76,31 @@ func ValidateSriovInterfaces(workerNodeList []*nodes.Builder, requestedNumber in
 	return nil
 }
 
+// GetMinTotalVFsAcrossWorkers returns the minimum total VFs for pfName across all workers.
+// Use when sizing VF ranges for cluster-wide SR-IOV policies (WorkerLabelMap).
+func GetMinTotalVFsAcrossWorkers(workerNodeList []*nodes.Builder, pfName string) (int, error) {
+	if len(workerNodeList) == 0 {
+		return 0, fmt.Errorf("workerNodeList is empty")
+	}
+
+	minTotal := -1
+
+	for _, worker := range workerNodeList {
+		total, err := sriov.NewNetworkNodeStateBuilder(APIClient,
+			worker.Definition.Name, NetConfig.SriovOperatorNamespace).GetTotalVFs(pfName)
+		if err != nil {
+			return 0, fmt.Errorf("failed to get total VFs for %s on node %s: %w",
+				pfName, worker.Definition.Name, err)
+		}
+
+		if minTotal < 0 || total < minTotal {
+			minTotal = total
+		}
+	}
+
+	return minTotal, nil
+}
+
 // CreateSriovNetworkAndWaitForNADCreation creates a SriovNetwork and waits for NAD Creation on the test namespace.
 func CreateSriovNetworkAndWaitForNADCreation(sNet *sriov.NetworkBuilder, timeout time.Duration) error {
 	klog.V(90).Infof("Creating SriovNetwork %s and waiting for net-attach-def to be created", sNet.Definition.Name)
@@ -367,6 +392,67 @@ func CreateSriovNetworkWithWhereaboutsIPAM(
 	return CreateSriovNetworkAndWaitForNADCreation(networkBuilder, tsparams.NADWaitTimeout)
 }
 
+// applyBondSlaveVFSettings sets bond slave VF params (cnf-gotests defineSriovBondNetwork).
+func applyBondSlaveVFSettings(builder *sriov.NetworkBuilder) *sriov.NetworkBuilder {
+	return builder.WithTrustFlag(true).WithSpoof(false).WithLinkState("auto")
+}
+
+// CreateSriovBondNetwork creates a bond slave SriovNetwork without IPAM.
+// Slave interfaces (net1, net2) are L2-only; the bond NAD carries the test IP on bond0.
+func CreateSriovBondNetwork(name, resourceName string) error {
+	klog.V(90).Infof("Creating bond slave SR-IOV network %s without IPAM", name)
+
+	networkBuilder := sriov.NewNetworkBuilder(
+		APIClient, name, NetConfig.SriovOperatorNamespace,
+		tsparams.TestNamespaceName, resourceName)
+
+	networkBuilder = applyBondSlaveVFSettings(networkBuilder).WithMacAddressSupport()
+	networkBuilder.Definition.Spec.IPAM = ""
+
+	var err error
+
+	if networkBuilder.Exists() {
+		// Replace stale SriovNetworks (e.g. prior Whereabouts IPAM) so slave NADs are regenerated without IPAM.
+		_, err = networkBuilder.Update(true)
+	} else {
+		_, err = networkBuilder.Create()
+	}
+
+	if err != nil {
+		return fmt.Errorf("create or update bond slave SriovNetwork %s: %w", name, err)
+	}
+
+	return WaitForNADCreation(name, tsparams.TestNamespaceName, tsparams.NADWaitTimeout)
+}
+
+// CreateSriovBondNetworkWithWhereaboutsIPAM creates a bond slave SriovNetwork with Whereabouts IPAM
+// and bond VF settings (Trust on, SpoofChk off, LinkState auto).
+func CreateSriovBondNetworkWithWhereaboutsIPAM(
+	name,
+	resourceName,
+	ipRange,
+	gateway,
+	networkName,
+	ipv6Range string,
+) error {
+	klog.V(90).Infof("Creating bond slave SR-IOV network %s with whereabouts IPAM, range %s, gateway %s",
+		name, ipRange, gateway)
+
+	networkBuilder := sriov.NewNetworkBuilder(
+		APIClient, name, NetConfig.SriovOperatorNamespace,
+		tsparams.TestNamespaceName, resourceName)
+
+	networkBuilder = applyBondSlaveVFSettings(networkBuilder)
+
+	if ipv6Range != "" {
+		networkBuilder.Definition.Spec.IPAM = whereaboutsDualStackIPAMJSON(ipRange, ipv6Range, networkName)
+	} else {
+		networkBuilder = networkBuilder.WithWhereaboutsIPAM(ipRange, gateway, "", networkName)
+	}
+
+	return CreateSriovNetworkAndWaitForNADCreation(networkBuilder, tsparams.NADWaitTimeout)
+}
+
 // CreateSriovNetworkWithVLANAndWhereabouts creates an SR-IOV network with Whereabouts IPAM and VLAN tagging.
 // Dual-stack uses ipRanges without gateway (ipv6Gateway is ignored, same as CreateSriovNetworkWithWhereaboutsIPAM).
 func CreateSriovNetworkWithVLANAndWhereabouts(
@@ -503,13 +589,14 @@ func CreateAllSriovPolicies(
 		vfEndSmallMTU   = 4
 		vfStartLargeMTU = 5
 		vfEndLargeMTU   = 9
+		totalVFs        = 10
 	)
 
 	// Create policy for PF1 with small MTU
 	if err := CreateSriovPolicy(
 		fmt.Sprintf("%s-policy-pf1-mtu%d", policyPrefix, mtuSmall),
 		resourcePF1SmallMTU, pf1, mtuSmall,
-		vfStartSmallMTU, vfEndSmallMTU); err != nil {
+		vfStartSmallMTU, vfEndSmallMTU, totalVFs); err != nil {
 		return fmt.Errorf("failed to create PF1 MTU%d policy: %w", mtuSmall, err)
 	}
 
@@ -517,7 +604,7 @@ func CreateAllSriovPolicies(
 	if err := CreateSriovPolicy(
 		fmt.Sprintf("%s-policy-pf1-mtu%d", policyPrefix, mtuLarge),
 		resourcePF1LargeMTU, pf1, mtuLarge,
-		vfStartLargeMTU, vfEndLargeMTU); err != nil {
+		vfStartLargeMTU, vfEndLargeMTU, totalVFs); err != nil {
 		return fmt.Errorf("failed to create PF1 MTU%d policy: %w", mtuLarge, err)
 	}
 
@@ -525,7 +612,7 @@ func CreateAllSriovPolicies(
 	if err := CreateSriovPolicy(
 		fmt.Sprintf("%s-policy-pf2-mtu%d", policyPrefix, mtuSmall),
 		resourcePF2SmallMTU, pf2, mtuSmall,
-		vfStartSmallMTU, vfEndSmallMTU); err != nil {
+		vfStartSmallMTU, vfEndSmallMTU, totalVFs); err != nil {
 		return fmt.Errorf("failed to create PF2 MTU%d policy: %w", mtuSmall, err)
 	}
 
@@ -533,7 +620,7 @@ func CreateAllSriovPolicies(
 	if err := CreateSriovPolicy(
 		fmt.Sprintf("%s-policy-pf2-mtu%d", policyPrefix, mtuLarge),
 		resourcePF2LargeMTU, pf2, mtuLarge,
-		vfStartLargeMTU, vfEndLargeMTU); err != nil {
+		vfStartLargeMTU, vfEndLargeMTU, totalVFs); err != nil {
 		return fmt.Errorf("failed to create PF2 MTU%d policy: %w", mtuLarge, err)
 	}
 
@@ -556,18 +643,17 @@ func CreateSriovPolicy(
 	pfName string,
 	mtu,
 	vfStart,
-	vfEnd int,
+	vfEnd,
+	numVFs int,
 ) error {
 	klog.V(90).Infof("Creating SR-IOV policy %s", name)
-
-	const totalVFs = 10
 
 	_, err := sriov.NewPolicyBuilder(
 		APIClient,
 		name,
 		NetConfig.SriovOperatorNamespace,
 		resourceName,
-		totalVFs,
+		numVFs,
 		[]string{pfName},
 		NetConfig.WorkerLabelMap).
 		WithMTU(mtu).
@@ -850,8 +936,14 @@ func CreateSriovNetworksForBothMTUs(
 }
 
 // RunTrafficTest runs all traffic type tests (ICMP, TCP, UDP, SCTP, multicast) between client and server pods.
-func RunTrafficTest(clientPod *pod.Builder, serverIP string, mtu int) error {
-	klog.V(90).Infof("Running traffic tests against %s with MTU %d", serverIP, mtu)
+// Optional interfaceName defaults to tsparams.Net1Interface when omitted or empty (e.g. bond tests use bond0).
+func RunTrafficTest(clientPod *pod.Builder, serverIP string, mtu int, interfaceName ...string) error {
+	iface := tsparams.Net1Interface
+	if len(interfaceName) > 0 && interfaceName[0] != "" {
+		iface = interfaceName[0]
+	}
+
+	klog.V(90).Infof("Running traffic tests against %s with MTU %d on interface %s", serverIP, mtu, iface)
 	serverIPAddress := ipaddr.RemovePrefix(serverIP)
 
 	// Subtract header overhead to fit within MTU.
@@ -866,25 +958,25 @@ func RunTrafficTest(clientPod *pod.Builder, serverIP string, mtu int) error {
 	}
 
 	if err := cmd.ICMPConnectivityCheck(
-		clientPod, []string{serverIPWithPrefix}, tsparams.Net1Interface); err != nil {
+		clientPod, []string{serverIPWithPrefix}, iface); err != nil {
 		failedProtocols = append(failedProtocols, fmt.Sprintf("ICMP: %v", err))
 	}
 
 	if err := RunProtocolTest(clientPod, "TCP",
 		fmt.Sprintf("testcmd -protocol tcp -port 5001 -interface %s -server %s -mtu %d",
-			tsparams.Net1Interface, serverIPAddress, packetSize)); err != nil {
+			iface, serverIPAddress, packetSize)); err != nil {
 		failedProtocols = append(failedProtocols, fmt.Sprintf("TCP: %v", err))
 	}
 
 	if err := RunProtocolTest(clientPod, "UDP",
 		fmt.Sprintf("testcmd -protocol udp -port 5002 -interface %s -server %s -mtu %d",
-			tsparams.Net1Interface, serverIPAddress, packetSize)); err != nil {
+			iface, serverIPAddress, packetSize)); err != nil {
 		failedProtocols = append(failedProtocols, fmt.Sprintf("UDP: %v", err))
 	}
 
 	if err := RunProtocolTest(clientPod, "SCTP",
 		fmt.Sprintf("testcmd -protocol sctp -port 5003 -interface %s -server %s -mtu %d",
-			tsparams.Net1Interface, serverIPAddress, packetSize)); err != nil {
+			iface, serverIPAddress, packetSize)); err != nil {
 		failedProtocols = append(failedProtocols, fmt.Sprintf("SCTP: %v", err))
 	}
 
@@ -897,7 +989,7 @@ func RunTrafficTest(clientPod *pod.Builder, serverIP string, mtu int) error {
 
 	if err := RunProtocolTest(clientPod, "multicast",
 		fmt.Sprintf("testcmd -multicast -protocol udp -port 5004 -interface %s -server %s -mtu %d",
-			tsparams.Net1Interface, multicastGroup, packetSize)); err != nil {
+			iface, multicastGroup, packetSize)); err != nil {
 		failedProtocols = append(failedProtocols, fmt.Sprintf("multicast: %v", err))
 	}
 

--- a/tests/cnf/core/network/sriov/internal/tsparams/consts.go
+++ b/tests/cnf/core/network/sriov/internal/tsparams/consts.go
@@ -34,6 +34,8 @@ const (
 	LabelSriovHWEnabled = "sriov-hw-enabled"
 	// LabelLACPTestCases represents LACP tests that can be used for test cases selection.
 	LabelLACPTestCases = "lacp"
+	// LabelBondModeTestCases represents SR-IOV Bond CNI mode tests that can be used for test cases selection.
+	LabelBondModeTestCases = "bond-mode"
 
 	// Net1Interface is the name of the first secondary network interface attached to pods.
 	Net1Interface = "net1"

--- a/tests/cnf/core/network/sriov/tests/allmulti.go
+++ b/tests/cnf/core/network/sriov/tests/allmulti.go
@@ -6,7 +6,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nad"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/namespace"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nodes"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
@@ -148,18 +147,19 @@ var _ = Describe(
 
 			By("Define and create Bonded network attachment for allmulti client")
 
-			nadBondAllmultiConfig := defineBondNAD(bondNadNameAllMulti, "active-backup")
+			bondAllMulti, err := sriovenv.CreateBondNAD(bondNadNameAllMulti, sriovenv.BondModeActiveBackup, "static", 0, 2)
+			Expect(err).ToNot(HaveOccurred(), "Failed to build Bond NAD %s", bondNadNameAllMulti)
 
-			_, err = nadBondAllmultiConfig.Create()
-			Expect(err).ToNot(HaveOccurred(), "Failed to create Bond Nad %s",
-				nadBondAllmultiConfig.Definition.Name)
+			_, err = bondAllMulti.Create()
+			Expect(err).ToNot(HaveOccurred(), "Failed to create Bond NAD %s", bondNadNameAllMulti)
 
 			By("Define and create Bonded network attachment for default client")
 
-			nadBondDefaultConfig := defineBondNAD(bondNadNameDefault, "active-backup")
-			_, err = nadBondDefaultConfig.Create()
-			Expect(err).ToNot(HaveOccurred(), "Failed to create Bond Nad %s",
-				nadBondDefaultConfig.Definition.Name)
+			bondDefault, err := sriovenv.CreateBondNAD(bondNadNameDefault, sriovenv.BondModeActiveBackup, "static", 0, 2)
+			Expect(err).ToNot(HaveOccurred(), "Failed to build Bond NAD %s", bondNadNameDefault)
+
+			_, err = bondDefault.Create()
+			Expect(err).ToNot(HaveOccurred(), "Failed to create Bond NAD %s", bondNadNameDefault)
 
 			By("Waiting until cluster MCP and SR-IOV are stable")
 
@@ -473,20 +473,6 @@ func runAllMultiTestCases(
 
 	By("Verify the client receives traffic from the multicast group after being added to the group")
 	assertMulticastTrafficIsReceived(defaultClientPod, tcpDumpCMD, multicastGroupIP)
-}
-
-// defineBondNAD returns network attachment definition for a Bond interface.
-func defineBondNAD(nadname, mode string) *nad.Builder {
-	bondNad, err := nad.NewMasterBondPlugin(nadname, mode).WithFailOverMac(1).
-		WithLinksInContainer(true).WithMiimon(100).
-		WithLinks([]nad.Link{{Name: "net1"}, {Name: "net2"}}).WithCapabilities(&nad.Capability{IPs: true}).
-		WithIPAM(&nad.IPAM{Type: "static"}).GetMasterPluginConfig()
-	Expect(err).ToNot(HaveOccurred(), "Failed to define Bond NAD for %s", nadname)
-
-	createdNad, err := nad.NewBuilder(APIClient, nadname, tsparams.TestNamespaceName).WithMasterPlugin(bondNad).Create()
-	Expect(err).ToNot(HaveOccurred(), "Failed to create Bond NAD for %s", nadname)
-
-	return createdNad
 }
 
 // defineAndCreateSrIovNetworkWithOutIPAM is used to create sriovnetworks with IPAM for a bonded interface.

--- a/tests/cnf/core/network/sriov/tests/externalllymanaged.go
+++ b/tests/cnf/core/network/sriov/tests/externalllymanaged.go
@@ -459,7 +459,7 @@ var _ = Describe("ExternallyManaged", Ordered, Label(tsparams.LabelExternallyMan
 				By("Creating a new bond interface with the VFs and vlan interface for this bond via nmstate operator")
 
 				bondPolicy := nmstate.NewPolicyBuilder(APIClient, secondBondInterfaceName, NetConfig.WorkerLabelMap).
-					WithBondInterface(vfsUnderTest, secondBondInterfaceName, "active-backup").
+					WithBondInterface(vfsUnderTest, secondBondInterfaceName, sriovenv.BondModeActiveBackup).
 					WithVlanInterface(secondBondInterfaceName, uint16(testVlan))
 
 				err = netnmstate.CreatePolicyAndWaitUntilItsAvailable(netparam.DefaultTimeout, bondPolicy)

--- a/tests/cnf/core/network/sriov/tests/lacp.go
+++ b/tests/cnf/core/network/sriov/tests/lacp.go
@@ -52,8 +52,7 @@ const (
 	bondTestInterface         = "bond0"
 	nodeBond10Interface       = "bond10"
 	nodeBond20Interface       = "bond20"
-	bondModeActiveBackup      = "active-backup"
-	bondMode802_3ad           = "802.3ad"
+	lacpNMStateBondMode8023ad = "802.3ad" // NMState link-aggregation only; not valid for Bond CNI NAD
 	bondedNADNameActiveBackup = "lacp-bond-nad"
 	logTypeInitialization     = "initialization"
 	logTypeVFDisable          = "vf-disable"
@@ -306,7 +305,7 @@ var _ = Describe("LACP Status Relay", Ordered, Label(tsparams.LabelLACPTestCases
 				fmt.Sprintf("LACP should be functioning properly in bonded client pod %s", bondTestInterface))
 
 			performLACPFailureAndRecoveryTestWithMode(bondedClientPod, worker0NodeName, secondaryInterface0,
-				srIovInterfacesUnderTest, switchCredentials, bondModeActiveBackup)
+				srIovInterfacesUnderTest, switchCredentials, sriovenv.BondModeActiveBackup)
 		})
 
 		It("Verify that an interface can be added and removed from the PFLACPMonitor interface monitoring",
@@ -754,35 +753,6 @@ var _ = Describe("LACP Status Relay", Ordered, Label(tsparams.LabelLACPTestCases
 	})
 })
 
-func defineBondNad(nadName,
-	bondType,
-	ipam string,
-	numberSlaveInterfaces int) (*nad.Builder, error) {
-	var bondLinks []nad.Link
-	for i := 1; i <= numberSlaveInterfaces; i++ {
-		bondLinks = append(bondLinks, nad.Link{Name: fmt.Sprintf("net%d", i)})
-	}
-
-	ipamConfig := &nad.IPAM{Type: ipam}
-
-	bondPlugin := nad.NewMasterBondPlugin(nadName, bondType).
-		WithFailOverMac(1).
-		WithLinksInContainer(true).
-		WithMiimon(100).
-		WithLinks(bondLinks).
-		WithCapabilities(&nad.Capability{IPs: true}).
-		WithIPAM(ipamConfig)
-
-	masterPluginConfig, err := bondPlugin.GetMasterPluginConfig()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get master plugin config: %w", err)
-	}
-
-	// Use eco-goinfra framework for all bond types - consistent and reliable
-	return nad.NewBuilder(APIClient, nadName, tsparams.TestNamespaceName).
-		WithMasterPlugin(masterPluginConfig), nil
-}
-
 func lacpSwitchCleanup(credentials *sriovenv.SwitchCredentials, lacpInterfaces, interfaces, configs []string,
 	lacpConfigured, physicalInterfacesConfigured bool) {
 	By("Restoring switch configuration to pre-test state")
@@ -840,7 +810,12 @@ func configureLACPBondInterfaces(workerNodeName string, sriovInterfacesUnderTest
 	}
 
 	bond10Policy := nmstate.NewPolicyBuilder(APIClient, nodeBond10Interface, nodeSelector).
-		WithBondInterface([]string{sriovInterfacesUnderTest[0]}, nodeBond10Interface, bondMode802_3ad, bondInterfaceOptions)
+		WithBondInterface(
+			[]string{sriovInterfacesUnderTest[0]},
+			nodeBond10Interface,
+			lacpNMStateBondMode8023ad,
+			bondInterfaceOptions,
+		)
 
 	// Delete existing policy if it exists to ensure clean state
 	if bond10Policy.Exists() {
@@ -853,7 +828,12 @@ func configureLACPBondInterfaces(workerNodeName string, sriovInterfacesUnderTest
 
 	if len(sriovInterfacesUnderTest) > 1 {
 		bond20Policy := nmstate.NewPolicyBuilder(APIClient, nodeBond20Interface, nodeSelector).
-			WithBondInterface([]string{sriovInterfacesUnderTest[1]}, nodeBond20Interface, bondMode802_3ad, bondInterfaceOptions)
+			WithBondInterface(
+				[]string{sriovInterfacesUnderTest[1]},
+				nodeBond20Interface,
+				lacpNMStateBondMode8023ad,
+				bondInterfaceOptions,
+			)
 
 		// Delete existing policy if it exists to ensure clean state
 		if bond20Policy.Exists() {
@@ -867,9 +847,9 @@ func configureLACPBondInterfaces(workerNodeName string, sriovInterfacesUnderTest
 }
 
 func createBondedNAD(nadName string) error {
-	bondNadBuilder, err := defineBondNad(nadName, bondModeActiveBackup, "static", 2)
+	bondNadBuilder, err := sriovenv.CreateBondNAD(nadName, sriovenv.BondModeActiveBackup, "static", 0, 2)
 	if err != nil {
-		return fmt.Errorf("failed to define bonded NAD %s: %w", nadName, err)
+		return fmt.Errorf("failed to build bonded NAD %s: %w", nadName, err)
 	}
 
 	_, err = bondNadBuilder.Create()
@@ -1858,7 +1838,7 @@ func verifyVFEnableLogs(podLogs, targetInterface string, expectedVFs int) error 
 func checkBondingStatusInPod(bondedPod *pod.Builder, expectedMode ...string) error {
 	bondInterface := bondTestInterface
 
-	mode := bondModeActiveBackup
+	mode := sriovenv.BondModeActiveBackup
 	if len(expectedMode) > 0 {
 		mode = expectedMode[0]
 	}
@@ -1886,7 +1866,7 @@ func configureLACPBondInterfaceSecondary(nodeName, interfaceName string) {
 
 	nmstatePolicyName := fmt.Sprintf("lacp-bond-secondary-%s", nodeName)
 	secondaryBondPolicy := nmstate.NewPolicyBuilder(APIClient, nmstatePolicyName, nodeSelector).
-		WithBondInterface([]string{interfaceName}, nodeBond20Interface, bondMode802_3ad, bondInterfaceOptions)
+		WithBondInterface([]string{interfaceName}, nodeBond20Interface, lacpNMStateBondMode8023ad, bondInterfaceOptions)
 
 	err := netnmstate.CreatePolicyAndWaitUntilItsAvailable(netparam.DefaultTimeout, secondaryBondPolicy)
 	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Failed to create secondary bond policy for %s", nodeBond20Interface))
@@ -2134,7 +2114,7 @@ func verifyInterfaceIsUp(nodeName, interfaceName string) error {
 }
 
 func analyzePodBondingStatus(bondingOutput, bondInterface, location string, expectedMode ...string) error {
-	mode := bondModeActiveBackup
+	mode := sriovenv.BondModeActiveBackup
 	if len(expectedMode) > 0 {
 		mode = expectedMode[0]
 	}
@@ -2261,11 +2241,11 @@ func verifyBondingDegradedState(bondedPod *pod.Builder) error {
 	// Verify exactly one interface is down (degraded state)
 	downInterfaces := 0
 
-	if net1Status == "down" {
+	if net1Status == lacpExpectedStateDown {
 		downInterfaces++
 	}
 
-	if net2Status == "down" {
+	if net2Status == lacpExpectedStateDown {
 		downInterfaces++
 	}
 
@@ -2282,10 +2262,10 @@ func verifyBondingDegradedState(bondedPod *pod.Builder) error {
 
 func validateBondingModeOutput(bondingMode, expectedMode, location, bondInterface string) error {
 	switch expectedMode {
-	case bondModeActiveBackup:
-		if !strings.Contains(bondingMode, bondModeActiveBackup) {
+	case sriovenv.BondModeActiveBackup:
+		if !strings.Contains(bondingMode, sriovenv.BondModeActiveBackup) {
 			return fmt.Errorf("expected %s bonding mode, got: %s on %s %s",
-				bondModeActiveBackup, bondingMode, location, bondInterface)
+				sriovenv.BondModeActiveBackup, bondingMode, location, bondInterface)
 		}
 	default:
 		return fmt.Errorf("unsupported bonding mode validation: %s", expectedMode)

--- a/tests/cnf/core/network/sriov/tests/sriov-bond-mode.go
+++ b/tests/cnf/core/network/sriov/tests/sriov-bond-mode.go
@@ -1,0 +1,1333 @@
+package tests
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nad"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/namespace"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nodes"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/sriov"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/cmd"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/ipaddr"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netenv"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netinittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netparam"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/sriov/internal/sriovenv"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/sriov/internal/tsparams"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/cluster"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/sriovoperator"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/klog/v2"
+)
+
+const (
+	bondNADName = "sriov-bond-nad"
+
+	mtu1280 = 1280
+	mtu9000 = 9000
+
+	// SR-IOV policy resourceNames for bond tests (PF1/PF2 × small/jumbo MTU; shared by IPv4 and IPv6).
+	bondResourcePF1Small = "sriovbondpf1mtu1280"
+	bondResourcePF1Jumbo = "sriovbondpf1mtu9000"
+	bondResourcePF2Small = "sriovbondpf2mtu1280"
+	bondResourcePF2Jumbo = "sriovbondpf2mtu9000"
+
+	// bondMinVFsPerPF is the minimum total VFs per PF for bond tests on Mellanox and other five-VF devices.
+	bondMinVFsPerPF = 5
+	// bondMinVFsStandardLayout is the minimum total VFs per PF for the standard small/jumbo VF split.
+	bondMinVFsStandardLayout = 10
+	// bondMinSwitchInterfaces is the number of physical switch ports used for static LAG setup.
+	bondMinSwitchInterfaces = 4
+)
+
+// Lab switch state for balance-rr/xor LAG setup (active-backup tests leave the switch untouched).
+var (
+	bondSwitchCredentials  *sriovenv.SwitchCredentials
+	bondSwitchInterfaces   []string
+	bondSwitchLagNames     []string
+	bondSwitchSavedConfigs []string
+)
+
+var _ = Describe(
+	"SRIOV Bond CNI",
+	Ordered,
+	Label(tsparams.LabelSuite, tsparams.LabelBondModeTestCases),
+	ContinueOnFailure,
+	func() {
+		var (
+			workerNodeList  []*nodes.Builder
+			pf1             string
+			pf2             string
+			pf1NumVFs       int
+			pf2NumVFs       int
+			clusterIPFamily string
+			err             error
+		)
+
+		BeforeAll(func() {
+			By("Checking cluster IP family")
+
+			clusterIPFamily, err = netenv.GetClusterIPFamily(APIClient)
+			Expect(err).ToNot(HaveOccurred(), "Failed to detect cluster IP family")
+
+			if !netenv.ClusterSupportsIPv4(clusterIPFamily) && !netenv.ClusterSupportsIPv6(clusterIPFamily) {
+				Skip("Cluster does not support IPv4 or IPv6 - skipping SR-IOV bond tests")
+			}
+
+			By("Discover and list worker nodes")
+
+			workerNodeList, err = nodes.List(
+				APIClient, metav1.ListOptions{LabelSelector: labels.Set(NetConfig.WorkerLabelMap).String()})
+			Expect(err).ToNot(HaveOccurred(), "Failed to list worker nodes")
+
+			if len(workerNodeList) < 2 {
+				Skip("Cluster needs at least 2 worker nodes for SR-IOV bond tests")
+			}
+
+			By("Validating SR-IOV interfaces exist on nodes")
+			Expect(sriovenv.ValidateSriovInterfaces(workerNodeList, 2)).ToNot(HaveOccurred(),
+				"Failed to get required SR-IOV interfaces")
+
+			sriovInterfaces, err := NetConfig.GetSriovInterfaces(2)
+			Expect(err).ToNot(HaveOccurred(), "Failed to retrieve SR-IOV interfaces for testing")
+
+			pf1 = sriovInterfaces[0]
+			pf2 = sriovInterfaces[1]
+
+			sriovenv.ActivateSCTPModuleOnWorkerNodes()
+
+			By("Verifying SCTP kernel module is loaded on worker nodes")
+
+			sctpOutput, err := cluster.ExecCmdWithStdout(APIClient, "lsmod | grep -q sctp && echo loaded",
+				metav1.ListOptions{LabelSelector: labels.Set(NetConfig.WorkerLabelMap).String()})
+			Expect(err).ToNot(HaveOccurred(), "Failed to check SCTP kernel module on worker nodes")
+			Expect(sctpOutput).NotTo(BeEmpty(),
+				"SCTP kernel module must be loaded on workers for this suite (traffic tests require SCTP); "+
+					"configure SCTP per tests/cnf/core/network/README prerequisites (e.g. MachineConfig)")
+
+			By("Selecting VF ranges for shared bond SR-IOV policies")
+
+			pf1Total, vfErr := sriovenv.GetMinTotalVFsAcrossWorkers(workerNodeList, pf1)
+			Expect(vfErr).ToNot(HaveOccurred(), "Failed to get minimum total VFs for PF1 across workers")
+
+			pf2Total, vfErr := sriovenv.GetMinTotalVFsAcrossWorkers(workerNodeList, pf2)
+			Expect(vfErr).ToNot(HaveOccurred(), "Failed to get minimum total VFs for PF2 across workers")
+
+			pf1NumVFs = pf1Total
+			pf2NumVFs = pf2Total
+
+			minTotal := pf1Total
+			if pf2Total < minTotal {
+				minTotal = pf2Total
+			}
+
+			if minTotal < bondMinVFsPerPF {
+				Skip(fmt.Sprintf(
+					"Bond tests require >=%d VFs per PF on every worker; min across workers: pf1=%d, pf2=%d",
+					bondMinVFsPerPF, pf1Total, pf2Total))
+			}
+
+			vfSmallEnd, vfLargeStart, vfLargeEnd, layoutOK := selectBondVFLayout(minTotal)
+			Expect(layoutOK).To(BeTrue(), "Failed to select bond VF layout")
+
+			bondNetworks := bondSlaveNetworkConfigs(
+				bondNetworksV4DiffPFSmall, bondNetworksV4DiffPFJumbo,
+				bondNetworksV4SamePFSmall, bondNetworksV4SamePFJumbo,
+				bondResourcePF1Small, bondResourcePF1Jumbo,
+				bondResourcePF2Small, bondResourcePF2Jumbo,
+			)
+			bondNetworks = append(bondNetworks, bondSlaveNetworkConfigs(
+				bondNetworksV6DiffPFSmall, bondNetworksV6DiffPFJumbo,
+				bondNetworksV6SamePFSmall, bondNetworksV6SamePFJumbo,
+				bondResourcePF1Small, bondResourcePF1Jumbo,
+				bondResourcePF2Small, bondResourcePF2Jumbo,
+			)...)
+
+			By("Removing stale bond SR-IOV policies from prior suite revisions")
+
+			Expect(cleanupStaleBondSriovPolicies()).To(Succeed(), "Failed to remove stale bond SR-IOV policies")
+
+			setupBondStack(bondStackParams{
+				pf1:          pf1,
+				pf2:          pf2,
+				pf1NumVFs:    pf1NumVFs,
+				pf2NumVFs:    pf2NumVFs,
+				vfSmallStart: 0,
+				vfSmallEnd:   vfSmallEnd,
+				vfLargeStart: vfLargeStart,
+				vfLargeEnd:   vfLargeEnd,
+				networks:     bondNetworks,
+			})
+		})
+
+		AfterAll(func() {
+			if len(bondSwitchSavedConfigs) > 0 && bondSwitchCredentials != nil {
+				By("Restoring lab switch configuration after bond tests")
+
+				err = restoreBondSwitchLAG(
+					bondSwitchCredentials, bondSwitchInterfaces, bondSwitchLagNames, bondSwitchSavedConfigs)
+				Expect(err).ToNot(HaveOccurred(), "Failed to restore lab switch configuration")
+			}
+
+			By("Removing SR-IOV configuration")
+
+			err = sriovoperator.RemoveSriovConfigurationAndWaitForSriovAndMCPStable(
+				APIClient,
+				NetConfig.WorkerLabelEnvVar,
+				NetConfig.SriovOperatorNamespace,
+				tsparams.MCOWaitTimeout,
+				tsparams.DefaultTimeout)
+			Expect(err).ToNot(HaveOccurred(), "Failed to remove SR-IOV configuration")
+		})
+
+		AfterEach(func() {
+			By("Deleting test pods")
+
+			err = namespace.NewBuilder(APIClient, tsparams.TestNamespaceName).CleanObjects(
+				netparam.DefaultTimeout, pod.GetGVR())
+			Expect(err).ToNot(HaveOccurred(), "Failed to delete test pods")
+
+			// Best-effort cleanup: tests may create mode- and MTU-specific bond NADs.
+			for _, nadName := range bondNADNamesForCleanup() {
+				deleteBondNADBestEffort(nadName)
+			}
+		})
+
+		Context("Mode: active-backup", func() {
+			It("DiffNodeDiffPF IPv4", reportxml.ID("89050"), func() {
+				if !netenv.ClusterSupportsIPv4(clusterIPFamily) {
+					Skip("Cluster does not support IPv4 - skipping SR-IOV bond IPv4 tests")
+				}
+
+				runBondScenario(
+					sriovenv.BondModeActiveBackup,
+					mtu1280, mtu9000,
+					tsparams.ServerIPv4IPAddress, tsparams.ClientIPv4IPAddress,
+					tsparams.ServerIPv4IPAddress2, tsparams.ClientIPv4IPAddress2,
+					workerNodeList[0].Definition.Name, workerNodeList[1].Definition.Name,
+					bondNetworksV4DiffPFSmall, bondNetworksV4DiffPFJumbo,
+				)
+			})
+
+			It("DiffNodeSamePF IPv4", reportxml.ID("89051"), func() {
+				if !netenv.ClusterSupportsIPv4(clusterIPFamily) {
+					Skip("Cluster does not support IPv4 - skipping SR-IOV bond IPv4 tests")
+				}
+
+				runBondScenario(
+					sriovenv.BondModeActiveBackup,
+					mtu1280, mtu9000,
+					tsparams.ServerIPv4IPAddress, tsparams.ClientIPv4IPAddress,
+					tsparams.ServerIPv4IPAddress2, tsparams.ClientIPv4IPAddress2,
+					workerNodeList[0].Definition.Name, workerNodeList[1].Definition.Name,
+					bondNetworksV4SamePFSmall, bondNetworksV4SamePFJumbo,
+				)
+			})
+
+			It("DiffNodeDiffPF IPv6", reportxml.ID("89057"), func() {
+				if !netenv.ClusterSupportsIPv6(clusterIPFamily) {
+					Skip("Cluster does not support IPv6 - skipping SR-IOV bond IPv6 tests")
+				}
+
+				runBondScenario(
+					sriovenv.BondModeActiveBackup,
+					mtu1280, mtu9000,
+					tsparams.ServerIPv6IPAddress, tsparams.ClientIPv6IPAddress,
+					tsparams.ServerIPv6IPAddress2, tsparams.ClientIPv6IPAddress2,
+					workerNodeList[0].Definition.Name, workerNodeList[1].Definition.Name,
+					bondNetworksV6DiffPFSmall, bondNetworksV6DiffPFJumbo,
+				)
+			})
+
+			It("DiffNodeSamePF IPv6", reportxml.ID("89058"), func() {
+				if !netenv.ClusterSupportsIPv6(clusterIPFamily) {
+					Skip("Cluster does not support IPv6 - skipping SR-IOV bond IPv6 tests")
+				}
+
+				runBondScenario(
+					sriovenv.BondModeActiveBackup,
+					mtu1280, mtu9000,
+					tsparams.ServerIPv6IPAddress, tsparams.ClientIPv6IPAddress,
+					tsparams.ServerIPv6IPAddress2, tsparams.ClientIPv6IPAddress2,
+					workerNodeList[0].Definition.Name, workerNodeList[1].Definition.Name,
+					bondNetworksV6SamePFSmall, bondNetworksV6SamePFJumbo,
+				)
+			})
+		})
+
+		Context("Mode: active-active", func() {
+			// cnf-gotests TestActiveActiveBondScenario: switch LAG + DiffNodeDiffPF only (PF1+PF2 slaves).
+			BeforeEach(func() {
+				By("Configure static LAGs on lab switch for active-active bond tests")
+
+				err = setupBondSwitchLAGForActiveActiveTests()
+				Expect(err).ToNot(HaveOccurred(), "Failed to configure static LAGs on lab switch")
+			})
+
+			AfterEach(func() {
+				restoreBondSwitchLAGAfterActiveActiveTest()
+			})
+
+			It("balance-rr DiffNodeDiffPF IPv4", reportxml.ID("89052"), func() {
+				if !netenv.ClusterSupportsIPv4(clusterIPFamily) {
+					Skip("Cluster does not support IPv4 - skipping SR-IOV bond IPv4 tests")
+				}
+
+				runBondScenario(
+					sriovenv.BondModeBalanceRR,
+					mtu1280, mtu9000,
+					tsparams.ServerIPv4IPAddress, tsparams.ClientIPv4IPAddress,
+					tsparams.ServerIPv4IPAddress2, tsparams.ClientIPv4IPAddress2,
+					workerNodeList[0].Definition.Name, workerNodeList[1].Definition.Name,
+					bondNetworksV4DiffPFSmall, bondNetworksV4DiffPFJumbo,
+				)
+			})
+
+			It("balance-xor: DiffNodeDiffPF IPv4", reportxml.ID("89054"), func() {
+				if !netenv.ClusterSupportsIPv4(clusterIPFamily) {
+					Skip("Cluster does not support IPv4 - skipping SR-IOV bond IPv4 tests")
+				}
+
+				runBondScenario(
+					sriovenv.BondModeBalanceXOR,
+					mtu1280, mtu9000,
+					tsparams.ServerIPv4IPAddress, tsparams.ClientIPv4IPAddress,
+					tsparams.ServerIPv4IPAddress2, tsparams.ClientIPv4IPAddress2,
+					workerNodeList[0].Definition.Name, workerNodeList[1].Definition.Name,
+					bondNetworksV4DiffPFSmall, bondNetworksV4DiffPFJumbo,
+				)
+			})
+
+			It("balance-rr: DiffNodeDiffPF IPv6", reportxml.ID("89059"), func() {
+				if !netenv.ClusterSupportsIPv6(clusterIPFamily) {
+					Skip("Cluster does not support IPv6 - skipping SR-IOV bond IPv6 tests")
+				}
+
+				runBondScenario(
+					sriovenv.BondModeBalanceRR,
+					mtu1280, mtu9000,
+					tsparams.ServerIPv6IPAddress, tsparams.ClientIPv6IPAddress,
+					tsparams.ServerIPv6IPAddress2, tsparams.ClientIPv6IPAddress2,
+					workerNodeList[0].Definition.Name, workerNodeList[1].Definition.Name,
+					bondNetworksV6DiffPFSmall, bondNetworksV6DiffPFJumbo,
+				)
+			})
+
+			It("balance-xor: DiffNodeDiffPF IPv6", reportxml.ID("89061"), func() {
+				if !netenv.ClusterSupportsIPv6(clusterIPFamily) {
+					Skip("Cluster does not support IPv6 - skipping SR-IOV bond IPv6 tests")
+				}
+
+				runBondScenario(
+					sriovenv.BondModeBalanceXOR,
+					mtu1280, mtu9000,
+					tsparams.ServerIPv6IPAddress, tsparams.ClientIPv6IPAddress,
+					tsparams.ServerIPv6IPAddress2, tsparams.ClientIPv6IPAddress2,
+					workerNodeList[0].Definition.Name, workerNodeList[1].Definition.Name,
+					bondNetworksV6DiffPFSmall, bondNetworksV6DiffPFJumbo,
+				)
+			})
+		})
+
+		Context("Scale: Bond with 16 VFs", func() {
+			const (
+				scaleBondMode    = sriovenv.BondModeActiveBackup
+				scaleBondNADIPv4 = "sriov-bond-scale-nad"
+				scaleBondNADIPv6 = "sriov-bond-scale-nad-ipv6"
+				scaleNetA        = "sriov-bond-scale-a"
+				scaleNetB        = "sriov-bond-scale-b"
+				scaleResA        = "sriovbondscalea"
+				scaleResB        = "sriovbondscaleb"
+				scaleTotalVFs    = 16
+				scaleSlaveCount  = 16
+			)
+
+			createBondScalePolicies := func(mtu, vfStart, pf1NumVFs, pf2NumVFs int) {
+				vfEnd := vfStart + scaleTotalVFs - 1
+
+				_, err := sriov.NewPolicyBuilder(
+					APIClient,
+					"bond-scale-policy-pf1",
+					NetConfig.SriovOperatorNamespace,
+					scaleResA,
+					pf1NumVFs,
+					[]string{pf1},
+					NetConfig.WorkerLabelMap).
+					WithMTU(mtu).
+					WithVFRange(vfStart, vfEnd).
+					Create()
+				Expect(err).ToNot(HaveOccurred(), "Failed to create scale policy for PF1")
+
+				_, err = sriov.NewPolicyBuilder(
+					APIClient,
+					"bond-scale-policy-pf2",
+					NetConfig.SriovOperatorNamespace,
+					scaleResB,
+					pf2NumVFs,
+					[]string{pf2},
+					NetConfig.WorkerLabelMap).
+					WithMTU(mtu).
+					WithVFRange(vfStart, vfEnd).
+					Create()
+				Expect(err).ToNot(HaveOccurred(), "Failed to create scale policy for PF2")
+			}
+
+			BeforeAll(func() {
+				supportsIPv4 := netenv.ClusterSupportsIPv4(clusterIPFamily)
+				supportsIPv6 := netenv.ClusterSupportsIPv6(clusterIPFamily)
+
+				if !supportsIPv4 && !supportsIPv6 {
+					Skip("Cluster does not support IPv4 or IPv6 - skipping SR-IOV bond scale tests")
+				}
+
+				By("Checking that requested interfaces support enough total VFs for scale tests")
+
+				pf1Total, err := sriovenv.GetMinTotalVFsAcrossWorkers(workerNodeList, pf1)
+				Expect(err).ToNot(HaveOccurred(), "Failed to get minimum total VFs for PF1 across workers")
+
+				pf2Total, err := sriovenv.GetMinTotalVFsAcrossWorkers(workerNodeList, pf2)
+				Expect(err).ToNot(HaveOccurred(), "Failed to get minimum total VFs for PF2 across workers")
+
+				if pf1Total < scaleTotalVFs || pf2Total < scaleTotalVFs {
+					Skip(fmt.Sprintf(
+						"Scale test requires >=%d total VFs on each PF on every worker; min across workers: pf1=%d, pf2=%d",
+						scaleTotalVFs, pf1Total, pf2Total))
+				}
+
+				By("Removing functional bond SR-IOV policies before scale setup")
+
+				Expect(deleteBondSriovPolicies(bondFunctionalPolicyNames)).To(Succeed(),
+					"Failed to remove functional bond SR-IOV policies before scale tests")
+
+				By("Creating shared SR-IOV policies and networks for 16-VF scale tests")
+
+				// Match functional policy NumVfs (PF total across workers) so scale setup does not
+				// change configured VF count after removing functional policies.
+				createBondScalePolicies(mtu1280, 0, pf1Total, pf2Total)
+
+				err = sriovenv.CreateSriovBondNetwork(scaleNetA, scaleResA)
+				Expect(err).ToNot(HaveOccurred(), "Failed to create scale SR-IOV network A")
+
+				err = sriovenv.CreateSriovBondNetwork(scaleNetB, scaleResB)
+				Expect(err).ToNot(HaveOccurred(), "Failed to create scale SR-IOV network B")
+
+				err = sriovoperator.WaitForSriovAndMCPStable(
+					APIClient, tsparams.MCOWaitTimeout, tsparams.DefaultStableDuration,
+					NetConfig.CnfMcpLabel, NetConfig.SriovOperatorNamespace)
+				Expect(err).ToNot(HaveOccurred(), "Failed waiting for SR-IOV and MCP stability for scale policies")
+			})
+
+			AfterAll(func() {
+				deleteBondNADBestEffort(scaleBondNADIPv4)
+				deleteBondNADBestEffort(scaleBondNADIPv6)
+			})
+
+			AfterEach(func() {
+				deleteBondNADBestEffort(scaleBondNADIPv4)
+				deleteBondNADBestEffort(scaleBondNADIPv6)
+			})
+
+			runBondScaleICMPTest := func(
+				bondNAD, netA, netB string,
+				mtu int,
+				serverIP, clientIP, icmpPrefix string,
+			) {
+				By("Creating bond NAD with 16 slave links")
+
+				bondBuilder, err := sriovenv.CreateBondNAD(bondNAD, scaleBondMode, "static", mtu, scaleSlaveCount)
+				Expect(err).ToNot(HaveOccurred(), "Failed to build scale bond NAD")
+
+				_, err = bondBuilder.Create()
+				Expect(err).ToNot(HaveOccurred(), "Failed to create scale bond NAD")
+
+				By("Creating slave network list (8 from each SR-IOV network)")
+
+				var slaveNetworks []string
+
+				for idx := 0; idx < scaleSlaveCount/2; idx++ {
+					slaveNetworks = append(slaveNetworks, netA)
+				}
+
+				for idx := 0; idx < scaleSlaveCount/2; idx++ {
+					slaveNetworks = append(slaveNetworks, netB)
+				}
+
+				serverNode := workerNodeList[0].Definition.Name
+				clientNode := workerNodeList[1].Definition.Name
+
+				_, clientPod := createBondedPodsPair(
+					bondNAD,
+					"bond-scale-server", "bond-scale-client",
+					serverNode, clientNode,
+					slaveNetworks, serverIP, clientIP, mtu,
+				)
+
+				By("Verifying bond interface is up, has correct mode and slave count")
+				Expect(sriovenv.VerifyBondInterfaceState(
+					clientPod, sriovenv.BondInterfaceName, scaleBondMode, scaleSlaveCount)).
+					To(Succeed(), "Bond interface validation failed")
+
+				By("Running ICMP connectivity over the bond")
+
+				serverIPNoPrefix := ipaddr.RemovePrefix(serverIP)
+				Expect(cmd.ICMPConnectivityCheck(clientPod, []string{serverIPNoPrefix + icmpPrefix}, sriovenv.BondInterfaceName)).
+					To(Succeed(), "ICMP connectivity over bond failed")
+			}
+
+			It("Verify bond with 16 VFs works with ICMP traffic IPv4", reportxml.ID("89056"), func() {
+				if !netenv.ClusterSupportsIPv4(clusterIPFamily) {
+					Skip("Cluster does not support IPv4 - skipping SR-IOV bond IPv4 scale test")
+				}
+
+				runBondScaleICMPTest(
+					scaleBondNADIPv4, scaleNetA, scaleNetB,
+					mtu1280,
+					tsparams.ServerIPv4IPAddress, tsparams.ClientIPv4IPAddress, "/32",
+				)
+			})
+
+			It("Verify bond with 16 VFs works with ICMP traffic IPv6", reportxml.ID("89068"), func() {
+				if !netenv.ClusterSupportsIPv6(clusterIPFamily) {
+					Skip("Cluster does not support IPv6 - skipping SR-IOV bond IPv6 scale test")
+				}
+
+				runBondScaleICMPTest(
+					scaleBondNADIPv6, scaleNetA, scaleNetB,
+					mtu1280,
+					tsparams.ServerIPv6IPAddress, tsparams.ClientIPv6IPAddress, "/128",
+				)
+			})
+		})
+	})
+
+var (
+	// SR-IOV networks used as bond slaves per family/mtu/connectivity.
+	// DiffPF = one slave backed by PF1 resource and one by PF2 resource.
+	// SamePF = both slaves backed by PF1 resource (two distinct networks).
+	// Small = MTU 1280; Jumbo = MTU 9000. Shared SR-IOV policies serve both IPv4 and IPv6 bond tests.
+	bondNetworksV4DiffPFSmall = []string{"sriov-bond-v4-diffpf-small-pf1", "sriov-bond-v4-diffpf-small-pf2"}
+	bondNetworksV4DiffPFJumbo = []string{"sriov-bond-v4-diffpf-jumbo-pf1", "sriov-bond-v4-diffpf-jumbo-pf2"}
+	bondNetworksV4SamePFSmall = []string{"sriov-bond-v4-samepf-small-a", "sriov-bond-v4-samepf-small-b"}
+	bondNetworksV4SamePFJumbo = []string{"sriov-bond-v4-samepf-jumbo-a", "sriov-bond-v4-samepf-jumbo-b"}
+
+	bondNetworksV6DiffPFSmall = []string{"sriov-bond-v6-diffpf-small-pf1", "sriov-bond-v6-diffpf-small-pf2"}
+	bondNetworksV6DiffPFJumbo = []string{"sriov-bond-v6-diffpf-jumbo-pf1", "sriov-bond-v6-diffpf-jumbo-pf2"}
+	bondNetworksV6SamePFSmall = []string{"sriov-bond-v6-samepf-small-a", "sriov-bond-v6-samepf-small-b"}
+	bondNetworksV6SamePFJumbo = []string{"sriov-bond-v6-samepf-jumbo-a", "sriov-bond-v6-samepf-jumbo-b"}
+)
+
+//nolint:unparam // mtu values are fixed by the suite's MTU matrix.
+func runBondScenario(
+	bondMode string,
+	mtuSmall int,
+	mtuLarge int,
+	serverIPSmall string,
+	clientIPSmall string,
+	serverIPLarge string,
+	clientIPLarge string,
+	serverNode string,
+	clientNode string,
+	slaveNetworksSmall []string,
+	slaveNetworksLarge []string,
+) {
+	nadSmall := bondNADNameFor(bondMode, mtuSmall)
+	nadLarge := bondNADNameFor(bondMode, mtuLarge)
+
+	By("Creating bond NADs for both MTUs")
+
+	deleteBondNADBestEffort(nadSmall)
+	deleteBondNADBestEffort(nadLarge)
+
+	bondSmall, err := sriovenv.CreateBondNAD(nadSmall, bondMode, "static", mtuSmall, 2)
+	Expect(err).ToNot(HaveOccurred(), "Failed to build small MTU bond NAD")
+
+	_, err = bondSmall.Create()
+	Expect(err).ToNot(HaveOccurred(), "Failed to create small MTU bond NAD")
+
+	defer func() { deleteBondNADBestEffort(nadSmall) }()
+
+	bondLarge, err := sriovenv.CreateBondNAD(nadLarge, bondMode, "static", mtuLarge, 2)
+	Expect(err).ToNot(HaveOccurred(), "Failed to build large MTU bond NAD")
+
+	_, err = bondLarge.Create()
+	Expect(err).ToNot(HaveOccurred(), "Failed to create large MTU bond NAD")
+
+	defer func() { deleteBondNADBestEffort(nadLarge) }()
+
+	modeSuffix := strings.ReplaceAll(bondMode, "balance-", "")
+	serverSmallName := fmt.Sprintf("bond-server-%s-mtu%d", modeSuffix, mtuSmall)
+	clientSmallName := fmt.Sprintf("bond-client-%s-mtu%d", modeSuffix, mtuSmall)
+	serverLargeName := fmt.Sprintf("bond-server-%s-mtu%d", modeSuffix, mtuLarge)
+	clientLargeName := fmt.Sprintf("bond-client-%s-mtu%d", modeSuffix, mtuLarge)
+
+	By("Creating server and client pods for both MTUs (4 pods total)")
+
+	_, clientSmall := createBondedPodsPair(
+		nadSmall,
+		serverSmallName, clientSmallName,
+		serverNode, clientNode,
+		slaveNetworksSmall, serverIPSmall, clientIPSmall, mtuSmall,
+	)
+	_, clientLarge := createBondedPodsPair(
+		nadLarge,
+		serverLargeName, clientLargeName,
+		serverNode, clientNode,
+		slaveNetworksLarge, serverIPLarge, clientIPLarge, mtuLarge,
+	)
+
+	By("Verifying traffic on bond interface for both MTUs")
+	Expect(verifyInitialBondTraffic(bondMode, clientSmall, serverIPSmall, mtuSmall, "small MTU", false)).
+		To(Succeed(), "Bond initial traffic failed (small MTU)")
+	Expect(verifyInitialBondTraffic(bondMode, clientLarge, serverIPLarge, mtuLarge, "large MTU", false)).
+		To(Succeed(), "Bond initial traffic failed (large MTU)")
+
+	By("Triggering link failure and verifying traffic still works for both MTUs")
+	Expect(triggerBondLinkFailureAndVerify(clientSmall, bondMode, serverIPSmall, mtuSmall)).
+		To(Succeed(), "Bond link failure verification failed (small MTU)")
+	Expect(triggerBondLinkFailureAndVerify(clientLarge, bondMode, serverIPLarge, mtuLarge)).
+		To(Succeed(), "Bond link failure verification failed (large MTU)")
+}
+
+func verifyInitialBondTraffic(
+	bondMode string,
+	clientPod *pod.Builder,
+	serverIP string,
+	mtu int,
+	desc string,
+	afterFailover bool,
+) error {
+	timeout := tsparams.WaitTimeout
+	pollInterval := tsparams.NADWaitTimeout
+
+	check := func() error {
+		return sriovenv.RunTrafficTest(clientPod, serverIP, mtu, sriovenv.BondInterfaceName)
+	}
+
+	if afterFailover {
+		timeout = sriovenv.BondActiveSlaveChangeTimeout
+		pollInterval = time.Second
+		check = func() error {
+			return runBondConnectivityAfterFailover(clientPod, serverIP, mtu, bondMode)
+		}
+
+		if bondMode == sriovenv.BondModeBalanceXOR {
+			timeout = 2 * time.Minute
+			pollInterval = tsparams.NADWaitTimeout
+		}
+	}
+
+	deadline := time.Now().Add(timeout)
+
+	var lastErr error
+
+	for {
+		lastErr = check()
+		if lastErr == nil {
+			return nil
+		}
+
+		if time.Now().After(deadline) {
+			if afterFailover {
+				return fmt.Errorf("bond traffic failed after failover (%s) within %v: %w", desc, timeout, lastErr)
+			}
+
+			return fmt.Errorf("traffic tests failed on bond interface (%s, mode %s) within %v: %w",
+				desc, bondMode, timeout, lastErr)
+		}
+
+		time.Sleep(pollInterval)
+	}
+}
+
+func createBondedPodsPair(
+	nadName string,
+	serverName, clientName,
+	serverNode, clientNode string,
+	slaveNetworks []string,
+	serverIPWithCIDR, clientIPWithCIDR string,
+	mtu int,
+) (*pod.Builder, *pod.Builder) {
+	annotationServer := pod.StaticIPBondAnnotationWithInterface(
+		nadName,
+		sriovenv.BondInterfaceName,
+		slaveNetworks,
+		[]string{serverIPWithCIDR},
+	)
+	Expect(annotationServer).NotTo(BeNil(), "Failed to create bond annotation for server pod")
+
+	annotationClient := pod.StaticIPBondAnnotationWithInterface(
+		nadName,
+		sriovenv.BondInterfaceName,
+		slaveNetworks,
+		[]string{clientIPWithCIDR},
+	)
+	Expect(annotationClient).NotTo(BeNil(), "Failed to create bond annotation for client pod")
+
+	serverBindIP := ipaddr.RemovePrefix(serverIPWithCIDR)
+	serverCmd := sriovenv.BuildServerCommand(serverBindIP, sriovenv.BondInterfaceName, mtu)
+
+	serverContainer, err := pod.NewContainerBuilder("server", NetConfig.CnfNetTestContainer, serverCmd).GetContainerCfg()
+	Expect(err).ToNot(HaveOccurred(), "Failed to build server container config")
+
+	serverPodBuilder := pod.NewBuilder(APIClient, serverName, tsparams.TestNamespaceName, NetConfig.CnfNetTestContainer)
+
+	serverPod, err := serverPodBuilder.
+		DefineOnNode(serverNode).
+		RedefineDefaultContainer(*serverContainer).
+		WithPrivilegedFlag().
+		WithSecondaryNetwork(annotationServer).
+		CreateAndWaitUntilRunning(netparam.DefaultTimeout)
+	Expect(err).ToNot(HaveOccurred(), "Failed to create server pod")
+
+	Expect(sriovenv.WaitForServerReady(serverPod, tsparams.WaitTimeout)).
+		To(Succeed(), "Server pod testcmd listeners not ready")
+
+	clientPodBuilder := pod.NewBuilder(APIClient, clientName, tsparams.TestNamespaceName, NetConfig.CnfNetTestContainer)
+
+	clientPod, err := clientPodBuilder.
+		DefineOnNode(clientNode).
+		WithPrivilegedFlag().
+		WithSecondaryNetwork(annotationClient).
+		CreateAndWaitUntilRunning(netparam.DefaultTimeout)
+	Expect(err).ToNot(HaveOccurred(), "Failed to create client pod")
+
+	Expect(sriovenv.WaitForBondSlavesMIIUp(serverPod, sriovenv.BondInterfaceName)).
+		To(Succeed(), "Server bond slaves not MII up in pod %s", serverName)
+	Expect(sriovenv.WaitForBondSlavesMIIUp(clientPod, sriovenv.BondInterfaceName)).
+		To(Succeed(), "Client bond slaves not MII up in pod %s", clientName)
+
+	return serverPod, clientPod
+}
+
+// bondNetworkConfig describes a single SR-IOV network for bond slave creation.
+type bondNetworkConfig struct {
+	name,
+	resource string
+}
+
+type bondStackParams struct {
+	pf1,
+	pf2 string
+	pf1NumVFs,
+	pf2NumVFs int
+	vfSmallStart,
+	vfSmallEnd,
+	vfLargeStart,
+	vfLargeEnd int
+	networks []bondNetworkConfig
+}
+
+// bondFunctionalPolicyNames are the shared MTU-split policies created by setupBondStack.
+var bondFunctionalPolicyNames = []string{
+	"bond-policy-pf1-mtu1280",
+	"bond-policy-pf1-mtu9000",
+	"bond-policy-pf2-mtu1280",
+	"bond-policy-pf2-mtu9000",
+}
+
+// bondSriovPolicyNames lists bond suite policy names from current and prior revisions.
+var bondSriovPolicyNames = []string{
+	"ipv4-policy-pf1-mtu500",
+	"ipv4-policy-pf1-mtu9000",
+	"ipv4-policy-pf2-mtu500",
+	"ipv4-policy-pf2-mtu9000",
+	"ipv6-policy-pf1-mtu1280",
+	"ipv6-policy-pf1-mtu9000",
+	"ipv6-policy-pf2-mtu1280",
+	"ipv6-policy-pf2-mtu9000",
+	"bond-policy-pf1-mtu1280",
+	"bond-policy-pf1-mtu9000",
+	"bond-policy-pf2-mtu1280",
+	"bond-policy-pf2-mtu9000",
+	"bond-scale-policy-pf1",
+	"bond-scale-policy-pf2",
+	"bond-scale-policy-pf1-ipv6",
+	"bond-scale-policy-pf2-ipv6",
+}
+
+func deleteBondSriovPolicies(policyNames []string) error {
+	deleted := false
+
+	for _, name := range policyNames {
+		policy, pullErr := sriov.PullPolicy(APIClient, name, NetConfig.SriovOperatorNamespace)
+		if pullErr != nil {
+			continue
+		}
+
+		if err := policy.Delete(); err != nil {
+			return fmt.Errorf("failed to delete SR-IOV policy %s: %w", name, err)
+		}
+
+		deleted = true
+	}
+
+	if !deleted {
+		return nil
+	}
+
+	return sriovoperator.WaitForSriovAndMCPStable(
+		APIClient, tsparams.MCOWaitTimeout, tsparams.DefaultStableDuration,
+		NetConfig.CnfMcpLabel, NetConfig.SriovOperatorNamespace)
+}
+
+func cleanupStaleBondSriovPolicies() error {
+	return deleteBondSriovPolicies(bondSriovPolicyNames)
+}
+
+// selectBondVFLayout returns VF ranges for shared 1280/9000 bond policies on each PF.
+func selectBondVFLayout(minTotal int) (vfSmallEnd, vfLargeStart, vfLargeEnd int, ok bool) {
+	if minTotal < bondMinVFsPerPF {
+		return 0, 0, 0, false
+	}
+
+	switch {
+	case minTotal >= bondMinVFsStandardLayout:
+		// Standard layout: small MTU VFs 0-4, jumbo MTU VFs 5-9.
+		return 4, 5, 9, true
+	default:
+		// Five-VF layout: small MTU VFs 0-1, jumbo MTU VFs 2-4.
+		return 1, 2, 4, true
+	}
+}
+
+func setupBondStack(params bondStackParams) {
+	By("Creating shared SR-IOV policies and networks for bond tests")
+
+	policies := []struct {
+		pfSuffix string
+		resource string
+		pf       string
+		numVFs   int
+		mtu      int
+		vfStart  int
+		vfEnd    int
+	}{
+		{"pf1", bondResourcePF1Small, params.pf1, params.pf1NumVFs, mtu1280, params.vfSmallStart, params.vfSmallEnd},
+		{"pf1", bondResourcePF1Jumbo, params.pf1, params.pf1NumVFs, mtu9000, params.vfLargeStart, params.vfLargeEnd},
+		{"pf2", bondResourcePF2Small, params.pf2, params.pf2NumVFs, mtu1280, params.vfSmallStart, params.vfSmallEnd},
+		{"pf2", bondResourcePF2Jumbo, params.pf2, params.pf2NumVFs, mtu9000, params.vfLargeStart, params.vfLargeEnd},
+	}
+
+	for _, policy := range policies {
+		policyName := fmt.Sprintf("bond-policy-%s-mtu%d", policy.pfSuffix, policy.mtu)
+
+		Expect(sriovenv.CreateSriovPolicy(
+			policyName, policy.resource, policy.pf, policy.mtu, policy.vfStart, policy.vfEnd, policy.numVFs,
+		)).To(Succeed(), "Failed to create bond %s MTU%d policy", policy.pfSuffix, policy.mtu)
+	}
+
+	Expect(sriovoperator.WaitForSriovAndMCPStable(
+		APIClient, tsparams.MCOWaitTimeout, tsparams.DefaultStableDuration,
+		NetConfig.CnfMcpLabel, NetConfig.SriovOperatorNamespace)).
+		To(Succeed(), "Failed to wait for SR-IOV and MCP stability after bond policies")
+
+	Expect(createBondSlaveNetworks(params.networks)).
+		To(Succeed(), "Failed to create bond slave networks")
+}
+
+func bondSlaveNetworkConfigs(
+	diffPFSmall,
+	diffPFJumbo,
+	samePFSmall,
+	samePFJumbo []string,
+	resPF1Small,
+	resPF1Jumbo,
+	resPF2Small,
+	resPF2Jumbo string,
+) []bondNetworkConfig {
+	return []bondNetworkConfig{
+		{name: diffPFSmall[0], resource: resPF1Small},
+		{name: diffPFJumbo[0], resource: resPF1Jumbo},
+		{name: diffPFSmall[1], resource: resPF2Small},
+		{name: diffPFJumbo[1], resource: resPF2Jumbo},
+		{name: samePFSmall[0], resource: resPF1Small},
+		{name: samePFSmall[1], resource: resPF1Small},
+		{name: samePFJumbo[0], resource: resPF1Jumbo},
+		{name: samePFJumbo[1], resource: resPF1Jumbo},
+	}
+}
+
+// createBondSlaveNetworks creates bond slave SriovNetworks without IPAM (Trust on, SpoofChk off, LinkState auto).
+func createBondSlaveNetworks(configs []bondNetworkConfig) error {
+	for _, cfg := range configs {
+		if err := sriovenv.CreateSriovBondNetwork(cfg.name, cfg.resource); err != nil {
+			return fmt.Errorf("failed to create network %s: %w", cfg.name, err)
+		}
+	}
+
+	return nil
+}
+
+func bondICMPDestination(serverIPWithCIDR string) string {
+	ipNoPrefix := ipaddr.RemovePrefix(serverIPWithCIDR)
+	if net.ParseIP(ipNoPrefix).To4() == nil {
+		return ipNoPrefix + "/128"
+	}
+
+	return ipNoPrefix + "/32"
+}
+
+// runBondConnectivityAfterFailover validates reachability after a slave/link failure.
+// Balance modes use ICMP only (TCP can flake during rebalance); active-backup keeps full traffic tests.
+func runBondConnectivityAfterFailover(clientPod *pod.Builder, serverIP string, mtu int, bondMode string) error {
+	if bondMode == sriovenv.BondModeActiveBackup {
+		return sriovenv.RunTrafficTest(clientPod, serverIP, mtu, sriovenv.BondInterfaceName)
+	}
+
+	return cmd.ICMPConnectivityCheck(clientPod, []string{bondICMPDestination(serverIP)}, sriovenv.BondInterfaceName)
+}
+
+func bondPeerSlave(slave string) string {
+	if slave == sriovenv.BondSlave1IfName {
+		return sriovenv.BondSlave2IfName
+	}
+
+	return sriovenv.BondSlave1IfName
+}
+
+func triggerBondLinkFailureAndVerify(clientPod *pod.Builder, bondMode, serverIP string, mtu int) error {
+	if bondMode == sriovenv.BondModeActiveBackup {
+		return verifyActiveBackupBondFailover(clientPod, bondMode, serverIP, mtu)
+	}
+
+	switchErr := toggleSwitchPortsAndVerifyTraffic(clientPod, serverIP, mtu, bondMode)
+	if switchErr == nil {
+		return nil
+	}
+
+	klog.V(90).Infof("Switch-based link failure check failed (%v), falling back to pod slave link toggle", switchErr)
+
+	return verifyPodSlaveToggleFailover(clientPod, bondMode, serverIP, mtu)
+}
+
+func verifyActiveBackupBondFailover(clientPod *pod.Builder, bondMode, serverIP string, mtu int) error {
+	active, err := sriovenv.GetBondActiveSlave(clientPod, sriovenv.BondInterfaceName)
+	if err != nil {
+		return err
+	}
+
+	if err := verifyBondSlaveFailover(clientPod, bondMode, serverIP, mtu, active, "after failover",
+		func() error {
+			_, waitErr := sriovenv.WaitForBondActiveSlaveChange(clientPod, sriovenv.BondInterfaceName, active)
+
+			return waitErr
+		},
+	); err != nil {
+		return err
+	}
+
+	secondary := bondPeerSlave(active)
+
+	return verifyBondSlaveFailover(clientPod, bondMode, serverIP, mtu, secondary,
+		"after secondary failover",
+		func() error {
+			return sriovenv.WaitForBondSlaveMIIDown(clientPod, sriovenv.BondInterfaceName, secondary)
+		},
+	)
+}
+
+func verifyPodSlaveToggleFailover(clientPod *pod.Builder, bondMode, serverIP string, mtu int) error {
+	for _, slave := range []string{sriovenv.BondSlave1IfName, sriovenv.BondSlave2IfName} {
+		if err := verifyBondSlaveFailover(clientPod, bondMode, serverIP, mtu, slave, "after failover",
+			func() error {
+				return sriovenv.WaitForBondSlaveMIIDown(clientPod, sriovenv.BondInterfaceName, slave)
+			},
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func verifyBondSlaveFailover(
+	clientPod *pod.Builder,
+	bondMode, serverIP string,
+	mtu int,
+	slave, trafficLabel string,
+	waitAfterDown func() error,
+) error {
+	if err := sriovenv.SetLinkStatus(clientPod, slave, "down"); err != nil {
+		return fmt.Errorf("failed to bring slave %s down: %w", slave, err)
+	}
+
+	if waitAfterDown != nil {
+		if err := waitAfterDown(); err != nil {
+			return err
+		}
+	}
+
+	if err := verifyInitialBondTraffic(bondMode, clientPod, serverIP, mtu, trafficLabel, true); err != nil {
+		return fmt.Errorf("traffic failed %s: %w", trafficLabel, err)
+	}
+
+	if err := sriovenv.SetLinkStatus(clientPod, slave, "up"); err != nil {
+		return fmt.Errorf("failed to bring slave %s up: %w", slave, err)
+	}
+
+	if err := sriovenv.WaitForBondSlavesMIIUp(clientPod, sriovenv.BondInterfaceName); err != nil {
+		return fmt.Errorf("bond did not recover after bringing %s up: %w", slave, err)
+	}
+
+	return nil
+}
+
+func waitForSwitchInterfaceUp(jnpr *cmd.Junos, switchInterface string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+
+	for {
+		up, err := jnpr.IsSwitchInterfaceUp(switchInterface)
+		if err == nil && up {
+			return nil
+		}
+
+		if time.Now().After(deadline) {
+			if err != nil {
+				return fmt.Errorf("switch interface %s not up within %v: %w", switchInterface, timeout, err)
+			}
+
+			return fmt.Errorf("switch interface %s not up within %v", switchInterface, timeout)
+		}
+
+		time.Sleep(tsparams.NADWaitTimeout)
+	}
+}
+
+// toggleSwitchPortsAndVerifyTraffic mirrors cnf-gotests TestActiveActiveBondScenario switch failover:
+// disable first LAG member, verify traffic, re-enable it, disable second member, wait for ae up, verify again.
+func toggleSwitchPortsAndVerifyTraffic(clientPod *pod.Builder, serverIP string, mtu int, bondMode string) error {
+	if bondSwitchCredentials == nil || len(bondSwitchInterfaces) < 2 || len(bondSwitchLagNames) < 1 {
+		return fmt.Errorf("switch LAG not configured (need credentials, 2+ interfaces, LAG name)")
+	}
+
+	jnpr, err := cmd.NewSession(
+		bondSwitchCredentials.SwitchIP, bondSwitchCredentials.User, bondSwitchCredentials.Password)
+	if err != nil {
+		return err
+	}
+	defer jnpr.Close()
+
+	disable := func(iface string) error {
+		return jnpr.Config([]string{fmt.Sprintf("set interfaces %s disable", iface)})
+	}
+	enable := func(iface string) error {
+		return jnpr.Config([]string{fmt.Sprintf("delete interfaces %s disable", iface)})
+	}
+	restoreSwitchPortBestEffort := func(iface string) {
+		if restoreErr := enable(iface); restoreErr != nil {
+			klog.Warningf("best-effort switch restore failed for %s: %v", iface, restoreErr)
+		}
+	}
+
+	firstPort := bondSwitchInterfaces[0]
+	secondPort := bondSwitchInterfaces[1]
+	lagName := bondSwitchLagNames[0]
+
+	if err := disable(firstPort); err != nil {
+		return fmt.Errorf("failed to disable switch interface %s: %w", firstPort, err)
+	}
+
+	if err := verifyInitialBondTraffic(bondMode, clientPod, serverIP, mtu, "after failover", true); err != nil {
+		restoreSwitchPortBestEffort(firstPort)
+
+		return fmt.Errorf("traffic failed after disabling switch port %s: %w", firstPort, err)
+	}
+
+	if err := enable(firstPort); err != nil {
+		return fmt.Errorf("failed to re-enable switch interface %s: %w", firstPort, err)
+	}
+
+	if err := disable(secondPort); err != nil {
+		return fmt.Errorf("failed to disable switch interface %s: %w", secondPort, err)
+	}
+
+	if err := waitForSwitchInterfaceUp(jnpr, lagName, time.Minute); err != nil {
+		restoreSwitchPortBestEffort(secondPort)
+
+		return err
+	}
+
+	if err := verifyInitialBondTraffic(bondMode, clientPod, serverIP, mtu, "after failover", true); err != nil {
+		restoreSwitchPortBestEffort(secondPort)
+
+		return fmt.Errorf("traffic failed after disabling switch port %s: %w", secondPort, err)
+	}
+
+	if err := enable(secondPort); err != nil {
+		return fmt.Errorf("failed to re-enable switch interface %s: %w", secondPort, err)
+	}
+
+	if err := sriovenv.WaitForBondSlavesMIIUp(clientPod, sriovenv.BondInterfaceName); err != nil {
+		return fmt.Errorf("bond did not recover after switch failover: %w", err)
+	}
+
+	return nil
+}
+
+func bondNADNameFor(bondMode string, mtu int) string {
+	return fmt.Sprintf("%s-%s-mtu%d", bondNADName, bondMode, mtu)
+}
+
+func bondNADNamesForCleanup() []string {
+	modes := []string{
+		sriovenv.BondModeActiveBackup,
+		sriovenv.BondModeBalanceRR,
+		sriovenv.BondModeBalanceXOR,
+	}
+	mtus := []int{mtu1280, mtu9000}
+
+	seen := make(map[string]struct{})
+
+	var names []string
+
+	add := func(name string) {
+		if _, exists := seen[name]; exists {
+			return
+		}
+
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+
+	for _, mode := range modes {
+		for _, mtu := range mtus {
+			add(bondNADNameFor(mode, mtu))
+		}
+	}
+
+	// Legacy MTU-only NAD names from earlier revisions.
+	add(bondNADName)
+
+	for _, mtu := range mtus {
+		add(fmt.Sprintf("%s-mtu%d", bondNADName, mtu))
+	}
+
+	return names
+}
+
+func setupBondSwitchLAGForActiveActiveTests() error {
+	var err error
+
+	if bondSwitchCredentials == nil {
+		bondSwitchCredentials, err = sriovenv.NewSwitchCredentials()
+		if err != nil {
+			return fmt.Errorf("switch credentials: %w", err)
+		}
+	}
+
+	bondSwitchInterfaces, err = NetConfig.GetSwitchInterfaces()
+	if err != nil {
+		return fmt.Errorf("switch interfaces: %w", err)
+	}
+
+	if len(bondSwitchInterfaces) != bondMinSwitchInterfaces {
+		return fmt.Errorf("need %d switch interfaces (ECO_CNF_CORE_NET_SWITCH_INTERFACES), got %d",
+			bondMinSwitchInterfaces, len(bondSwitchInterfaces))
+	}
+
+	bondSwitchLagNames, err = NetConfig.GetSwitchLagNames()
+	if err != nil {
+		return fmt.Errorf("switch LAG names: %w", err)
+	}
+
+	nativeVLAN, err := NetConfig.GetNativeVLANID()
+	if err != nil {
+		return fmt.Errorf("native VLAN: %w", err)
+	}
+
+	klog.Infof("Bond switch LAG native VLAN %d", nativeVLAN)
+
+	bondSwitchSavedConfigs, err = configureStaticLAGsOnSwitch(
+		bondSwitchCredentials, bondSwitchInterfaces, bondSwitchLagNames)
+	if err != nil {
+		if len(bondSwitchSavedConfigs) > 0 {
+			if restoreErr := restoreBondSwitchLAG(
+				bondSwitchCredentials, bondSwitchInterfaces, bondSwitchLagNames, bondSwitchSavedConfigs,
+			); restoreErr != nil {
+				return fmt.Errorf("configure static LAGs: %w (restore failed: %w)", err, restoreErr)
+			}
+
+			bondSwitchSavedConfigs = nil
+		}
+
+		return fmt.Errorf("configure static LAGs: %w", err)
+	}
+
+	klog.Infof("Configured static switch LAGs %v on ports %v", bondSwitchLagNames, bondSwitchInterfaces)
+
+	return nil
+}
+
+func restoreBondSwitchLAGAfterActiveActiveTest() {
+	if len(bondSwitchSavedConfigs) == 0 || bondSwitchCredentials == nil {
+		return
+	}
+
+	By("Restoring lab switch configuration after active-active bond test")
+
+	err := restoreBondSwitchLAG(
+		bondSwitchCredentials, bondSwitchInterfaces, bondSwitchLagNames, bondSwitchSavedConfigs)
+	Expect(err).ToNot(HaveOccurred(), "Failed to restore lab switch configuration after active-active bond test")
+
+	bondSwitchSavedConfigs = nil
+}
+
+func bondStaticLAGCleanupCommands(physicalInterfaces, lagInterfaces []string) []string {
+	var cleanupCommands []string
+
+	for _, physicalInterface := range physicalInterfaces {
+		cleanupCommands = append(cleanupCommands,
+			fmt.Sprintf("delete interfaces %s ether-options 802.3ad", physicalInterface))
+	}
+
+	for _, lagInterface := range lagInterfaces {
+		cleanupCommands = append(cleanupCommands, fmt.Sprintf("delete interfaces %s", lagInterface))
+	}
+
+	for _, physicalInterface := range physicalInterfaces {
+		cleanupCommands = append(cleanupCommands, fmt.Sprintf("delete interfaces %s", physicalInterface))
+	}
+
+	return cleanupCommands
+}
+
+// configureStaticLAGsOnSwitch mirrors cnf-gotests configureLAGsOnSwitch: wipe the four physical
+// ports, create two static (non-LACP) 802.3ad LAGs, and trunk lab VLANs on each ae.
+func configureStaticLAGsOnSwitch(
+	credentials *sriovenv.SwitchCredentials,
+	physicalInterfaces, lagInterfaces []string,
+) ([]string, error) {
+	if len(physicalInterfaces) != bondMinSwitchInterfaces {
+		return nil, fmt.Errorf("need %d switch interfaces, got %d", bondMinSwitchInterfaces, len(physicalInterfaces))
+	}
+
+	if len(lagInterfaces) != 2 {
+		return nil, fmt.Errorf("need 2 switch LAG names, got %d", len(lagInterfaces))
+	}
+
+	jnpr, err := cmd.NewSession(credentials.SwitchIP, credentials.User, credentials.Password)
+	if err != nil {
+		return nil, err
+	}
+	defer jnpr.Close()
+
+	savedConfigs, err := jnpr.SaveInterfaceConfigs(physicalInterfaces)
+	if err != nil {
+		return nil, fmt.Errorf("save switch interface configs: %w", err)
+	}
+
+	cleanupCommands := bondStaticLAGCleanupCommands(physicalInterfaces, lagInterfaces)
+
+	if len(cleanupCommands) > 0 {
+		if err := jnpr.Config(cleanupCommands); err != nil {
+			return savedConfigs, fmt.Errorf("clean switch interfaces before LAG setup: %w", err)
+		}
+	}
+
+	vlan, err := NetConfig.GetNativeVLANID()
+	if err != nil {
+		return rollbackBondSwitchLAGSetup(
+			credentials, physicalInterfaces, lagInterfaces, savedConfigs,
+			fmt.Errorf("native VLAN: %w", err))
+	}
+
+	lagMembers := [][2]string{
+		{physicalInterfaces[0], physicalInterfaces[1]},
+		{physicalInterfaces[2], physicalInterfaces[3]},
+	}
+
+	var configureCommands []string
+
+	for idx, lagInterface := range lagInterfaces {
+		for _, physicalInterface := range lagMembers[idx] {
+			configureCommands = append(configureCommands,
+				fmt.Sprintf("set interfaces %s ether-options 802.3ad %s", physicalInterface, lagInterface))
+		}
+
+		configureCommands = append(configureCommands,
+			fmt.Sprintf("set interfaces %s aggregated-ether-options lacp disable", lagInterface),
+			fmt.Sprintf("set interfaces %s unit 0 family ethernet-switching interface-mode trunk", lagInterface),
+			fmt.Sprintf("set interfaces %s unit 0 family ethernet-switching interface-mode trunk vlan "+
+				"members vlan%d", lagInterface, vlan),
+			fmt.Sprintf("set interfaces %s native-vlan-id %d", lagInterface, vlan),
+			fmt.Sprintf("set interfaces %s mtu 9216", lagInterface),
+		)
+	}
+
+	if err := jnpr.Config(configureCommands); err != nil {
+		return rollbackBondSwitchLAGSetup(
+			credentials, physicalInterfaces, lagInterfaces, savedConfigs,
+			fmt.Errorf("configure static LAGs: %w", err))
+	}
+
+	return savedConfigs, nil
+}
+
+func rollbackBondSwitchLAGSetup(
+	credentials *sriovenv.SwitchCredentials,
+	physicalInterfaces, lagInterfaces, savedConfigs []string,
+	setupErr error,
+) ([]string, error) {
+	klog.Warningf("Bond switch LAG setup failed, restoring saved interface configs: %v", setupErr)
+
+	if restoreErr := restoreBondSwitchLAG(
+		credentials, physicalInterfaces, lagInterfaces, savedConfigs,
+	); restoreErr != nil {
+		return savedConfigs, fmt.Errorf("%w (failed to restore switch interfaces: %w)", setupErr, restoreErr)
+	}
+
+	return savedConfigs, setupErr
+}
+
+func restoreBondSwitchLAG(
+	credentials *sriovenv.SwitchCredentials,
+	physicalInterfaces, lagInterfaces, savedConfigs []string,
+) error {
+	if credentials == nil || len(savedConfigs) == 0 {
+		return nil
+	}
+
+	jnpr, err := cmd.NewSession(credentials.SwitchIP, credentials.User, credentials.Password)
+	if err != nil {
+		return err
+	}
+	defer jnpr.Close()
+
+	if len(lagInterfaces) > 0 && len(physicalInterfaces) > 0 {
+		if err := jnpr.DisableLACP(lagInterfaces, physicalInterfaces); err != nil {
+			klog.V(90).Infof("Failed to remove static LAG configuration from switch: %v", err)
+		}
+	}
+
+	return jnpr.RestoreInterfaceConfigs(savedConfigs)
+}
+
+func deleteBondNADIfExists(name string) error {
+	nadBuilder := nad.NewBuilder(APIClient, name, tsparams.TestNamespaceName)
+
+	_, err := nadBuilder.Get()
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	return nadBuilder.Delete()
+}
+
+func deleteBondNADBestEffort(name string) {
+	if err := deleteBondNADIfExists(name); err != nil {
+		klog.Warningf("best-effort bond NAD cleanup failed for %s: %v", name, err)
+	}
+}


### PR DESCRIPTION
PR summary 
Adds a new SR-IOV Bond CNI “bond-mode” test suite for IPv4 and IPv6 in sriov-bond-mode.go, covering active-backup bonding with traffic validation (ICMP/TCP/UDP/SCTP/multicast) and bond failover scenarios.
Introduces a reusable SR-IOV helper sriovenv.CreateBondNAD to create Bond NADs, and updates the existing QinQ suite to reuse this shared bond setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an SR-IOV bond-mode test suite validating IPv4/IPv6 connectivity, failover behavior, and degraded/recovery states, including a “16 VFs” scale scenario.
  * Added a bond-mode test-selection label.
* **New Features**
  * Added reusable helpers for creating bond network attachments and for observing/validating bond state in pods (active slave, MII status, link readiness).
* **Refactor**
  * Updated existing bonding-related tests to use shared bond-mode constants and the new bond attachment helper; simplified bond NAD creation paths.
* **Chores**
  * Enhanced traffic testing to allow choosing the interface used for connectivity checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->