### PR TITLE
Add CAPOA TLS security profile adherence tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -141,6 +141,7 @@ linters:
         - github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/raninittools
         - github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran-deployment/internal/raninittools
         - github.com/rh-ecosystem-edge/eco-gotests/tests/assisted/ztp/internal/ztpinittools
+        - github.com/rh-ecosystem-edge/eco-gotests/tests/assisted/ztp/capoa-tls/internal/inittools
         - github.com/rh-ecosystem-edge/eco-gotests/tests/system-tests/ipsec/internal/ipsecinittools
         - github.com/rh-ecosystem-edge/eco-gotests/tests/system-tests/ran-du/internal/randuinittools
         - github.com/rh-ecosystem-edge/eco-gotests/tests/system-tests/internal/systemtestsinittools
@@ -185,6 +186,9 @@ linters:
       - linters:
           - gochecknoinits
         path: tests/assisted/ztp/internal/ztpinittools
+      - linters:
+          - gochecknoinits
+        path: tests/assisted/ztp/capoa-tls/internal/inittools
       - linters:
           - gochecknoinits
         path: tests/system-tests/ipsec/internal/ipsecinittools

--- a/tests/assisted/ztp/internal/tlsprofile/helpers.go
+++ b/tests/assisted/ztp/internal/tlsprofile/helpers.go
@@ -1,0 +1,39 @@
+package tlsprofile
+
+import (
+	"context"
+	"encoding/json"
+
+	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// PatchAPIServerTLSProfile applies the given TLS security profile to the cluster APIServer.
+func PatchAPIServerTLSProfile(client *clients.Settings, profile configv1.TLSSecurityProfile) {
+	patchMap := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"tlsSecurityProfile": profile,
+		},
+	}
+
+	patchBytes, err := json.Marshal(patchMap)
+	Expect(err).ToNot(HaveOccurred(), "failed to marshal TLS profile patch")
+
+	apiserver := &configv1.APIServer{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}}
+	err = client.Patch(context.TODO(), apiserver, runtimeclient.RawPatch(types.MergePatchType, patchBytes))
+	Expect(err).ToNot(HaveOccurred(), "failed to patch apiserver TLS profile")
+}
+
+// RemoveAPIServerTLSProfile removes the tlsSecurityProfile from the cluster APIServer.
+func RemoveAPIServerTLSProfile(client *clients.Settings) {
+	patchBytes := []byte(`{"spec":{"tlsSecurityProfile":null}}`)
+	apiserver := &configv1.APIServer{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}}
+
+	err := client.Patch(context.TODO(), apiserver,
+		runtimeclient.RawPatch(types.MergePatchType, patchBytes))
+	Expect(err).ToNot(HaveOccurred(), "failed to remove apiserver TLS profile")
+}

--- a/tests/assisted/ztp/internal/tlsprofile/pods.go
+++ b/tests/assisted/ztp/internal/tlsprofile/pods.go
@@ -1,0 +1,151 @@
+package tlsprofile
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
+)
+
+// FindPod returns the first pod whose name contains deploymentName.
+func FindPod(client *clients.Settings, component *Component, deploymentName string) *pod.Builder {
+	pods, err := component.ListPods(client, component.Namespace)
+	Expect(err).ToNot(HaveOccurred(), "failed to list %s pods", component.Name)
+
+	for _, p := range pods {
+		if strings.Contains(p.Object.Name, deploymentName) {
+			return p
+		}
+	}
+
+	Fail(fmt.Sprintf("no %s pod found matching %s", component.Name, deploymentName))
+
+	return nil
+}
+
+// WaitPodsReady waits until the expected number of healthy pods is reached.
+func WaitPodsReady(client *clients.Settings, component *Component) {
+	Eventually(func() int {
+		pods, err := component.ListPods(client, component.Namespace)
+		if err != nil {
+			return 0
+		}
+
+		ready := 0
+
+		for _, p := range pods {
+			if p.IsHealthy() {
+				ready++
+			}
+		}
+
+		return ready
+	}).WithTimeout(component.PodReadyTimeout).WithPolling(10*time.Second).
+		Should(BeNumerically(">=", component.ExpectedHealthyPods),
+			"%s pods should be ready", component.Name)
+}
+
+// RestartPods deletes all component pods and waits for them to come back ready.
+func RestartPods(client *clients.Settings, component *Component) {
+	pods, err := component.ListPods(client, component.Namespace)
+	Expect(err).ToNot(HaveOccurred(), "failed to list %s pods", component.Name)
+
+	for _, p := range pods {
+		podName := p.Object.Name
+		_, err := p.DeleteAndWait(component.PodReadyTimeout)
+		Expect(err).ToNot(HaveOccurred(), "failed to delete pod %s", podName)
+	}
+
+	WaitPodsReady(client, component)
+}
+
+// WaitPodsRestarted waits for the component to automatically restart after a TLS profile change.
+func WaitPodsRestarted(client *clients.Settings, component *Component) {
+	switch component.RestartMode {
+	case RestartModeContainerRestart:
+		waitContainerRestart(client, component)
+	case RestartModePodReplacement:
+		waitPodReplacement(client, component)
+	}
+
+	WaitPodsReady(client, component)
+}
+
+func waitContainerRestart(client *clients.Settings, component *Component) {
+	restartCounts := make(map[string]int32)
+
+	for _, d := range component.Deployments {
+		restartCounts[d.Name] = GetContainerRestartCount(client, component, d)
+	}
+
+	for _, d := range component.Deployments {
+		deploy := d
+
+		Eventually(func() int32 {
+			return GetContainerRestartCount(client, component, deploy)
+		}).WithTimeout(component.AutoRestartTimeout).WithPolling(5*time.Second).
+			Should(BeNumerically(">", restartCounts[deploy.Name]),
+				"%s %s should have restarted", component.Name, deploy.Name)
+	}
+}
+
+func waitPodReplacement(client *clients.Settings, component *Component) {
+	pods, err := component.ListPods(client, component.Namespace)
+	Expect(err).ToNot(HaveOccurred(), "failed to list %s pods", component.Name)
+
+	oldNames := make(map[string]bool)
+
+	for _, p := range pods {
+		oldNames[p.Object.Name] = true
+	}
+
+	Eventually(func() bool {
+		currentPods, err := component.ListPods(client, component.Namespace)
+		if err != nil {
+			return false
+		}
+
+		for _, p := range currentPods {
+			if oldNames[p.Object.Name] {
+				return false
+			}
+		}
+
+		return len(currentPods) >= component.ExpectedHealthyPods
+	}).WithTimeout(component.AutoRestartTimeout).WithPolling(5*time.Second).
+		Should(BeTrue(), "%s pods should have been replaced", component.Name)
+}
+
+// GetContainerRestartCount returns the restart count of the container for the given deployment.
+func GetContainerRestartCount(client *clients.Settings, component *Component, deploy Deployment) int32 {
+	p := FindPod(client, component, deploy.Name)
+
+	for _, cs := range p.Object.Status.ContainerStatuses {
+		if cs.Name == deploy.ContainerName {
+			return cs.RestartCount
+		}
+	}
+
+	return -1
+}
+
+// AssertControllerLogsContain asserts that the deployment's container logs contain the given pattern.
+func AssertControllerLogsContain(client *clients.Settings, component *Component,
+	deploy Deployment, pattern string) {
+	Eventually(func() string {
+		p := FindPod(client, component, deploy.Name)
+
+		logs, err := p.GetFullLog(deploy.ContainerName)
+		if err != nil {
+			return ""
+		}
+
+		return logs
+	}).WithTimeout(30*time.Second).WithPolling(5*time.Second).
+		Should(ContainSubstring(pattern),
+			fmt.Sprintf("%s %s logs should contain %q", component.Name, deploy.Name, pattern))
+}

--- a/tests/assisted/ztp/internal/tlsprofile/portforward.go
+++ b/tests/assisted/ztp/internal/tlsprofile/portforward.go
@@ -1,0 +1,104 @@
+package tlsprofile
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+)
+
+var portForwardStopChans = map[string]chan struct{}{}
+
+func portForwardKey(endpoint Endpoint) string {
+	return fmt.Sprintf("%s:%d", endpoint.ServiceName, endpoint.LocalPort)
+}
+
+// StartPortForward sets up a port-forward to the pod behind the endpoint and returns the local address.
+func StartPortForward(client *clients.Settings, component *Component, endpoint Endpoint) string {
+	key := portForwardKey(endpoint)
+	StopPortForward(endpoint)
+
+	targetPod := findPodForEndpoint(client, component, endpoint)
+
+	restConfig := client.Config
+	apiURL, err := url.Parse(restConfig.Host)
+	Expect(err).ToNot(HaveOccurred(), "failed to parse API server URL")
+
+	apiURL.Path = fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/portforward",
+		component.Namespace, targetPod.Object.Name)
+
+	transport, upgrader, err := spdy.RoundTripperFor(restConfig)
+	Expect(err).ToNot(HaveOccurred(), "failed to create SPDY round-tripper")
+
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, http.MethodPost, apiURL)
+
+	stopChan := make(chan struct{})
+	readyChan := make(chan struct{})
+
+	forwarder, err := portforward.New(dialer,
+		[]string{fmt.Sprintf("%d:%d", endpoint.LocalPort, endpoint.RemotePort)},
+		stopChan, readyChan, nil, nil)
+	Expect(err).ToNot(HaveOccurred(), "failed to create port-forwarder for %s", endpoint.ServiceName)
+
+	go func() {
+		_ = forwarder.ForwardPorts()
+	}()
+
+	select {
+	case <-readyChan:
+	case <-time.After(60 * time.Second):
+		close(stopChan)
+		Fail(fmt.Sprintf("port-forward to %s did not become ready in 60s", endpoint.ServiceName))
+	}
+
+	portForwardStopChans[key] = stopChan
+
+	return fmt.Sprintf("localhost:%d", endpoint.LocalPort)
+}
+
+// StopPortForward closes the port-forward for the given endpoint if one is active.
+func StopPortForward(endpoint Endpoint) {
+	key := portForwardKey(endpoint)
+
+	if stopChan, ok := portForwardStopChans[key]; ok {
+		close(stopChan)
+		delete(portForwardStopChans, key)
+	}
+}
+
+// StopAllPortForwards closes all active port-forwards.
+func StopAllPortForwards() {
+	for key, stopChan := range portForwardStopChans {
+		close(stopChan)
+		delete(portForwardStopChans, key)
+	}
+}
+
+func findPodForEndpoint(client *clients.Settings, component *Component, endpoint Endpoint) *pod.Builder {
+	pods, err := component.ListPods(client, component.Namespace)
+	Expect(err).ToNot(HaveOccurred(), "failed to list %s pods", component.Name)
+	Expect(pods).ToNot(BeEmpty(), "no %s pods found", component.Name)
+
+	if endpoint.DeploymentName == "" {
+		return pods[0]
+	}
+
+	for _, p := range pods {
+		if strings.Contains(p.Object.Name, endpoint.DeploymentName) {
+			return p
+		}
+	}
+
+	Fail(fmt.Sprintf("no %s pod found matching deployment %s for endpoint %s",
+		component.Name, endpoint.DeploymentName, endpoint.ServiceName))
+
+	return nil
+}

