### PR TITLE
kmm modules: fix nil pointer panic in build-without-loading test

### DIFF
--- a/tests/hw-accel/kmm/modules/tests/external-registry-test.go
+++ b/tests/hw-accel/kmm/modules/tests/external-registry-test.go
@@ -383,6 +383,8 @@ var _ = Describe("KMM", Label(kmmparams.LabelSuite, kmmparams.LabelSanity), func
 
 			configmapContent := define.SimpleKmodConfigMapContents()
 
+			_ = configmap.NewBuilder(APIClient, moduleName, localNsName).Delete()
+
 			dockerfileConfigMap, err := configmap.NewBuilder(APIClient, moduleName, localNsName).
 				WithData(configmapContent).Create()
 


### PR DESCRIPTION
## Summary
- Delete stale configmap before creating it in the "should build image without loading it" test
- The configmap `simple-kmod` is created by Context 1 and never cleaned up before Context 2 reuses the same name
- The common framework's `Create()` returns nil error on `AlreadyExists` but does not set `builder.Object`, causing a nil pointer dereference at `dockerfileConfigMap.Object.Name`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test robustness by adding cleanup logic to ensure consistent state initialization before test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->