### PR TITLE
lca ipc: support ipv6 single scenario

### DIFF
--- a/tests/lca/ipchange/tests/ipconfig-test.go
+++ b/tests/lca/ipchange/tests/ipconfig-test.go
@@ -2,11 +2,13 @@ package ipchange_test
 
 import (
 	"fmt"
+	"net"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/lca"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/network"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
 	lcaipcv1 "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/ipchange/api/ipconfig/v1"
 
@@ -130,11 +132,17 @@ var _ = Describe(
 				InitMonitorTimeoutSeconds: 9,
 			}
 
-			By("Updating IPv4 fields with arbitrary values to ensure the spec is updated")
+			By("Updating IP address fields with arbitrary values to ensure the spec is updated")
 
-			builder.WithIPv4Address("192.168.250.250").
-				WithIPv4Gateway("192.168.250.254").
-				WithIPv4MachineNetwork("192.168.250.0/24")
+			if clusterHasIPv4Network() {
+				builder.WithIPv4Address("192.168.250.250").
+					WithIPv4Gateway("192.168.250.254").
+					WithIPv4MachineNetwork("192.168.250.0/24")
+			} else {
+				builder.WithIPv6Address("2001:db8::2").
+					WithIPv6Gateway("2001:db8::1").
+					WithIPv6MachineNetwork("2001:db8::/64")
+			}
 
 			By("Setting the stage to Config")
 
@@ -183,3 +191,19 @@ var _ = Describe(
 			Expect(err).NotTo(HaveOccurred(), "failed to wait for IPConfig to become Idle")
 		})
 	})
+
+// clusterHasIPv4Network returns true if the cluster has at least one IPv4 cluster network CIDR
+// configured in the cluster-level Network config (config.openshift.io/v1).
+func clusterHasIPv4Network() bool {
+	netConfig, err := network.PullConfig(APIClient)
+	Expect(err).NotTo(HaveOccurred(), "failed to pull cluster network config")
+
+	for _, clusterNet := range netConfig.Object.Spec.ClusterNetwork {
+		ip, _, err := net.ParseCIDR(clusterNet.CIDR)
+		if err == nil && ip.To4() != nil {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
Assuring the tests don't fail on a setup
with single stack IPv6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced IP configuration test to dynamically support both IPv4 and IPv6 scenarios by detecting cluster network CIDRs, improving robustness and coverage.
  * Added an assertion to ensure cluster network information is successfully retrieved before proceeding, reducing flakiness and false negatives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->