--- a/tests/assisted/ztp/internal/tlsprofile/tls.go
+++ b/tests/assisted/ztp/internal/tlsprofile/tls.go
@@ -1,0 +1,103 @@
+package tlsprofile
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+)
+
+// AssertTLSConnects verifies that a TLS handshake succeeds with the given version and cipher constraints.
+func AssertTLSConnects(client *clients.Settings, component *Component,
+	endpoint Endpoint, minVersion, maxVersion uint16, cipherSuites []uint16) {
+	addr := StartPortForward(client, component, endpoint)
+
+	defer StopPortForward(endpoint)
+
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: true, //nolint:gosec
+		MinVersion:         minVersion,
+		MaxVersion:         maxVersion,
+	}
+
+	if len(cipherSuites) > 0 {
+		tlsConfig.CipherSuites = cipherSuites
+	}
+
+	Eventually(func() error {
+		dialer := &net.Dialer{Timeout: 10 * time.Second}
+
+		conn, dialErr := tls.DialWithDialer(dialer, "tcp", addr, tlsConfig)
+		if dialErr != nil {
+			return dialErr
+		}
+
+		defer conn.Close()
+
+		state := conn.ConnectionState()
+		if !state.HandshakeComplete {
+			return fmt.Errorf("TLS handshake not complete")
+		}
+
+		return nil
+	}).WithTimeout(30*time.Second).WithPolling(2*time.Second).
+		Should(Succeed(), "TLS connection to %s (%s) should succeed",
+			endpoint.ServiceName, component.Name)
+}
+
+// AssertTLSRejectedVersion verifies that a TLS handshake is rejected for the given TLS version.
+func AssertTLSRejectedVersion(client *clients.Settings, component *Component,
+	endpoint Endpoint, version uint16) {
+	AssertTLSRejectedWith(client, component, endpoint, version, version, nil)
+}
+
+// AssertTLSRejected verifies that a TLS 1.2 handshake is rejected with the given cipher suites.
+func AssertTLSRejected(client *clients.Settings, component *Component,
+	endpoint Endpoint, cipherSuites []uint16) {
+	AssertTLSRejectedWith(client, component, endpoint, tls.VersionTLS12, tls.VersionTLS12, cipherSuites)
+}
+
+// AssertTLSRejectedWith verifies that a TLS handshake is rejected with the given version and cipher constraints.
+func AssertTLSRejectedWith(client *clients.Settings, component *Component,
+	endpoint Endpoint, minVersion, maxVersion uint16, cipherSuites []uint16) {
+	addr := StartPortForward(client, component, endpoint)
+
+	defer StopPortForward(endpoint)
+
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: true, //nolint:gosec
+		MinVersion:         minVersion,
+		MaxVersion:         maxVersion,
+	}
+
+	if len(cipherSuites) > 0 {
+		tlsConfig.CipherSuites = cipherSuites
+	}
+
+	Eventually(func() string {
+		dialer := &net.Dialer{Timeout: 10 * time.Second}
+		conn, dialErr := tls.DialWithDialer(dialer, "tcp", addr, tlsConfig)
+
+		if conn != nil {
+			conn.Close()
+		}
+
+		if dialErr == nil {
+			return "connected"
+		}
+
+		errMsg := dialErr.Error()
+		if strings.Contains(errMsg, "connection refused") || errMsg == "EOF" {
+			return "not-ready"
+		}
+
+		return errMsg
+	}).WithTimeout(30*time.Second).WithPolling(2*time.Second).
+		Should(ContainSubstring("tls:"),
+			"TLS connection to %s (%s) should be rejected with TLS error",
+			endpoint.ServiceName, component.Name)
+}

--- a/tests/assisted/ztp/internal/tlsprofile/types.go
+++ b/tests/assisted/ztp/internal/tlsprofile/types.go
@@ -1,0 +1,63 @@
+package tlsprofile
+
+import (
+	"time"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
+)
+
+// RestartMode indicates how a component restarts after TLS profile changes.
+type RestartMode int
+
+const (
+	// RestartModeContainerRestart means the container restarts in-place (same pod UID, restart count increases).
+	RestartModeContainerRestart RestartMode = iota
+	// RestartModePodReplacement means the pod is replaced entirely (new pod name).
+	RestartModePodReplacement
+)
+
+// Endpoint represents a TLS-secured service endpoint to probe.
+type Endpoint struct {
+	ServiceName    string
+	LocalPort      int
+	RemotePort     int
+	DeploymentName string
+}
+
+// Deployment represents a deployment whose pods should be tracked for logs and restarts.
+type Deployment struct {
+	Name          string
+	ContainerName string
+}
+
+// WebhookTestConfig holds details for webhook validation testing after a TLS profile change.
+type WebhookTestConfig struct {
+	TestNamespace      string
+	APIVersion         string
+	Kind               string
+	ResourceName       string
+	CreateSpec         map[string]interface{}
+	MutationPatch      []byte
+	RejectionSubstring string
+}
+
+// Component fully describes a TLS-adherent component for testing.
+type Component struct {
+	Name                string
+	Label               string
+	Namespace           string
+	RestartMode         RestartMode
+	Endpoints           []Endpoint
+	Deployments         []Deployment
+	ListPods            func(*clients.Settings, string) ([]*pod.Builder, error)
+	ExpectedHealthyPods int
+	PodReadyTimeout     time.Duration
+	AutoRestartTimeout  time.Duration
+	HonoringLogPattern  string
+	WebhookTest         *WebhookTestConfig
+	AllowedCipher       uint16
+	AllowedCipherAlt    uint16
+	DisallowedCipher    uint16
+	OldProfileCipher    uint16
+}

