### PR TITLE
lca: fix seed hostname reference filter for kube-controller-manager GC logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ reports
 .claude/
 tests/hw-accel/nfd/**/*.md
 tests/hw-accel/nfd/*.md
+CLAUDE.local.md

--- a/tests/lca/imagebasedupgrade/cnf/internal/validations/post_ibu_validations.go
+++ b/tests/lca/imagebasedupgrade/cnf/internal/validations/post_ibu_validations.go
@@ -224,10 +224,11 @@ func ValidateSeedHostnameRefLogs() {
 	It("Validate no seed hostname references in pod logs", reportxml.ID("71392"), Label("ValidateSeedRefPodLogs",
 		"ValidateSeedReferences"), func() {
 		By("Validate no seed hostname references in pod logs", func() {
-			// Seed refs from garbage-collector-controller are expected during IBU; exclude them from this check.
+			// Seed refs from kube-controller-manager's garbage collector are expected during IBU
+			// as it cleans up seed Node/MachineConfigNode resources post-pivot.
 			logCmd := fmt.Sprintf(
 				`grep -Ri %q /var/log/pods | `+
-					`grep -vE "lifecycle-agent-controller-manager|garbage-collector-controller" | wc -l`,
+					`grep -vE "lifecycle-agent-controller-manager|kube-controller-manager" | wc -l`,
 				seedInfo.SNOHostname,
 			)
 			logRes, err := cluster.ExecCmdWithStdout(TargetSNOAPIClient, logCmd)


### PR DESCRIPTION
The test was excluding 'garbage-collector-controller' but GC logs come from 'kube-controller-manager' pod. Updated filter to correctly exclude expected kube-controller-manager GC cleanup logs of stale seed resources post-IBU.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated validation checks for image-based upgrade log analysis
* **Chores**
  * Updated local file configuration exclusions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->