### PR TITLE
Tolerate managed cluster webhook in KMM AfterSuite cleanup

### DIFF
--- a/tests/hw-accel/kmm/modules/modules_suite_test.go
+++ b/tests/hw-accel/kmm/modules/modules_suite_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/kmm/internal/kmmparams"
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/internal/inittools"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/reporter"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog/v2"
@@ -120,13 +121,23 @@ var _ = AfterSuite(func() {
 	svcAccount.Exists()
 
 	crb := define.ModuleCRB(*svcAccount, prereqName)
-	err = crb.Delete()
-	Expect(err).ToNot(HaveOccurred(), "error deleting helper clusterrolebinding")
+	if err = crb.Delete(); err != nil {
+		if k8serrors.IsForbidden(err) {
+			klog.Infof("Skipping CRB deletion: blocked by managed cluster admission webhook: %v", err)
+		} else {
+			Expect(err).ToNot(HaveOccurred(), "error deleting helper clusterrolebinding")
+		}
+	}
 
 	By("Delete helper service account")
 
-	err = svcAccount.Delete()
-	Expect(err).ToNot(HaveOccurred(), "error deleting helper serviceaccount")
+	if err = svcAccount.Delete(); err != nil {
+		if k8serrors.IsForbidden(err) {
+			klog.Infof("Skipping SA deletion: blocked by managed cluster admission webhook: %v", err)
+		} else {
+			Expect(err).ToNot(HaveOccurred(), "error deleting helper serviceaccount")
+		}
+	}
 })
 
 var _ = ReportAfterSuite("", func(report Report) {


### PR DESCRIPTION
On ROSA/managed OpenShift clusters, the admission webhook clusterrolebindings-validation.managed.openshift.io blocks deletion of certain ClusterRoleBindings with a 403 Forbidden. This caused the KMM modules AfterSuite to fail even though all 47 test specs passed.

Check for k8serrors.IsForbidden on CRB and SA deletion: log a warning and continue on managed clusters, fail on other errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test resilience by enhancing error handling for resource cleanup operations in test scenarios. When managed cluster admission webhooks restrict access to helper resources, the test suite now gracefully skips deletion operations and logs the action, while maintaining strict error reporting for other failure conditions. This ensures more stable and reliable test execution across different cluster environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->