--- a/tests/assisted/ztp/operator/internal/tsparams/operatorvars.go
+++ b/tests/assisted/ztp/operator/internal/tsparams/operatorvars.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	// Labels represents the range of labels that can be used for test cases selection.
-	Labels = append(ztpparams.Labels, LabelSuite)
+	Labels = append(append([]string{}, ztpparams.Labels...), LabelSuite)
 
 	// ReporterNamespacesToDump tells to the reporter from where to collect logs.
 	ReporterNamespacesToDump = map[string]string{

--- a/tests/assisted/ztp/tls-profile/internal/inittools/inittools.go
+++ b/tests/assisted/ztp/tls-profile/internal/inittools/inittools.go
@@ -1,0 +1,18 @@
+package inittools
+
+import (
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/config"
+)
+
+var (
+	// HubAPIClient provides API access to hub cluster via KUBECONFIG env var.
+	HubAPIClient *clients.Settings
+	// GeneralConfig provides access to general configuration parameters.
+	GeneralConfig *config.GeneralConfig
+)
+
+func init() {
+	HubAPIClient = clients.New("")
+	GeneralConfig = config.NewConfig()
+}

--- a/tests/assisted/ztp/tls-profile/internal/tsparams/const.go
+++ b/tests/assisted/ztp/tls-profile/internal/tsparams/const.go
@@ -1,0 +1,15 @@
+package tsparams
+
+const (
+	// LabelSuite represents the tls-profile label that can be used for test cases selection.
+	LabelSuite = "tls-profile"
+
+	// LabelTLSProfileCommon represents the label for generic TLS profile tests across all components.
+	LabelTLSProfileCommon = "tls-profile-common"
+
+	// LabelCAPOATLSProfile represents the label for CAPOA-specific TLS profile tests.
+	LabelCAPOATLSProfile = "tls-profile-capoa"
+
+	// LabelIBIOTLSProfile represents the label for IBIO-specific TLS profile tests.
+	LabelIBIOTLSProfile = "tls-profile-ibio"
+)

--- a/tests/assisted/ztp/tls-profile/internal/tsparams/tls-profile-vars.go
+++ b/tests/assisted/ztp/tls-profile/internal/tsparams/tls-profile-vars.go
@@ -1,11 +1,7 @@
 package tsparams
 
 import (
-	bmhv1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/openshift-kni/k8sreporter"
-	hiveextV1Beta1 "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/assisted/api/hiveextension/v1beta1"
-	agentInstallV1Beta1 "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/assisted/api/v1beta1"
-	hivev1 "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/assisted/hive/api/v1"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/assisted/ztp/internal/ztpparams"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -21,11 +17,6 @@ var (
 
 	// ReporterCRDsToDump tells to the reporter what CRs to dump.
 	ReporterCRDsToDump = []k8sreporter.CRData{
-		{Cr: &corev1.SecretList{}},
-		{Cr: &hivev1.ClusterDeploymentList{}},
-		{Cr: &hiveextV1Beta1.AgentClusterInstallList{}},
-		{Cr: &agentInstallV1Beta1.InfraEnvList{}},
-		{Cr: &bmhv1alpha1.BareMetalHostList{}},
-		{Cr: &agentInstallV1Beta1.AgentList{}},
+		{Cr: &corev1.PodList{}},
 	}
 )

--- a/tests/assisted/ztp/tls-profile/tests/common_tls_profile_tests.go
+++ b/tests/assisted/ztp/tls-profile/tests/common_tls_profile_tests.go
@@ -1,0 +1,383 @@
+package tls_profile_test
+
+import (
+	"context"
+	"crypto/tls"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/namespace"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/assisted/ztp/internal/tlsprofile"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/assisted/ztp/tls-profile/internal/inittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/assisted/ztp/tls-profile/internal/tsparams"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func init() {
+	for _, c := range allComponents {
+		component := c
+		registerCommonTLSTests(component)
+	}
+}
+
+func registerCommonTLSTests(component *tlsprofile.Component) {
+	var _ = Describe(
+		component.Name+" TLS Profile",
+		Ordered, ContinueOnFailure,
+		Label(tsparams.LabelTLSProfileCommon, component.Label), func() {
+			BeforeAll(func() {
+				By("Verifying hub API client is available")
+
+				if HubAPIClient == nil {
+					Skip("Hub API client is nil")
+				}
+
+				By("Verifying TLS adherence is enabled on the cluster")
+
+				apiserverU := &unstructured.Unstructured{}
+				apiserverU.SetGroupVersionKind(schema.GroupVersionKind{
+					Group:   "config.openshift.io",
+					Version: "v1",
+					Kind:    "APIServer",
+				})
+
+				err := HubAPIClient.Get(context.TODO(), runtimeclient.ObjectKey{Name: "cluster"}, apiserverU)
+				Expect(err).ToNot(HaveOccurred(), "failed to get apiserver/cluster")
+
+				adherence, _, _ := unstructured.NestedString(apiserverU.Object, "spec", "tlsAdherence")
+				if adherence != "StrictAllComponents" {
+					Skip("TLS adherence is not StrictAllComponents (got: " + adherence + ")")
+				}
+
+				By("Verifying " + component.Name + " pods are running")
+
+				pods, err := component.ListPods(HubAPIClient, component.Namespace)
+				Expect(err).ToNot(HaveOccurred(), "failed to list %s pods", component.Name)
+
+				if len(pods) == 0 {
+					Skip(component.Name + " pods not found in " + component.Namespace + " — not deployed")
+				}
+
+				tlsprofile.WaitPodsReady(HubAPIClient, component)
+			})
+
+			AfterAll(func() {
+				By("Restoring default Intermediate TLS profile")
+				tlsprofile.RemoveAPIServerTLSProfile(HubAPIClient)
+				tlsprofile.RestartPods(HubAPIClient, component)
+				tlsprofile.StopAllPortForwards()
+			})
+
+			It("Verifies default Intermediate TLS profile on "+component.Name+" endpoints",
+				reportxml.ID("88843"), func() {
+					By("Confirming no tlsSecurityProfile is set on apiserver")
+					tlsprofile.RemoveAPIServerTLSProfile(HubAPIClient)
+					tlsprofile.RestartPods(HubAPIClient, component)
+
+					By("Verifying controller logs show honoring message")
+
+					for _, d := range component.Deployments {
+						tlsprofile.AssertControllerLogsContain(HubAPIClient, component,
+							d, component.HonoringLogPattern)
+					}
+
+					for _, ep := range component.Endpoints {
+						By("Probing TLS 1.2 on " + ep.ServiceName)
+						tlsprofile.AssertTLSConnects(HubAPIClient, component, ep,
+							tls.VersionTLS12, tls.VersionTLS12, nil)
+
+						By("Probing TLS 1.3 on " + ep.ServiceName)
+						tlsprofile.AssertTLSConnects(HubAPIClient, component, ep,
+							tls.VersionTLS13, tls.VersionTLS13, nil)
+					}
+
+					By("Verifying TLS 1.1 is rejected on " + component.Endpoints[0].ServiceName)
+					tlsprofile.AssertTLSRejectedVersion(HubAPIClient, component,
+						component.Endpoints[0], tls.VersionTLS11)
+
+					By("Verifying TLS 1.0 is rejected on " + component.Endpoints[0].ServiceName)
+					tlsprofile.AssertTLSRejectedVersion(HubAPIClient, component,
+						component.Endpoints[0], tls.VersionTLS10)
+				})
+
+			It("Verifies Old TLS profile enables broader cipher set on "+component.Name,
+				reportxml.ID("88844"), func() {
+					By("Applying Old TLS profile")
+					tlsprofile.PatchAPIServerTLSProfile(HubAPIClient, configv1.TLSSecurityProfile{
+						Type: configv1.TLSProfileOldType,
+						Old:  &configv1.OldTLSProfile{},
+					})
+
+					By("Restarting " + component.Name + " pods to pick up Old profile")
+					tlsprofile.RestartPods(HubAPIClient, component)
+
+					By("Verifying controller logs show VersionTLS10")
+
+					for _, d := range component.Deployments {
+						tlsprofile.AssertControllerLogsContain(HubAPIClient, component,
+							d, "VersionTLS10")
+					}
+
+					for _, ep := range component.Endpoints {
+						By("Verifying Old-specific cipher connects on " + ep.ServiceName)
+						tlsprofile.AssertTLSConnects(HubAPIClient, component, ep,
+							tls.VersionTLS12, tls.VersionTLS12,
+							[]uint16{component.OldProfileCipher})
+					}
+				})
+
+			It("Verifies Modern TLS profile restricts to TLS 1.3 only on "+component.Name,
+				reportxml.ID("88845"), func() {
+					By("Applying Modern TLS profile")
+					tlsprofile.PatchAPIServerTLSProfile(HubAPIClient, configv1.TLSSecurityProfile{
+						Type:   configv1.TLSProfileModernType,
+						Modern: &configv1.ModernTLSProfile{},
+					})
+
+					By("Restarting " + component.Name + " pods to pick up Modern profile")
+					tlsprofile.RestartPods(HubAPIClient, component)
+
+					By("Verifying controller logs show VersionTLS13")
+
+					for _, d := range component.Deployments {
+						tlsprofile.AssertControllerLogsContain(HubAPIClient, component,
+							d, "VersionTLS13")
+					}
+
+					for _, ep := range component.Endpoints {
+						By("Verifying TLS 1.3 connects on " + ep.ServiceName)
+						tlsprofile.AssertTLSConnects(HubAPIClient, component, ep,
+							tls.VersionTLS13, tls.VersionTLS13, nil)
+
+						By("Verifying TLS 1.2 is rejected on " + ep.ServiceName)
+						tlsprofile.AssertTLSRejected(HubAPIClient, component, ep, nil)
+					}
+				})
+
+			It("Verifies Custom TLS profile restricts to specified ciphers on "+component.Name,
+				reportxml.ID("88846"), func() {
+					By("Applying Custom TLS profile with 2 ciphers")
+					tlsprofile.PatchAPIServerTLSProfile(HubAPIClient, configv1.TLSSecurityProfile{
+						Type: configv1.TLSProfileCustomType,
+						Custom: &configv1.CustomTLSProfile{
+							TLSProfileSpec: configv1.TLSProfileSpec{
+								Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256", "ECDHE-RSA-AES256-GCM-SHA384", "ECDHE-ECDSA-AES128-GCM-SHA256", "ECDHE-ECDSA-AES256-GCM-SHA384"},
+								MinTLSVersion: configv1.VersionTLS12,
+							},
+						},
+					})
+
+					By("Restarting " + component.Name + " pods to pick up Custom profile")
+					tlsprofile.RestartPods(HubAPIClient, component)
+
+					for _, ep := range component.Endpoints {
+						By("Verifying allowed cipher connects on " + ep.ServiceName)
+						tlsprofile.AssertTLSConnects(HubAPIClient, component, ep,
+							tls.VersionTLS12, tls.VersionTLS12,
+							[]uint16{component.AllowedCipher})
+
+						By("Verifying disallowed cipher is rejected on " + ep.ServiceName)
+						tlsprofile.AssertTLSRejected(HubAPIClient, component, ep,
+							[]uint16{component.DisallowedCipher})
+					}
+				})
+
+			It("Verifies profile change triggers automatic reconciliation on "+component.Name,
+				reportxml.ID("88847"), func() {
+					By("Restoring Intermediate baseline")
+					tlsprofile.RemoveAPIServerTLSProfile(HubAPIClient)
+					tlsprofile.RestartPods(HubAPIClient, component)
+
+					By("Recording baseline cipher connectivity")
+					tlsprofile.AssertTLSConnects(HubAPIClient, component, component.Endpoints[0],
+						tls.VersionTLS12, tls.VersionTLS12,
+						[]uint16{component.AllowedCipher})
+
+					By("Switching to Custom single-cipher profile")
+					tlsprofile.PatchAPIServerTLSProfile(HubAPIClient, configv1.TLSSecurityProfile{
+						Type: configv1.TLSProfileCustomType,
+						Custom: &configv1.CustomTLSProfile{
+							TLSProfileSpec: configv1.TLSProfileSpec{
+								Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256", "ECDHE-ECDSA-AES128-GCM-SHA256"},
+								MinTLSVersion: configv1.VersionTLS12,
+							},
+						},
+					})
+
+					By("Waiting for automatic reconciliation (no manual pod restart)")
+					tlsprofile.WaitPodsRestarted(HubAPIClient, component)
+
+					for _, d := range component.Deployments {
+						tlsprofile.AssertControllerLogsContain(HubAPIClient, component,
+							d, component.HonoringLogPattern)
+					}
+
+					By("Verifying AES256 is now rejected under single-cipher Custom profile")
+					tlsprofile.AssertTLSRejected(HubAPIClient, component, component.Endpoints[0],
+						[]uint16{component.AllowedCipherAlt})
+
+					By("Switching back to Intermediate")
+					tlsprofile.RemoveAPIServerTLSProfile(HubAPIClient)
+					tlsprofile.WaitPodsRestarted(HubAPIClient, component)
+
+					By("Verifying AES256 is restored under Intermediate")
+					tlsprofile.AssertTLSConnects(HubAPIClient, component, component.Endpoints[0],
+						tls.VersionTLS12, tls.VersionTLS12,
+						[]uint16{component.AllowedCipherAlt})
+				})
+
+			It("Verifies webhook validation works after TLS profile change on "+component.Name,
+				reportxml.ID("88848"), func() {
+					if component.WebhookTest == nil {
+						Skip(component.Name + " has no webhook validation test configured")
+					}
+
+					wt := component.WebhookTest
+
+					By("Applying Custom TLS profile")
+					tlsprofile.PatchAPIServerTLSProfile(HubAPIClient, configv1.TLSSecurityProfile{
+						Type: configv1.TLSProfileCustomType,
+						Custom: &configv1.CustomTLSProfile{
+							TLSProfileSpec: configv1.TLSProfileSpec{
+								Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256", "ECDHE-RSA-AES256-GCM-SHA384", "ECDHE-ECDSA-AES128-GCM-SHA256", "ECDHE-ECDSA-AES256-GCM-SHA384"},
+								MinTLSVersion: configv1.VersionTLS12,
+							},
+						},
+					})
+					tlsprofile.RestartPods(HubAPIClient, component)
+
+					By("Ensuring test namespace does not exist")
+
+					nsBuilder := namespace.NewBuilder(HubAPIClient, wt.TestNamespace)
+
+					err := nsBuilder.DeleteAndWait(2 * time.Minute)
+					Expect(err).ToNot(HaveOccurred(), "failed to clean up namespace %s", wt.TestNamespace)
+
+					By("Creating test namespace")
+
+					nsBuilder, err = namespace.NewBuilder(HubAPIClient, wt.TestNamespace).Create()
+					Expect(err).ToNot(HaveOccurred(), "failed to create test namespace")
+
+					DeferCleanup(func() {
+						_ = nsBuilder.Delete()
+					})
+
+					By("Creating valid " + wt.Kind)
+
+					resource := &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": wt.APIVersion,
+							"kind":       wt.Kind,
+							"metadata": map[string]interface{}{
+								"name":      wt.ResourceName,
+								"namespace": wt.TestNamespace,
+							},
+							"spec": wt.CreateSpec,
+						},
+					}
+
+					err = HubAPIClient.Create(context.TODO(), resource)
+					Expect(err).ToNot(HaveOccurred(),
+						"valid %s should be accepted", wt.Kind)
+
+					By("Attempting to update spec (should be rejected)")
+
+					err = HubAPIClient.Patch(context.TODO(), resource,
+						runtimeclient.RawPatch(types.MergePatchType, wt.MutationPatch))
+					Expect(err).To(HaveOccurred(),
+						"spec update should be rejected by webhook")
+					Expect(err.Error()).To(ContainSubstring(wt.RejectionSubstring),
+						"rejection reason should mention %s", wt.RejectionSubstring)
+
+					By("Updating metadata only (should succeed)")
+
+					labelPatch := []byte(`{"metadata":{"labels":{"tls-profile-test":"validation"}}}`)
+
+					err = HubAPIClient.Patch(context.TODO(), resource,
+						runtimeclient.RawPatch(types.MergePatchType, labelPatch))
+					Expect(err).ToNot(HaveOccurred(), "metadata update should be accepted")
+
+					By("Deleting the resource")
+
+					err = HubAPIClient.Delete(context.TODO(), resource)
+					Expect(err).ToNot(HaveOccurred(), "deletion should succeed")
+				})
+
+			It("Verifies restore to default profile on "+component.Name,
+				reportxml.ID("88850"), func() {
+					By("Applying Custom TLS profile")
+					tlsprofile.PatchAPIServerTLSProfile(HubAPIClient, configv1.TLSSecurityProfile{
+						Type: configv1.TLSProfileCustomType,
+						Custom: &configv1.CustomTLSProfile{
+							TLSProfileSpec: configv1.TLSProfileSpec{
+								Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256", "ECDHE-RSA-AES256-GCM-SHA384", "ECDHE-ECDSA-AES128-GCM-SHA256", "ECDHE-ECDSA-AES256-GCM-SHA384"},
+								MinTLSVersion: configv1.VersionTLS12,
+							},
+						},
+					})
+					tlsprofile.RestartPods(HubAPIClient, component)
+
+					By("Removing Custom profile to restore default")
+					tlsprofile.RemoveAPIServerTLSProfile(HubAPIClient)
+					tlsprofile.RestartPods(HubAPIClient, component)
+
+					By("Verifying no tlsSecurityProfile remains on apiserver")
+
+					apiserver := &configv1.APIServer{}
+
+					err := HubAPIClient.Get(context.TODO(), runtimeclient.ObjectKey{Name: "cluster"}, apiserver)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(apiserver.Spec.TLSSecurityProfile).To(BeNil(),
+						"tlsSecurityProfile should be nil after restore")
+
+					By("Verifying controller logs show Intermediate profile")
+
+					for _, d := range component.Deployments {
+						tlsprofile.AssertControllerLogsContain(HubAPIClient, component,
+							d, "VersionTLS12")
+					}
+
+					By("Verifying Intermediate ciphers are available")
+					tlsprofile.AssertTLSConnects(HubAPIClient, component, component.Endpoints[0],
+						tls.VersionTLS12, tls.VersionTLS12,
+						[]uint16{component.AllowedCipher})
+					tlsprofile.AssertTLSConnects(HubAPIClient, component, component.Endpoints[0],
+						tls.VersionTLS13, tls.VersionTLS13, nil)
+				})
+
+			It("Verifies SecurityProfileWatcher triggers restart on "+component.Name,
+				reportxml.ID("88858"), func() {
+					By("Ensuring Intermediate baseline and pods are ready")
+					tlsprofile.RemoveAPIServerTLSProfile(HubAPIClient)
+					tlsprofile.WaitPodsReady(HubAPIClient, component)
+
+					By("Changing TLS profile to Custom")
+					tlsprofile.PatchAPIServerTLSProfile(HubAPIClient, configv1.TLSSecurityProfile{
+						Type: configv1.TLSProfileCustomType,
+						Custom: &configv1.CustomTLSProfile{
+							TLSProfileSpec: configv1.TLSProfileSpec{
+								Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256", "ECDHE-RSA-AES256-GCM-SHA384", "ECDHE-ECDSA-AES128-GCM-SHA256", "ECDHE-ECDSA-AES256-GCM-SHA384"},
+								MinTLSVersion: configv1.VersionTLS12,
+							},
+						},
+					})
+
+					By("Waiting for automatic restart")
+					tlsprofile.WaitPodsRestarted(HubAPIClient, component)
+					tlsprofile.WaitPodsReady(HubAPIClient, component)
+
+					By("Verifying controllers honour the new profile")
+
+					for _, d := range component.Deployments {
+						tlsprofile.AssertControllerLogsContain(HubAPIClient, component,
+							d, component.HonoringLogPattern)
+					}
+				})
+		})
+}

