### PR TITLE
ocp-sriov: use VFNum instead of hardcoded values in SR-IOV tests

### DIFF
--- a/tests/ocp/sriov/tests/exposemtu.go
+++ b/tests/ocp/sriov/tests/exposemtu.go
@@ -93,7 +93,7 @@ var _ = Describe("SRIOV: Expose MTU:", Ordered, Label(tsparams.LabelExposeMTUTes
 			sriovAndResourceName5000,
 			SriovOcpConfig.SriovOperatorNamespace,
 			sriovAndResourceName5000,
-			5,
+			SriovOcpConfig.VFNum,
 			[]string{fmt.Sprintf("%s#0-1", sriovInterfacesUnderTest[0])}, SriovOcpConfig.WorkerLabelMap).
 			WithDevType("netdevice").WithMTU(5000).Create()
 		Expect(err).ToNot(HaveOccurred(), "Failed to configure SR-IOV policy with mtu 5000")
@@ -103,7 +103,7 @@ var _ = Describe("SRIOV: Expose MTU:", Ordered, Label(tsparams.LabelExposeMTUTes
 			sriovAndResourceName9000,
 			SriovOcpConfig.SriovOperatorNamespace,
 			sriovAndResourceName9000,
-			5,
+			SriovOcpConfig.VFNum,
 			[]string{fmt.Sprintf("%s#2-3", sriovInterfacesUnderTest[0])}, SriovOcpConfig.WorkerLabelMap).
 			WithDevType("netdevice").WithMTU(9000).Create()
 		Expect(err).ToNot(HaveOccurred(), "Failed to configure SR-IOV policy with mtu 9000")
@@ -176,7 +176,7 @@ func testExposeMTU(mtu int, interfacesUnderTest []string, devType string) {
 		sriovAndResourceNameExposeMTU,
 		SriovOcpConfig.SriovOperatorNamespace,
 		sriovAndResourceNameExposeMTU,
-		5,
+		SriovOcpConfig.VFNum,
 		interfacesUnderTest, SriovOcpConfig.WorkerLabelMap).WithDevType(devType).WithMTU(mtu)
 
 	err := sriovoperator.CreateSriovPolicyAndWaitUntilItsApplied(

--- a/tests/ocp/sriov/tests/metricsExporter.go
+++ b/tests/ocp/sriov/tests/metricsExporter.go
@@ -349,21 +349,21 @@ func defineMetricsPolicy(role, devType, nicVendor, pfName string, vfRange int) *
 	switch devType {
 	case "netdevice":
 		policy = sriov.NewPolicyBuilder(APIClient,
-			role+devType, SriovOcpConfig.OcpSriovOperatorNamespace, role+devType, 6, []string{pfName},
+			role+devType, SriovOcpConfig.OcpSriovOperatorNamespace, role+devType, SriovOcpConfig.VFNum, []string{pfName},
 			SriovOcpConfig.WorkerLabelMap).
 			WithDevType("netdevice").
 			WithVFRange(vfRange, vfRange)
 	case "vfiopci":
 		if nicVendor != tsparams.MlxVendorID {
 			policy = sriov.NewPolicyBuilder(APIClient,
-				role+devType, SriovOcpConfig.OcpSriovOperatorNamespace, role+devType, 6, []string{pfName},
+				role+devType, SriovOcpConfig.OcpSriovOperatorNamespace, role+devType, SriovOcpConfig.VFNum, []string{pfName},
 				SriovOcpConfig.WorkerLabelMap).
 				WithDevType("vfio-pci").
 				WithVFRange(vfRange, vfRange).
 				WithRDMA(false)
 		} else {
 			policy = sriov.NewPolicyBuilder(APIClient,
-				role+devType, SriovOcpConfig.OcpSriovOperatorNamespace, role+devType, 6, []string{pfName},
+				role+devType, SriovOcpConfig.OcpSriovOperatorNamespace, role+devType, SriovOcpConfig.VFNum, []string{pfName},
 				SriovOcpConfig.WorkerLabelMap).
 				WithDevType("netdevice").
 				WithVFRange(vfRange, vfRange).

--- a/tests/ocp/sriov/tests/reinstallation.go
+++ b/tests/ocp/sriov/tests/reinstallation.go
@@ -78,7 +78,7 @@ var _ = Describe("SRIOV Operator re-installation", Ordered, Label(tsparams.Label
 				sriovTestResourceName,
 				SriovOcpConfig.SriovOperatorNamespace,
 				sriovTestResourceName,
-				5,
+				SriovOcpConfig.VFNum,
 				[]string{sriovInterfacesUnderTest[0] + "#0-1"}, SriovOcpConfig.WorkerLabelMap)
 			err := sriovoperator.CreateSriovPolicyAndWaitUntilItsApplied(
 				APIClient,
@@ -132,7 +132,7 @@ var _ = Describe("SRIOV Operator re-installation", Ordered, Label(tsparams.Label
 					sriovTestResourceName,
 					SriovOcpConfig.SriovOperatorNamespace,
 					sriovTestResourceName,
-					5,
+					SriovOcpConfig.VFNum,
 					[]string{sriovInterfacesUnderTest[0] + "#0-1"}, SriovOcpConfig.WorkerLabelMap).Create()
 				Expect(err).To(HaveOccurred(), "SriovNetworkNodePolicy is created unexpectedly")
 
@@ -160,7 +160,7 @@ var _ = Describe("SRIOV Operator re-installation", Ordered, Label(tsparams.Label
 					sriovTestResourceName,
 					SriovOcpConfig.SriovOperatorNamespace,
 					sriovTestResourceName,
-					5,
+					SriovOcpConfig.VFNum,
 					[]string{sriovInterfacesUnderTest[0] + "#0-1"}, SriovOcpConfig.WorkerLabelMap)
 				err := sriovoperator.CreateSriovPolicyAndWaitUntilItsApplied(
 					APIClient,


### PR DESCRIPTION
## Problem

Three SR-IOV test files hardcode the numVfs argument in \`NewPolicyBuilder\` calls instead of using \`SriovOcpConfig.VFNum\` (\`ECO_OCP_SRIOV_VF_NUM\`):

- \`exposemtu.go\`: hardcodes \`5\` in 3 places
- \`reinstallation.go\`: hardcodes \`5\` in 3 places
- \`metricsExporter.go\`: hardcodes \`6\` in 3 places

On Mellanox CX6-DX hardware, the Mellanox SR-IOV plugin uses exact-match semantics for the firmware \`NUM_OF_VFS\` field: if the requested VF count differs from the firmware value, it writes the new value to firmware and triggers a node reboot. This reboot takes longer than \`MCOWaitTimeout\` (35 minutes) on this hardware.

**Effect:** When test groups run sequentially with different hardcoded VF counts, each transition triggers a firmware write and reboot that exceeds the timeout, causing tests to fail with \`context deadline exceeded\`.

## Fix

Replace all hardcoded VF counts with \`SriovOcpConfig.VFNum\` in all three files (9 total substitutions). This ensures every test group requests the same VF count, eliminating firmware changes between test groups and the resulting reboot loop.

## Files changed

- \`tests/ocp/sriov/tests/exposemtu.go\`: 3 occurrences of \`5\` → \`SriovOcpConfig.VFNum\`
- \`tests/ocp/sriov/tests/reinstallation.go\`: 3 occurrences of \`5\` → \`SriovOcpConfig.VFNum\`
- \`tests/ocp/sriov/tests/metricsExporter.go\`: 3 occurrences of \`6\` → \`SriovOcpConfig.VFNum\`

## Tests affected

Fixes: 73786, 73787, 73788, 73789, 73790 (exposemtu)
Also fixes the same class of failure for reinstallation tests (46528, 46532) and metricsExporter tests on Mellanox hardware.