### PR TITLE
lca ipc: update the dns validation

### DIFF
--- a/tests/lca/ipchange/tests/ipconfig-test.go
+++ b/tests/lca/ipchange/tests/ipconfig-test.go
@@ -107,7 +107,7 @@ var _ = Describe(
 					return err
 				}),
 			Entry("Validates input for dnsServers list entry in the IPConfig spec", reportxml.ID("88106"),
-				"spec.dnsServers[0]: Invalid value: \"string\": must be a valid IP address",
+				"spec.dnsServers[0]: Invalid value: \""+string(tsparams.BadIPv4Address)+"\": must be a valid IP address",
 				func(builder *lca.IPConfigBuilder) error {
 					builder.Definition.Spec.DNSServers = []lcaipcv1.IPAddress{tsparams.BadIPv4Address}
 


### PR DESCRIPTION
This change follows the upstream Kubernetes apimachinery update that now passes the real value to field.Invalid(), resulting in error messages like Invalid value: "192.168.130.261" instead of Invalid value: "string".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined DNS server configuration validation error messages to include the specific invalid IP address value, providing more informative feedback when misconfiguration occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->