--- a/tests/assisted/ztp/tls-profile/tests/components.go
+++ b/tests/assisted/ztp/tls-profile/tests/components.go
@@ -1,0 +1,110 @@
+package tls_profile_test
+
+import (
+	"crypto/tls"
+	"time"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/assisted/ztp/internal/tlsprofile"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/assisted/ztp/tls-profile/internal/tsparams"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var capoa = &tlsprofile.Component{
+	Name:        "CAPOA",
+	Label:       tsparams.LabelCAPOATLSProfile,
+	Namespace:   "multicluster-engine",
+	RestartMode: tlsprofile.RestartModeContainerRestart,
+	Endpoints: []tlsprofile.Endpoint{
+		{
+			ServiceName:    "capoa-bootstrap-webhook-service",
+			LocalPort:      19443,
+			RemotePort:     9443,
+			DeploymentName: "capoa-bootstrap-controller-manager",
+		},
+		{
+			ServiceName:    "capoa-controlplane-webhook-service",
+			LocalPort:      19444,
+			RemotePort:     9443,
+			DeploymentName: "capoa-controlplane-controller-manager",
+		},
+	},
+	Deployments: []tlsprofile.Deployment{
+		{Name: "capoa-bootstrap-controller-manager", ContainerName: "manager"},
+		{Name: "capoa-controlplane-controller-manager", ContainerName: "manager"},
+	},
+	ListPods: func(client *clients.Settings, ns string) ([]*pod.Builder, error) {
+		return pod.ListByNamePattern(client, "capoa", ns)
+	},
+	ExpectedHealthyPods: 2,
+	PodReadyTimeout:     5 * time.Minute,
+	AutoRestartTimeout:  10 * time.Minute,
+	HonoringLogPattern:  "honoring cluster-wide TLS profile",
+	AllowedCipher:       tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	AllowedCipherAlt:    tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	DisallowedCipher:    tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+	OldProfileCipher:    tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+	WebhookTest: &tlsprofile.WebhookTestConfig{
+		TestNamespace:      "tls-test-capoa",
+		APIVersion:         "bootstrap.cluster.x-k8s.io/v1alpha2",
+		Kind:               "OpenshiftAssistedConfig",
+		ResourceName:       "test-webhook-validation",
+		CreateSpec:         map[string]interface{}{"cpuArchitecture": "x86_64"},
+		MutationPatch:      []byte(`{"spec":{"cpuArchitecture":"aarch64"}}`),
+		RejectionSubstring: "immutable",
+	},
+}
+
+var ibio = &tlsprofile.Component{
+	Name:        "IBIO",
+	Label:       tsparams.LabelIBIOTLSProfile,
+	Namespace:   "multicluster-engine",
+	RestartMode: tlsprofile.RestartModeContainerRestart,
+	Endpoints: []tlsprofile.Endpoint{
+		{
+			ServiceName:    "image-based-install-webhook",
+			LocalPort:      19445,
+			RemotePort:     9443,
+			DeploymentName: "image-based-install-operator",
+		},
+		{
+			ServiceName:    "image-based-install-config",
+			LocalPort:      19446,
+			RemotePort:     8000,
+			DeploymentName: "image-based-install-operator",
+		},
+	},
+	Deployments: []tlsprofile.Deployment{
+		{Name: "image-based-install-operator", ContainerName: "manager"},
+	},
+	ListPods: func(client *clients.Settings, ns string) ([]*pod.Builder, error) {
+		return pod.List(client, ns, metav1.ListOptions{
+			LabelSelector: "app=image-based-install-operator",
+		})
+	},
+	ExpectedHealthyPods: 1,
+	PodReadyTimeout:     5 * time.Minute,
+	AutoRestartTimeout:  10 * time.Minute,
+	HonoringLogPattern:  "Reconciling APIServer TLS profile",
+	AllowedCipher:       tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	AllowedCipherAlt:    tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	DisallowedCipher:    tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+	OldProfileCipher:    tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+	WebhookTest: &tlsprofile.WebhookTestConfig{
+		TestNamespace: "tls-test-ibio",
+		APIVersion:    "extensions.hive.openshift.io/v1alpha1",
+		Kind:          "ImageClusterInstall",
+		ResourceName:  "test-webhook-validation",
+		CreateSpec: map[string]interface{}{
+			"clusterDeploymentRef": map[string]interface{}{"name": "tls-test-cd"},
+			"imageSetRef":          map[string]interface{}{"name": "tls-test-imageset"},
+			"hostname":             "tls-test-host",
+			"version":              "4.17.0",
+		},
+		MutationPatch:      []byte(`{"spec":{"clusterDeploymentRef":{"name":"different-cd-name"}}}`),
+		RejectionSubstring: "immutable",
+	},
+}
+
+var allComponents = []*tlsprofile.Component{capoa, ibio}

--- a/tests/assisted/ztp/tls-profile/tests/ibio_specific_tests.go
+++ b/tests/assisted/ztp/tls-profile/tests/ibio_specific_tests.go
@@ -1,0 +1,232 @@
+package tls_profile_test
+
+import (
+	"context"
+	"crypto/tls"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/assisted/ztp/internal/tlsprofile"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/assisted/ztp/tls-profile/internal/inittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/assisted/ztp/tls-profile/internal/tsparams"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe(
+	"IBIO TLS Profile — Component-Specific",
+	Ordered, ContinueOnFailure,
+	Label(tsparams.LabelIBIOTLSProfile), func() {
+		BeforeAll(func() {
+			By("Verifying hub API client is available")
+
+			if HubAPIClient == nil {
+				Skip("Hub API client is nil")
+			}
+
+			By("Verifying TLS adherence is enabled on the cluster")
+
+			apiserverU := &unstructured.Unstructured{}
+			apiserverU.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "config.openshift.io",
+				Version: "v1",
+				Kind:    "APIServer",
+			})
+
+			err := HubAPIClient.Get(context.TODO(), runtimeclient.ObjectKey{Name: "cluster"}, apiserverU)
+			Expect(err).ToNot(HaveOccurred(), "failed to get apiserver/cluster")
+
+			adherence, _, _ := unstructured.NestedString(apiserverU.Object, "spec", "tlsAdherence")
+			if adherence != "StrictAllComponents" {
+				Skip("TLS adherence is not StrictAllComponents (got: " + adherence + ")")
+			}
+
+			By("Verifying IBIO pods are running")
+
+			pods, err := ibio.ListPods(HubAPIClient, ibio.Namespace)
+			Expect(err).ToNot(HaveOccurred(), "failed to list IBIO pods")
+
+			if len(pods) == 0 {
+				Skip("IBIO pods not found in " + ibio.Namespace + " — not deployed")
+			}
+
+			tlsprofile.WaitPodsReady(HubAPIClient, ibio)
+		})
+
+		AfterAll(func() {
+			By("Restoring default Intermediate TLS profile")
+			tlsprofile.RemoveAPIServerTLSProfile(HubAPIClient)
+			tlsprofile.RestartPods(HubAPIClient, ibio)
+			tlsprofile.StopAllPortForwards()
+		})
+
+		It("Verifies config server enforces same TLS profile as webhook on IBIO",
+			reportxml.ID("88930"), func() {
+				By("Applying Custom TLS profile with 2 ciphers")
+				tlsprofile.PatchAPIServerTLSProfile(HubAPIClient, configv1.TLSSecurityProfile{
+					Type: configv1.TLSProfileCustomType,
+					Custom: &configv1.CustomTLSProfile{
+						TLSProfileSpec: configv1.TLSProfileSpec{
+							Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256", "ECDHE-RSA-AES256-GCM-SHA384", "ECDHE-ECDSA-AES128-GCM-SHA256", "ECDHE-ECDSA-AES256-GCM-SHA384"},
+							MinTLSVersion: configv1.VersionTLS12,
+						},
+					},
+				})
+
+				By("Waiting for IBIO pod restart")
+				tlsprofile.WaitPodsRestarted(HubAPIClient, ibio)
+
+				webhookEP := ibio.Endpoints[0]
+				configEP := ibio.Endpoints[1]
+
+				By("Verifying allowed cipher on webhook endpoint")
+				tlsprofile.AssertTLSConnects(HubAPIClient, ibio, webhookEP,
+					tls.VersionTLS12, tls.VersionTLS12,
+					[]uint16{tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256})
+
+				By("Verifying same allowed cipher on config server endpoint")
+				tlsprofile.AssertTLSConnects(HubAPIClient, ibio, configEP,
+					tls.VersionTLS12, tls.VersionTLS12,
+					[]uint16{tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256})
+
+				By("Verifying disallowed cipher is rejected on webhook endpoint")
+				tlsprofile.AssertTLSRejected(HubAPIClient, ibio, webhookEP,
+					[]uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256})
+
+				By("Verifying disallowed cipher is also rejected on config server endpoint")
+				tlsprofile.AssertTLSRejected(HubAPIClient, ibio, configEP,
+					[]uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256})
+			})
+
+		It("Verifies manager SecurityProfileWatcher triggers restart on IBIO",
+			reportxml.ID("88931"), func() {
+				By("Ensuring Intermediate baseline")
+				tlsprofile.RemoveAPIServerTLSProfile(HubAPIClient)
+				tlsprofile.RestartPods(HubAPIClient, ibio)
+
+				By("Changing TLS profile to Custom with 3 ciphers")
+				tlsprofile.PatchAPIServerTLSProfile(HubAPIClient, configv1.TLSSecurityProfile{
+					Type: configv1.TLSProfileCustomType,
+					Custom: &configv1.CustomTLSProfile{
+						TLSProfileSpec: configv1.TLSProfileSpec{
+							Ciphers: []string{
+								"ECDHE-RSA-AES128-GCM-SHA256",
+								"ECDHE-RSA-AES256-GCM-SHA384",
+								"ECDHE-ECDSA-AES128-GCM-SHA256",
+							},
+							MinTLSVersion: configv1.VersionTLS12,
+						},
+					},
+				})
+
+				By("Waiting for automatic pod replacement")
+				tlsprofile.WaitPodsRestarted(HubAPIClient, ibio)
+				tlsprofile.WaitPodsReady(HubAPIClient, ibio)
+
+				By("Verifying manager logs show TLS profile change")
+				tlsprofile.AssertControllerLogsContain(HubAPIClient, ibio,
+					ibio.Deployments[0], ibio.HonoringLogPattern)
+			})
+
+		It("Verifies manager restarts on TLS adherence policy change on IBIO",
+			reportxml.ID("88932"), func() {
+				By("Ensuring Custom profile baseline")
+				tlsprofile.PatchAPIServerTLSProfile(HubAPIClient, configv1.TLSSecurityProfile{
+					Type: configv1.TLSProfileCustomType,
+					Custom: &configv1.CustomTLSProfile{
+						TLSProfileSpec: configv1.TLSProfileSpec{
+							Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256", "ECDHE-RSA-AES256-GCM-SHA384", "ECDHE-ECDSA-AES128-GCM-SHA256", "ECDHE-ECDSA-AES256-GCM-SHA384"},
+							MinTLSVersion: configv1.VersionTLS12,
+						},
+					},
+				})
+				tlsprofile.WaitPodsRestarted(HubAPIClient, ibio)
+				tlsprofile.WaitPodsReady(HubAPIClient, ibio)
+
+				By("Removing TLS adherence policy")
+				apiserverU := &unstructured.Unstructured{}
+				apiserverU.SetGroupVersionKind(schema.GroupVersionKind{
+					Group:   "config.openshift.io",
+					Version: "v1",
+					Kind:    "APIServer",
+				})
+
+				err := HubAPIClient.Get(context.TODO(), runtimeclient.ObjectKey{Name: "cluster"}, apiserverU)
+				Expect(err).ToNot(HaveOccurred(), "failed to get apiserver/cluster")
+
+				patchBytes := []byte(`{"spec":{"tlsAdherence":""}}`)
+				err = HubAPIClient.Patch(context.TODO(), apiserverU,
+					runtimeclient.RawPatch("application/merge-patch+json", patchBytes))
+				Expect(err).ToNot(HaveOccurred(), "failed to remove tlsAdherence")
+
+				By("Waiting for pod restart after adherence change")
+				tlsprofile.WaitPodsRestarted(HubAPIClient, ibio)
+				tlsprofile.WaitPodsReady(HubAPIClient, ibio)
+
+				By("Restoring TLS adherence")
+				patchBytes = []byte(`{"spec":{"tlsAdherence":"StrictAllComponents"}}`)
+				err = HubAPIClient.Patch(context.TODO(), apiserverU,
+					runtimeclient.RawPatch("application/merge-patch+json", patchBytes))
+				Expect(err).ToNot(HaveOccurred(), "failed to restore tlsAdherence")
+
+				By("Waiting for restart after restoring adherence")
+				tlsprofile.WaitPodsRestarted(HubAPIClient, ibio)
+				tlsprofile.WaitPodsReady(HubAPIClient, ibio)
+			})
+
+		It("Verifies server container independently detects TLS change on IBIO",
+			reportxml.ID("88933"), func() {
+				By("Ensuring Intermediate baseline and pods ready")
+				tlsprofile.RemoveAPIServerTLSProfile(HubAPIClient)
+				tlsprofile.RestartPods(HubAPIClient, ibio)
+
+				By("Changing TLS profile to Custom single-cipher")
+				tlsprofile.PatchAPIServerTLSProfile(HubAPIClient, configv1.TLSSecurityProfile{
+					Type: configv1.TLSProfileCustomType,
+					Custom: &configv1.CustomTLSProfile{
+						TLSProfileSpec: configv1.TLSProfileSpec{
+							Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256", "ECDHE-ECDSA-AES128-GCM-SHA256"},
+							MinTLSVersion: configv1.VersionTLS12,
+						},
+					},
+				})
+
+				By("Waiting for pod replacement")
+				tlsprofile.WaitPodsRestarted(HubAPIClient, ibio)
+				tlsprofile.WaitPodsReady(HubAPIClient, ibio)
+
+				By("Verifying server container logs show TLS change detection")
+				serverDeploy := tlsprofile.Deployment{
+					Name:          ibio.Deployments[0].Name,
+					ContainerName: "server",
+				}
+				tlsprofile.AssertControllerLogsContain(HubAPIClient, ibio,
+					serverDeploy, "shutdown")
+			})
+
+		It("Verifies webhook validation after TLS profile change on IBIO",
+			reportxml.ID("88934"), func() {
+				By("Applying Custom TLS profile")
+				tlsprofile.PatchAPIServerTLSProfile(HubAPIClient, configv1.TLSSecurityProfile{
+					Type: configv1.TLSProfileCustomType,
+					Custom: &configv1.CustomTLSProfile{
+						TLSProfileSpec: configv1.TLSProfileSpec{
+							Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256", "ECDHE-RSA-AES256-GCM-SHA384", "ECDHE-ECDSA-AES128-GCM-SHA256", "ECDHE-ECDSA-AES256-GCM-SHA384"},
+							MinTLSVersion: configv1.VersionTLS12,
+						},
+					},
+				})
+
+				By("Waiting for IBIO pod restart")
+				tlsprofile.WaitPodsRestarted(HubAPIClient, ibio)
+				tlsprofile.WaitPodsReady(HubAPIClient, ibio)
+
+				By("Verifying webhook serves TLS correctly")
+				tlsprofile.AssertTLSConnects(HubAPIClient, ibio, ibio.Endpoints[0],
+					tls.VersionTLS12, tls.VersionTLS12,
+					[]uint16{tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256})
+			})
+	})

