### PR TITLE
system-tests: add waitgroup

### DIFF
--- a/tests/system-tests/rdscore/internal/rdscorecommon/sriov-pod-level-bond.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/sriov-pod-level-bond.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/system-tests/rdscore/internal/rdscoreparams"
@@ -1360,8 +1361,13 @@ func VerifyPodLevelBondWorkloadsAfterVFFailOver() {
 		Fail("Neither IPv4 nor IPv6 server address is configured for the server deployment")
 	}
 
-	go func() {
+	var waitGroup sync.WaitGroup
+
+	waitGroup.Add(2)
+
+	go func(waitGroup *sync.WaitGroup) {
 		defer GinkgoRecover()
+		defer waitGroup.Done()
 
 		By(fmt.Sprintf("Send data from the client container to the server address %s", targetIP))
 
@@ -1385,10 +1391,11 @@ func VerifyPodLevelBondWorkloadsAfterVFFailOver() {
 		Expect(testPassed).To(Equal(true),
 			fmt.Sprintf("TCP traffic test verification failed for the pod %s in namespace %s; output %s",
 				clientPodObj.Definition.Name, clientPodObj.Definition.Namespace, output))
-	}()
+	}(&waitGroup)
 
-	go func() {
+	go func(waitGroup *sync.WaitGroup) {
 		defer GinkgoRecover()
+		defer waitGroup.Done()
 
 		time.Sleep(time.Second * 2)
 
@@ -1396,7 +1403,7 @@ func VerifyPodLevelBondWorkloadsAfterVFFailOver() {
 		Expect(err).ToNot(HaveOccurred(),
 			fmt.Sprintf("Failed to disable bond active interface for the pod %s in namespace %s: %v",
 				serverPodObj.Definition.Name, serverPodObj.Definition.Namespace, err))
-	}()
+	}(&waitGroup)
 
 	var ctx SpecContext
 
@@ -1420,6 +1427,8 @@ func VerifyPodLevelBondWorkloadsAfterVFFailOver() {
 		return true
 	}).WithContext(ctx).WithPolling(time.Second).WithTimeout(30*time.Second).Should(BeTrue(),
 		"Fail-Over procedure failure; failed to switch to the new bond active interface")
+
+	waitGroup.Wait()
 
 	verifyConnectivity()
 }

--- a/tests/system-tests/rdscore/internal/rdscorecommon/sriov-pod-level-bond.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/sriov-pod-level-bond.go
@@ -1399,10 +1399,10 @@ func VerifyPodLevelBondWorkloadsAfterVFFailOver() {
 
 		time.Sleep(time.Second * 2)
 
-		err = disableBondActiveVFInterface(serverPodObj)
-		Expect(err).ToNot(HaveOccurred(),
+		disableErr := disableBondActiveVFInterface(serverPodObj)
+		Expect(disableErr).ToNot(HaveOccurred(),
 			fmt.Sprintf("Failed to disable bond active interface for the pod %s in namespace %s: %v",
-				serverPodObj.Definition.Name, serverPodObj.Definition.Namespace, err))
+				serverPodObj.Definition.Name, serverPodObj.Definition.Namespace, disableErr))
 	}(&waitGroup)
 
 	var ctx SpecContext

--- a/tests/system-tests/rdscore/internal/rdscorecommon/sriov-pod-level-bond.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/sriov-pod-level-bond.go
@@ -1364,6 +1364,7 @@ func VerifyPodLevelBondWorkloadsAfterVFFailOver() {
 	var waitGroup sync.WaitGroup
 
 	waitGroup.Add(2)
+	defer waitGroup.Wait()
 
 	go func(waitGroup *sync.WaitGroup) {
 		defer GinkgoRecover()
@@ -1427,8 +1428,6 @@ func VerifyPodLevelBondWorkloadsAfterVFFailOver() {
 		return true
 	}).WithContext(ctx).WithPolling(time.Second).WithTimeout(30*time.Second).Should(BeTrue(),
 		"Fail-Over procedure failure; failed to switch to the new bond active interface")
-
-	waitGroup.Wait()
 
 	verifyConnectivity()
 }


### PR DESCRIPTION
Add sync.WaitGroup to fix goroutine leak in VerifyPodLevelBondWorkloadsAfterVFFailOver. It caused false failures in subsequent tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved SR-IOV pod-level bond failover test: added coordinated concurrent actions to more reliably simulate interface disablement and traffic during failover, increasing realism and stability of failover verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->