### PR TITLE
system-tests: enhance drain timeout for production clusters

### DIFF
--- a/tests/system-tests/rdscore/internal/rdscorecommon/hard-reboot.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/hard-reboot.go
@@ -212,8 +212,7 @@ func VerifySoftReboot(ctx SpecContext) {
 
 		time.Sleep(5 * time.Second)
 
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Draining node %q", _node.Definition.Name)
-		err = _node.Drain()
+		err = DrainNodeWithRetry(ctx, _node)
 		Expect(err).ToNot(HaveOccurred(),
 			fmt.Sprintf("Failed to drain %q due to %v", _node.Definition.Name, err))
 

--- a/tests/system-tests/rdscore/internal/rdscorecommon/rdscore-helpers.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/rdscore-helpers.go
@@ -3,6 +3,7 @@ package rdscorecommon
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -16,6 +17,12 @@ import (
 const (
 	uncordonNodeInterval = 15 * time.Second
 	uncordonNodeTimeout  = 3 * time.Minute
+
+	// Drain operation constants.
+	drainNodeTimeout      = 25 * time.Minute // Total drain timeout
+	drainNodeGracePeriod  = 600              // Pod termination grace period (10 min)
+	drainNodeSkipWait     = 300              // Skip wait for stuck pods (5 min)
+	drainNodeRetryTimeout = 2 * time.Minute  // Retry window for transient failures
 )
 
 // UncordonNode uncordons a node referenced by nodeToUncordon parameter.
@@ -39,4 +46,69 @@ func UncordonNode(nodeToUncordon *nodes.Builder, interval, timeout time.Duration
 	if err != nil {
 		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to uncordon %q: %v", nodeToUncordon.Definition.Name, err)
 	}
+}
+
+// DrainNodeWithRetry drains a node with retry logic for transient failures.
+// It configures drain with production-appropriate timeouts and logs drain duration.
+func DrainNodeWithRetry(ctx context.Context, nodeToDrain *nodes.Builder) error {
+	By(fmt.Sprintf("Draining node %q with timeout=%v",
+		nodeToDrain.Definition.Name, drainNodeTimeout))
+
+	// Configure drain with extended timeout
+	nodeToDrain.SetDrainHelper(
+		true,                 // force: allow standalone pods
+		true,                 // ignoreDaemonsets: required for OpenShift
+		true,                 // deleteLocalData: required for emptyDir volumes
+		drainNodeGracePeriod, // gracePeriod: 10 minutes for clean shutdown
+		drainNodeSkipWait,    // skipWaitForDelete: 5 minutes for stuck pods
+		drainNodeTimeout,     // timeout: 25 minutes total
+	)
+
+	klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+		"Drain configuration - timeout=%v, gracePeriod=%ds, skipWait=%ds",
+		drainNodeTimeout, drainNodeGracePeriod, drainNodeSkipWait)
+
+	startTime := time.Now()
+
+	var lastErr error
+
+	// Retry for transient failures (gRPC keepalive timeouts, etc.)
+	err := wait.PollUntilContextTimeout(ctx, 15*time.Second,
+		drainNodeRetryTimeout, true,
+		func(context.Context) (bool, error) {
+			lastErr = nodeToDrain.Drain()
+			if lastErr == nil {
+				duration := time.Since(startTime)
+				klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+					"Successfully drained node %q in %v",
+					nodeToDrain.Definition.Name, duration)
+
+				return true, nil
+			}
+
+			// Check if error is retryable (gRPC/network issues)
+			errorMsg := lastErr.Error()
+			if strings.Contains(errorMsg, "keepalive") ||
+				strings.Contains(errorMsg, "Unavailable") ||
+				strings.Contains(errorMsg, "connection refused") {
+				klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+					"Drain failed with retryable error, will retry: %v", lastErr)
+
+				return false, nil // Retry
+			}
+
+			// Non-retryable error - fail immediately
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+				"Drain failed with non-retryable error: %v", lastErr)
+
+			return false, lastErr
+		})
+	if err != nil {
+		duration := time.Since(startTime)
+
+		return fmt.Errorf("failed to drain node %q after %v: %w",
+			nodeToDrain.Definition.Name, duration, lastErr)
+	}
+
+	return lastErr
 }