--- a/tests/assisted/ztp/tls-profile/tls_profile_suite_test.go
+++ b/tests/assisted/ztp/tls-profile/tls_profile_suite_test.go
@@ -1,0 +1,45 @@
+package tls_profile_test
+
+import (
+	"runtime"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/assisted/ztp/tls-profile/internal/inittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/assisted/ztp/tls-profile/internal/tsparams"
+	_ "github.com/rh-ecosystem-edge/eco-gotests/tests/assisted/ztp/tls-profile/tests"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/reporter"
+)
+
+var _, currentFile, _, _ = runtime.Caller(0)
+
+func TestTLSProfile(t *testing.T) {
+	_, reporterConfig := GinkgoConfiguration()
+	reporterConfig.JUnitReport = GeneralConfig.GetJunitReportPath(currentFile)
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "TLS Profile Suite", Label(tsparams.Labels...), reporterConfig)
+}
+
+var _ = BeforeSuite(func() {
+	By("Check if hub has valid apiClient")
+
+	if HubAPIClient == nil {
+		Skip("Cannot run TLS Profile suite when hub has nil api client")
+	}
+})
+
+var _ = ReportAfterSuite("", func(report Report) {
+	reportxml.Create(report, GeneralConfig.GetReportPath(), GeneralConfig.TCPrefix)
+})
+
+var _ = JustAfterEach(func() {
+	reporter.ReportIfFailed(
+		CurrentSpecReport(),
+		currentFile,
+		tsparams.ReporterNamespacesToDump,
+		tsparams.ReporterCRDsToDump)
+})

--- a/vendor/k8s.io/client-go/tools/portforward/OWNERS
+++ b/vendor/k8s.io/client-go/tools/portforward/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - aojea
+  - liggitt
+  - seans3
+reviewers:
+  - aojea
+  - liggitt
+  - seans3

--- a/vendor/k8s.io/client-go/tools/portforward/doc.go
+++ b/vendor/k8s.io/client-go/tools/portforward/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package portforward adds support for SSH-like port forwarding from the client's
+// local host to remote containers.
+package portforward

--- a/vendor/k8s.io/client-go/tools/portforward/fallback_dialer.go
+++ b/vendor/k8s.io/client-go/tools/portforward/fallback_dialer.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portforward
+
+import (
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/klog/v2"
+)
+
+var _ httpstream.Dialer = &FallbackDialer{}
+
+// FallbackDialer encapsulates a primary and secondary dialer, including
+// the boolean function to determine if the primary dialer failed. Implements
+// the httpstream.Dialer interface.
+type FallbackDialer struct {
+	primary        httpstream.Dialer
+	secondary      httpstream.Dialer
+	shouldFallback func(error) bool
+}
+
+// NewFallbackDialer creates the FallbackDialer with the primary and secondary dialers,
+// as well as the boolean function to determine if the primary dialer failed.
+func NewFallbackDialer(primary, secondary httpstream.Dialer, shouldFallback func(error) bool) httpstream.Dialer {
+	return &FallbackDialer{
+		primary:        primary,
+		secondary:      secondary,
+		shouldFallback: shouldFallback,
+	}
+}
+
+// Dial is the single function necessary to implement the "httpstream.Dialer" interface.
+// It takes the protocol version strings to request, returning an the upgraded
+// httstream.Connection and the negotiated protocol version accepted. If the initial
+// primary dialer fails, this function attempts the secondary dialer. Returns an error
+// if one occurs.
+func (f *FallbackDialer) Dial(protocols ...string) (httpstream.Connection, string, error) {
+	conn, version, err := f.primary.Dial(protocols...)
+	if err != nil && f.shouldFallback(err) {
+		klog.V(4).Infof("fallback to secondary dialer from primary dialer err: %v", err)
+		return f.secondary.Dial(protocols...)
+	}
+	return conn, version, err
+}