--- a/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-statefulset.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-statefulset.go
@@ -1127,7 +1127,8 @@ func ensurePodConnectivityAfterPodTermination(stLabel, namespace, targetPort str
 // ensurePodConnectivityAfterNodeDrain verifies inter-pod connectivity is restored after draining a node.
 //
 //nolint:funlen
-func ensurePodConnectivityAfterNodeDrain(stLabel, namespace, targetPort string, stReplicas int, sameNode bool) {
+func ensurePodConnectivityAfterNodeDrain(
+	ctx SpecContext, stLabel, namespace, targetPort string, stReplicas int, sameNode bool) {
 	By("Getting list of active pods")
 
 	activePods := getActivePods(stLabel, namespace)
@@ -1166,20 +1167,14 @@ func ensurePodConnectivityAfterNodeDrain(stLabel, namespace, targetPort string, 
 
 	defer UncordonNode(nodeObj, uncordonNodeInterval, uncordonNodeTimeout)
 
-	By(fmt.Sprintf("Draining node %q", nodeToDrain))
-
-	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Draining node %q", nodeToDrain)
-
 	time.Sleep(5 * time.Second)
 
-	err = nodeObj.Drain()
+	err = DrainNodeWithRetry(ctx, nodeObj)
 
 	Expect(err).ToNot(HaveOccurred(),
 		fmt.Sprintf("Failed to drain node %s due to: %v", nodeToDrain, err))
 
 	By("Waiting for new pod to be created")
-
-	var ctx SpecContext
 
 	Eventually(func() bool {
 		newActivePods := getActivePods(stLabel, namespace)
@@ -1805,7 +1800,7 @@ func EnsurePodConnectivityBetweenDifferentNodesAfterNodeDrain(ctx SpecContext) {
 
 	CreateStatefulsetOnDifferentNode(ctx)
 
-	ensurePodConnectivityAfterNodeDrain(myStatefulsetTwoLabel, RDSCoreConfig.WhereaboutNS,
+	ensurePodConnectivityAfterNodeDrain(ctx, myStatefulsetTwoLabel, RDSCoreConfig.WhereaboutNS,
 		RDSCoreConfig.WhereaboutsSTTwoPort, myStatefulsetTwoReplicas, false)
 }
 
@@ -1816,7 +1811,7 @@ func EnsurePodConnectivityOnSameNodeAfterNodeDrain(ctx SpecContext) {
 
 	CreateStatefulsetOnSameNode(ctx)
 
-	ensurePodConnectivityAfterNodeDrain(myStatefulsetOneLabel, RDSCoreConfig.WhereaboutNS,
+	ensurePodConnectivityAfterNodeDrain(ctx, myStatefulsetOneLabel, RDSCoreConfig.WhereaboutNS,
 		RDSCoreConfig.WhereaboutsSTOnePort, myStatefulsetOneReplicas, true)
 }
 


### PR DESCRIPTION
Graceful cluster reboot was failing on production
RDS clusters due to insufficient drain timeout.

Changes:
- Add DrainNodeWithRetry() helper with 25-minute timeout
- Add retry logic for transient gRPC keepalive failures
- Add drain duration logging for diagnostics
- Update VerifySoftReboot() to use new helper

Co-Authored-By: Claude Sonnet 4.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved node-drain behavior in reboot tests with retrying and extended timeouts to better handle transient network failures.
  * Drain operations now respect the calling context and are more resilient to intermittent errors, reducing flakiness in connectivity checks after reboots.
  * Removed redundant drain log output; overall reboot and readiness validation logic unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->