--- a/vendor/k8s.io/client-go/tools/portforward/portforward.go
+++ b/vendor/k8s.io/client-go/tools/portforward/portforward.go
@@ -1,0 +1,454 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portforward
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	netutils "k8s.io/utils/net"
+)
+
+// PortForwardProtocolV1Name is the subprotocol used for port forwarding.
+// TODO move to API machinery and re-unify with kubelet/server/portfoward
+const PortForwardProtocolV1Name = "portforward.k8s.io"
+
+var (
+	// error returned whenever we lost connection to a pod
+	ErrLostConnectionToPod = errors.New("lost connection to pod")
+
+	// set of error we're expecting during port-forwarding
+	networkClosedError = "use of closed network connection"
+)
+
+// PortForwarder knows how to listen for local connections and forward them to
+// a remote pod via an upgraded HTTP request.
+type PortForwarder struct {
+	addresses []listenAddress
+	ports     []ForwardedPort
+	stopChan  <-chan struct{}
+
+	dialer        httpstream.Dialer
+	streamConn    httpstream.Connection
+	listeners     []io.Closer
+	Ready         chan struct{}
+	requestIDLock sync.Mutex
+	requestID     int
+	out           io.Writer
+	errOut        io.Writer
+}
+
+// ForwardedPort contains a Local:Remote port pairing.
+type ForwardedPort struct {
+	Local  uint16
+	Remote uint16
+}
+
+/*
+valid port specifications:
+
+5000
+- forwards from localhost:5000 to pod:5000
+
+8888:5000
+- forwards from localhost:8888 to pod:5000
+
+0:5000
+:5000
+  - selects a random available local port,
+    forwards from localhost:<random port> to pod:5000
+*/
+func parsePorts(ports []string) ([]ForwardedPort, error) {
+	var forwards []ForwardedPort
+	for _, portString := range ports {
+		parts := strings.Split(portString, ":")
+		var localString, remoteString string
+		if len(parts) == 1 {
+			localString = parts[0]
+			remoteString = parts[0]
+		} else if len(parts) == 2 {
+			localString = parts[0]
+			if localString == "" {
+				// support :5000
+				localString = "0"
+			}
+			remoteString = parts[1]
+		} else {
+			return nil, fmt.Errorf("invalid port format '%s'", portString)
+		}
+
+		localPort, err := strconv.ParseUint(localString, 10, 16)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing local port '%s': %s", localString, err)
+		}
+
+		remotePort, err := strconv.ParseUint(remoteString, 10, 16)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing remote port '%s': %s", remoteString, err)
+		}
+		if remotePort == 0 {
+			return nil, fmt.Errorf("remote port must be > 0")
+		}
+
+		forwards = append(forwards, ForwardedPort{uint16(localPort), uint16(remotePort)})
+	}
+
+	return forwards, nil
+}
+
+type listenAddress struct {
+	address     string
+	protocol    string
+	failureMode string
+}
+
+func parseAddresses(addressesToParse []string) ([]listenAddress, error) {
+	var addresses []listenAddress
+	parsed := make(map[string]listenAddress)
+	for _, address := range addressesToParse {
+		if address == "localhost" {
+			if _, exists := parsed["127.0.0.1"]; !exists {
+				ip := listenAddress{address: "127.0.0.1", protocol: "tcp4", failureMode: "all"}
+				parsed[ip.address] = ip
+			}
+			if _, exists := parsed["::1"]; !exists {
+				ip := listenAddress{address: "::1", protocol: "tcp6", failureMode: "all"}
+				parsed[ip.address] = ip
+			}
+		} else if netutils.ParseIPSloppy(address).To4() != nil {
+			parsed[address] = listenAddress{address: address, protocol: "tcp4", failureMode: "any"}
+		} else if netutils.ParseIPSloppy(address) != nil {
+			parsed[address] = listenAddress{address: address, protocol: "tcp6", failureMode: "any"}
+		} else {
+			return nil, fmt.Errorf("%s is not a valid IP", address)
+		}
+	}
+	addresses = make([]listenAddress, len(parsed))
+	id := 0
+	for _, v := range parsed {
+		addresses[id] = v
+		id++
+	}
+	// Sort addresses before returning to get a stable order
+	sort.Slice(addresses, func(i, j int) bool { return addresses[i].address < addresses[j].address })
+
+	return addresses, nil
+}
+
+// New creates a new PortForwarder with localhost listen addresses.
+func New(dialer httpstream.Dialer, ports []string, stopChan <-chan struct{}, readyChan chan struct{}, out, errOut io.Writer) (*PortForwarder, error) {
+	return NewOnAddresses(dialer, []string{"localhost"}, ports, stopChan, readyChan, out, errOut)
+}
+
+// NewOnAddresses creates a new PortForwarder with custom listen addresses.
+func NewOnAddresses(dialer httpstream.Dialer, addresses []string, ports []string, stopChan <-chan struct{}, readyChan chan struct{}, out, errOut io.Writer) (*PortForwarder, error) {
+	if len(addresses) == 0 {
+		return nil, errors.New("you must specify at least 1 address")
+	}
+	parsedAddresses, err := parseAddresses(addresses)
+	if err != nil {
+		return nil, err
+	}
+	if len(ports) == 0 {
+		return nil, errors.New("you must specify at least 1 port")
+	}
+	parsedPorts, err := parsePorts(ports)
+	if err != nil {
+		return nil, err
+	}
+	return &PortForwarder{
+		dialer:    dialer,
+		addresses: parsedAddresses,
+		ports:     parsedPorts,
+		stopChan:  stopChan,
+		Ready:     readyChan,
+		out:       out,
+		errOut:    errOut,
+	}, nil
+}
+
+// ForwardPorts formats and executes a port forwarding request. The connection will remain
+// open until stopChan is closed.
+func (pf *PortForwarder) ForwardPorts() error {
+	defer pf.Close()
+
+	var err error
+	var protocol string
+	pf.streamConn, protocol, err = pf.dialer.Dial(PortForwardProtocolV1Name)
+	if err != nil {
+		return fmt.Errorf("error upgrading connection: %s", err)
+	}
+	defer pf.streamConn.Close()
+	if protocol != PortForwardProtocolV1Name {
+		return fmt.Errorf("unable to negotiate protocol: client supports %q, server returned %q", PortForwardProtocolV1Name, protocol)
+	}
+
+	return pf.forward()
+}
+
+// forward dials the remote host specific in req, upgrades the request, starts
+// listeners for each port specified in ports, and forwards local connections
+// to the remote host via streams.
+func (pf *PortForwarder) forward() error {
+	var err error
+
+	listenSuccess := false
+	for i := range pf.ports {
+		port := &pf.ports[i]
+		err = pf.listenOnPort(port)
+		switch {
+		case err == nil:
+			listenSuccess = true
+		default:
+			if pf.errOut != nil {
+				fmt.Fprintf(pf.errOut, "Unable to listen on port %d: %v\n", port.Local, err)
+			}
+		}
+	}
+
+	if !listenSuccess {
+		return fmt.Errorf("unable to listen on any of the requested ports: %v", pf.ports)
+	}
+
+	if pf.Ready != nil {
+		close(pf.Ready)
+	}
+
+	// wait for interrupt or conn closure
+	select {
+	case <-pf.stopChan:
+	case <-pf.streamConn.CloseChan():
+		return ErrLostConnectionToPod
+	}
+
+	return nil
+}
+
+// listenOnPort delegates listener creation and waits for connections on requested bind addresses.
+// An error is raised based on address groups (default and localhost) and their failure modes
+func (pf *PortForwarder) listenOnPort(port *ForwardedPort) error {
+	var errors []error
+	failCounters := make(map[string]int, 2)
+	successCounters := make(map[string]int, 2)
+	for _, addr := range pf.addresses {
+		err := pf.listenOnPortAndAddress(port, addr.protocol, addr.address)
+		if err != nil {
+			errors = append(errors, err)
+			failCounters[addr.failureMode]++
+		} else {
+			successCounters[addr.failureMode]++
+		}
+	}
+	if successCounters["all"] == 0 && failCounters["all"] > 0 {
+		return fmt.Errorf("%s: %v", "Listeners failed to create with the following errors", errors)
+	}
+	if failCounters["any"] > 0 {
+		return fmt.Errorf("%s: %v", "Listeners failed to create with the following errors", errors)
+	}
+	return nil
+}
+
+// listenOnPortAndAddress delegates listener creation and waits for new connections
+// in the background f
+func (pf *PortForwarder) listenOnPortAndAddress(port *ForwardedPort, protocol string, address string) error {
+	listener, err := pf.getListener(protocol, address, port)
+	if err != nil {
+		return err
+	}
+	pf.listeners = append(pf.listeners, listener)
+	go pf.waitForConnection(listener, *port)
+	return nil
+}
+
+// getListener creates a listener on the interface targeted by the given hostname on the given port with
+// the given protocol. protocol is in net.Listen style which basically admits values like tcp, tcp4, tcp6
+func (pf *PortForwarder) getListener(protocol string, hostname string, port *ForwardedPort) (net.Listener, error) {
+	listener, err := net.Listen(protocol, net.JoinHostPort(hostname, strconv.Itoa(int(port.Local))))
+	if err != nil {
+		return nil, fmt.Errorf("unable to create listener: Error %s", err)
+	}
+	listenerAddress := listener.Addr().String()
+	host, localPort, _ := net.SplitHostPort(listenerAddress)
+	localPortUInt, err := strconv.ParseUint(localPort, 10, 16)
+
+	if err != nil {
+		fmt.Fprintf(pf.out, "Failed to forward from %s:%d -> %d\n", hostname, localPortUInt, port.Remote)
+		return nil, fmt.Errorf("error parsing local port: %s from %s (%s)", err, listenerAddress, host)
+	}
+	port.Local = uint16(localPortUInt)
+	if pf.out != nil {
+		fmt.Fprintf(pf.out, "Forwarding from %s -> %d\n", net.JoinHostPort(hostname, strconv.Itoa(int(localPortUInt))), port.Remote)
+	}
+
+	return listener, nil
+}
+
+// waitForConnection waits for new connections to listener and handles them in
+// the background.
+func (pf *PortForwarder) waitForConnection(listener net.Listener, port ForwardedPort) {
+	for {
+		select {
+		case <-pf.streamConn.CloseChan():
+			return
+		default:
+			conn, err := listener.Accept()
+			if err != nil {
+				// TODO consider using something like https://github.com/hydrogen18/stoppableListener?
+				if !strings.Contains(strings.ToLower(err.Error()), networkClosedError) {
+					runtime.HandleError(fmt.Errorf("error accepting connection on port %d: %v", port.Local, err))
+				}
+				return
+			}
+			go pf.handleConnection(conn, port)
+		}
+	}
+}
+
+func (pf *PortForwarder) nextRequestID() int {
+	pf.requestIDLock.Lock()
+	defer pf.requestIDLock.Unlock()
+	id := pf.requestID
+	pf.requestID++
+	return id
+}
+
+// handleConnection copies data between the local connection and the stream to
+// the remote server.
+func (pf *PortForwarder) handleConnection(conn net.Conn, port ForwardedPort) {
+	defer conn.Close()
+
+	if pf.out != nil {
+		fmt.Fprintf(pf.out, "Handling connection for %d\n", port.Local)
+	}
+
+	requestID := pf.nextRequestID()
+
+	// create error stream
+	headers := http.Header{}
+	headers.Set(v1.StreamType, v1.StreamTypeError)
+	headers.Set(v1.PortHeader, fmt.Sprintf("%d", port.Remote))
+	headers.Set(v1.PortForwardRequestIDHeader, strconv.Itoa(requestID))
+	errorStream, err := pf.streamConn.CreateStream(headers)
+	if err != nil {
+		runtime.HandleError(fmt.Errorf("error creating error stream for port %d -> %d: %v", port.Local, port.Remote, err))
+		return
+	}
+	// we're not writing to this stream
+	errorStream.Close()
+	defer pf.streamConn.RemoveStreams(errorStream)
+
+	errorChan := make(chan error)
+	go func() {
+		message, err := io.ReadAll(errorStream)
+		switch {
+		case err != nil:
+			errorChan <- fmt.Errorf("error reading from error stream for port %d -> %d: %v", port.Local, port.Remote, err)
+		case len(message) > 0:
+			errorChan <- fmt.Errorf("an error occurred forwarding %d -> %d: %v", port.Local, port.Remote, string(message))
+		}
+		close(errorChan)
+	}()
+
+	// create data stream
+	headers.Set(v1.StreamType, v1.StreamTypeData)
+	dataStream, err := pf.streamConn.CreateStream(headers)
+	if err != nil {
+		runtime.HandleError(fmt.Errorf("error creating forwarding stream for port %d -> %d: %v", port.Local, port.Remote, err))
+		return
+	}
+	defer pf.streamConn.RemoveStreams(dataStream)
+
+	localError := make(chan struct{})
+	remoteDone := make(chan struct{})
+
+	go func() {
+		// Copy from the remote side to the local port.
+		if _, err := io.Copy(conn, dataStream); err != nil && !strings.Contains(strings.ToLower(err.Error()), networkClosedError) {
+			runtime.HandleError(fmt.Errorf("error copying from remote stream to local connection: %v", err))
+		}
+
+		// inform the select below that the remote copy is done
+		close(remoteDone)
+	}()
+
+	go func() {
+		// inform server we're not sending any more data after copy unblocks
+		defer dataStream.Close()
+
+		// Copy from the local port to the remote side.
+		if _, err := io.Copy(dataStream, conn); err != nil && !strings.Contains(strings.ToLower(err.Error()), networkClosedError) {
+			runtime.HandleError(fmt.Errorf("error copying from local connection to remote stream: %v", err))
+			// break out of the select below without waiting for the other copy to finish
+			close(localError)
+		}
+	}()
+
+	// wait for either a local->remote error or for copying from remote->local to finish
+	select {
+	case <-remoteDone:
+	case <-localError:
+	}
+
+	// reset dataStream to discard any unsent data, preventing port forwarding from being blocked.
+	// we must reset dataStream before waiting on errorChan, otherwise,
+	// the blocking data will affect errorStream and cause <-errorChan to block indefinitely.
+	_ = dataStream.Reset()
+
+	// always expect something on errorChan (it may be nil)
+	err = <-errorChan
+	if err != nil {
+		runtime.HandleError(err)
+		pf.streamConn.Close()
+	}
+}
+
+// Close stops all listeners of PortForwarder.
+func (pf *PortForwarder) Close() {
+	// stop all listeners
+	for _, l := range pf.listeners {
+		if err := l.Close(); err != nil {
+			runtime.HandleError(fmt.Errorf("error closing listener: %v", err))
+		}
+	}
+}
+
+// GetPorts will return the ports that were forwarded; this can be used to
+// retrieve the locally-bound port in cases where the input was port 0. This
+// function will signal an error if the Ready channel is nil or if the
+// listeners are not ready yet; this function will succeed after the Ready
+// channel has been closed.
+func (pf *PortForwarder) GetPorts() ([]ForwardedPort, error) {
+	if pf.Ready == nil {
+		return nil, fmt.Errorf("no Ready channel provided")
+	}
+	select {
+	case <-pf.Ready:
+		return pf.ports, nil
+	default:
+		return nil, fmt.Errorf("listeners not ready")
+	}
+}

--- a/vendor/k8s.io/client-go/tools/portforward/tunneling_connection.go
+++ b/vendor/k8s.io/client-go/tools/portforward/tunneling_connection.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portforward
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"time"
+
+	gwebsocket "github.com/gorilla/websocket"
+
+	"k8s.io/klog/v2"
+)
+
+var _ net.Conn = &TunnelingConnection{}
+
+// TunnelingConnection implements the "httpstream.Connection" interface, wrapping
+// a websocket connection that tunnels SPDY.
+type TunnelingConnection struct {
+	name              string
+	conn              *gwebsocket.Conn
+	inProgressMessage io.Reader
+	closeOnce         sync.Once
+}
+
+// NewTunnelingConnection wraps the passed gorilla/websockets connection
+// with the TunnelingConnection struct (implementing net.Conn).
+func NewTunnelingConnection(name string, conn *gwebsocket.Conn) *TunnelingConnection {
+	return &TunnelingConnection{
+		name: name,
+		conn: conn,
+	}
+}
+
+// Read implements "io.Reader" interface, reading from the stored connection
+// into the passed buffer "p". Returns the number of bytes read and an error.
+// Can keep track of the "inProgress" messsage from the tunneled connection.
+func (c *TunnelingConnection) Read(p []byte) (int, error) {
+	klog.V(7).Infof("%s: tunneling connection read...", c.name)
+	defer klog.V(7).Infof("%s: tunneling connection read...complete", c.name)
+	for {
+		if c.inProgressMessage == nil {
+			klog.V(8).Infof("%s: tunneling connection read before NextReader()...", c.name)
+			messageType, nextReader, err := c.conn.NextReader()
+			if err != nil {
+				closeError := &gwebsocket.CloseError{}
+				if errors.As(err, &closeError) && closeError.Code == gwebsocket.CloseNormalClosure {
+					return 0, io.EOF
+				}
+				klog.V(4).Infof("%s:tunneling connection NextReader() error: %v", c.name, err)
+				return 0, err
+			}
+			if messageType != gwebsocket.BinaryMessage {
+				return 0, fmt.Errorf("invalid message type received")
+			}
+			c.inProgressMessage = nextReader
+		}
+		klog.V(8).Infof("%s: tunneling connection read in progress message...", c.name)
+		i, err := c.inProgressMessage.Read(p)
+		if i == 0 && err == io.EOF {
+			c.inProgressMessage = nil
+		} else {
+			klog.V(8).Infof("%s: read %d bytes, error=%v, bytes=% X", c.name, i, err, p[:i])
+			return i, err
+		}
+	}
+}
+
+// Write implements "io.Writer" interface, copying the data in the passed
+// byte array "p" into the stored tunneled connection. Returns the number
+// of bytes written and an error.
+func (c *TunnelingConnection) Write(p []byte) (n int, err error) {
+	klog.V(7).Infof("%s: write: %d bytes, bytes=% X", c.name, len(p), p)
+	defer klog.V(7).Infof("%s: tunneling connection write...complete", c.name)
+	w, err := c.conn.NextWriter(gwebsocket.BinaryMessage)
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		// close, which flushes the message
+		closeErr := w.Close()
+		if closeErr != nil && err == nil {
+			// if closing/flushing errored and we weren't already returning an error, return the close error
+			err = closeErr
+		}
+	}()
+
+	n, err = w.Write(p)
+	return
+}
+
+// Close implements "io.Closer" interface, signaling the other tunneled connection
+// endpoint, and closing the tunneled connection only once.
+func (c *TunnelingConnection) Close() error {
+	var err error
+	c.closeOnce.Do(func() {
+		klog.V(7).Infof("%s: tunneling connection Close()...", c.name)
+		// Signal other endpoint that websocket connection is closing; ignore error.
+		normalCloseMsg := gwebsocket.FormatCloseMessage(gwebsocket.CloseNormalClosure, "")
+		writeControlErr := c.conn.WriteControl(gwebsocket.CloseMessage, normalCloseMsg, time.Now().Add(time.Second))
+		closeErr := c.conn.Close()
+		if closeErr != nil {
+			err = closeErr
+		} else if writeControlErr != nil {
+			err = writeControlErr
+		}
+	})
+	return err
+}
+
+// LocalAddr implements part of the "net.Conn" interface, returning the local
+// endpoint network address of the tunneled connection.
+func (c *TunnelingConnection) LocalAddr() net.Addr {
+	return c.conn.LocalAddr()
+}
+
+// LocalAddr implements part of the "net.Conn" interface, returning the remote
+// endpoint network address of the tunneled connection.
+func (c *TunnelingConnection) RemoteAddr() net.Addr {
+	return c.conn.RemoteAddr()
+}
+
+// SetDeadline sets the *absolute* time in the future for both
+// read and write deadlines. Returns an error if one occurs.
+func (c *TunnelingConnection) SetDeadline(t time.Time) error {
+	rerr := c.SetReadDeadline(t)
+	werr := c.SetWriteDeadline(t)
+	return errors.Join(rerr, werr)
+}
+
+// SetDeadline sets the *absolute* time in the future for the
+// read deadlines. Returns an error if one occurs.
+func (c *TunnelingConnection) SetReadDeadline(t time.Time) error {
+	return c.conn.SetReadDeadline(t)
+}
+
+// SetDeadline sets the *absolute* time in the future for the
+// write deadlines. Returns an error if one occurs.
+func (c *TunnelingConnection) SetWriteDeadline(t time.Time) error {
+	return c.conn.SetWriteDeadline(t)
+}

--- a/vendor/k8s.io/client-go/tools/portforward/tunneling_dialer.go
+++ b/vendor/k8s.io/client-go/tools/portforward/tunneling_dialer.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portforward
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/apimachinery/pkg/util/httpstream/spdy"
+	constants "k8s.io/apimachinery/pkg/util/portforward"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/transport/websocket"
+	"k8s.io/klog/v2"
+)
+
+const PingPeriod = 10 * time.Second
+
+// tunnelingDialer implements "httpstream.Dial" interface
+type tunnelingDialer struct {
+	url       *url.URL
+	transport http.RoundTripper
+	holder    websocket.ConnectionHolder
+}
+
+// NewTunnelingDialer creates and returns the tunnelingDialer structure which implemements the "httpstream.Dialer"
+// interface. The dialer can upgrade a websocket request, creating a websocket connection. This function
+// returns an error if one occurs.
+func NewSPDYOverWebsocketDialer(url *url.URL, config *restclient.Config) (httpstream.Dialer, error) {
+	transport, holder, err := websocket.RoundTripperFor(config)
+	if err != nil {
+		return nil, err
+	}
+	return &tunnelingDialer{
+		url:       url,
+		transport: transport,
+		holder:    holder,
+	}, nil
+}
+
+// Dial upgrades to a tunneling streaming connection, returning a SPDY connection
+// containing a WebSockets connection (which implements "net.Conn"). Also
+// returns the protocol negotiated, or an error.
+func (d *tunnelingDialer) Dial(protocols ...string) (httpstream.Connection, string, error) {
+	// There is no passed context, so skip the context when creating request for now.
+	// Websockets requires "GET" method: RFC 6455 Sec. 4.1 (page 17).
+	req, err := http.NewRequest("GET", d.url.String(), nil)
+	if err != nil {
+		return nil, "", err
+	}
+	// Add the spdy tunneling prefix to the requested protocols. The tunneling
+	// handler will know how to negotiate these protocols.
+	tunnelingProtocols := []string{}
+	for _, protocol := range protocols {
+		tunnelingProtocol := constants.WebsocketsSPDYTunnelingPrefix + protocol
+		tunnelingProtocols = append(tunnelingProtocols, tunnelingProtocol)
+	}
+	klog.V(4).Infoln("Before WebSocket Upgrade Connection...")
+	conn, err := websocket.Negotiate(d.transport, d.holder, req, tunnelingProtocols...)
+	if err != nil {
+		return nil, "", err
+	}
+	if conn == nil {
+		return nil, "", fmt.Errorf("negotiated websocket connection is nil")
+	}
+	protocol := conn.Subprotocol()
+	protocol = strings.TrimPrefix(protocol, constants.WebsocketsSPDYTunnelingPrefix)
+	klog.V(4).Infof("negotiated protocol: %s", protocol)
+
+	// Wrap the websocket connection which implements "net.Conn".
+	tConn := NewTunnelingConnection("client", conn)
+	// Create SPDY connection injecting the previously created tunneling connection.
+	spdyConn, err := spdy.NewClientConnectionWithPings(tConn, PingPeriod)
+
+	return spdyConn, protocol, err
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2167,6 +2167,7 @@ k8s.io/client-go/tools/leaderelection
 k8s.io/client-go/tools/leaderelection/resourcelock
 k8s.io/client-go/tools/metrics
 k8s.io/client-go/tools/pager
+k8s.io/client-go/tools/portforward
 k8s.io/client-go/tools/record
 k8s.io/client-go/tools/record/util
 k8s.io/client-go/tools/reference


### PR DESCRIPTION
Implement 8 test cases (OCP-88843 through OCP-88858) verifying that CAPOA bootstrap and controlplane webhook servers respect the cluster-wide TLS security profile from apiserver.config.openshift.io/cluster.

Tests run in a standalone capoa-tls sub-suite with their own inittools (no assisted-image-service dependency). Covers Intermediate (default), Old, Modern, and Custom profiles, automatic reconciliation via SecurityProfileWatcher, webhook validation after profile changes, and clean restore to defaults.

Uses eco-goinfra pod/namespace utilities and k8s client-go retry for transient API errors. TLS probing done via SPDY port-forward to webhook pods on container port 9443.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a TLS profile testing framework with suites for multiple components.
  * New test cases validating TLS versions, cipher enforcement, webhook behavior, and automatic reconciliation on profile changes.
  * Added helpers for pod lifecycle checks, restart verification, port-forwarding, TLS handshake assertions, reporting hooks, and component test configurations.

* **Chores**
  * Updated linter configuration to allow specific test initialization patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->