### PR TITLE
CNF-20475: migrate tbc ttsc holdover tests dpopsuev

### DIFF
--- a/tests/cnf/ran/ptp/internal/consumer/consumerv2.go
+++ b/tests/cnf/ran/ptp/internal/consumer/consumerv2.go
@@ -109,12 +109,12 @@ func createV2ConsumerDeploymentOnNode(client *clients.Settings, nodeName string)
 		return fmt.Errorf("failed to create consumer container: %w", err)
 	}
 
-	apiAddr := fmt.Sprintf("--local-api-addr=%s.%s.svc.cluster.local:9043",
+	apiAddr := fmt.Sprintf("--local-api-addr=%s.%s.svc.cluster.local.:9043",
 		getConsumerServiceName(nodeName), tsparams.CloudEventsNamespace)
 	consumerContainer.Args = []string{
 		apiAddr,
 		"--api-path=/api/ocloudNotifications/v2/",
-		"--http-event-publishers=ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043",
+		"--http-event-publishers=ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local.:9043",
 	}
 	consumerContainer.SecurityContext = nil
 

--- a/tests/cnf/ran/ptp/internal/metrics/consts.go
+++ b/tests/cnf/ran/ptp/internal/metrics/consts.go
@@ -48,8 +48,11 @@ type PtpClockClass uint8
 //nolint:revive // The clock class names are self explanatory and do not need individual comments.
 const (
 	ClockClass6   PtpClockClass = 6
-	ClockClass248 PtpClockClass = 248
 	ClockClass7   PtpClockClass = 7
+	ClockClass135 PtpClockClass = 135
+	ClockClass165 PtpClockClass = 165
+	ClockClass248 PtpClockClass = 248
+	ClockClass255 PtpClockClass = 255
 )
 
 // PtpProcessStatus is an enum representing all possible states of the PTP process.
@@ -142,5 +145,6 @@ const (
 	ProcessDPLL    PtpProcess = "dpll"
 	ProcessGNSS    PtpProcess = "gnss"
 	ProcessGM      PtpProcess = "GM"
+	ProcessTBC     PtpProcess = "T-BC"
 	ProcessChronyd PtpProcess = "chronyd"
 )

--- a/tests/cnf/ran/ptp/internal/profiles/nodematcher.go
+++ b/tests/cnf/ran/ptp/internal/profiles/nodematcher.go
@@ -49,8 +49,10 @@ func GetNodeInfoMap(client *clients.Settings) (map[string]*NodeInfo, error) {
 			Name: nodeBuilder.Definition.Name,
 		}
 
+		controlledNames := getControlledNamesForNode(recommendsForNode, ptpConfigList)
+
 		for reference := range recommendsForNode {
-			profileInfo, err := getMemoizedAndClonedProfileInfo(reference, ptpConfigList, ptpProfileInfos)
+			profileInfo, err := getMemoizedAndClonedProfileInfo(reference, ptpConfigList, ptpProfileInfos, controlledNames)
 			if err != nil {
 				klog.V(tsparams.LogLevel).Infof("Failed to get profile info for reference %v: %v", reference, err)
 
@@ -163,6 +165,41 @@ func nodeMatches(node *corev1.Node, recommend ptpv1.PtpRecommend) bool {
 	return false
 }
 
+// getControlledNamesForNode scans all profiles recommended to the node and collects the values of controllingProfile
+// PTP settings. The returned map contains profile names that are referenced as T-BC receivers by a TBC transmitter.
+func getControlledNamesForNode(
+	recommendsForNode map[ProfileReference]struct{},
+	allConfigs []*ptp.PtpConfigBuilder,
+) map[string]bool {
+	controlled := map[string]bool{}
+
+	for reference := range recommendsForNode {
+		configIndex := slices.IndexFunc(allConfigs, func(config *ptp.PtpConfigBuilder) bool {
+			return runtimeclient.ObjectKeyFromObject(config.Definition) == reference.ConfigReference
+		})
+
+		if configIndex == -1 {
+			continue
+		}
+
+		configProfiles := allConfigs[configIndex].Definition.Spec.Profile
+		if reference.ProfileIndex < 0 || reference.ProfileIndex >= len(configProfiles) {
+			continue
+		}
+
+		profile := configProfiles[reference.ProfileIndex]
+		if profile.PtpSettings == nil {
+			continue
+		}
+
+		if name, ok := profile.PtpSettings["controllingProfile"]; ok && name != "" {
+			controlled[name] = true
+		}
+	}
+
+	return controlled
+}
+
 // getMemoizedAndClonedProfileInfo retrieves a ProfileInfo for the given reference from the provided PtpConfigs. If the
 // profile has already been parsed and saved in ptpProfileInfos, a clone of it is returned. Otherwise, the profile is
 // parsed from the PtpConfig, saved in ptpProfileInfos, and a clone is returned. The returned ProfileInfo pointer is
@@ -171,7 +208,8 @@ func nodeMatches(node *corev1.Node, recommend ptpv1.PtpRecommend) bool {
 func getMemoizedAndClonedProfileInfo(
 	reference ProfileReference,
 	allConfigs []*ptp.PtpConfigBuilder,
-	ptpProfileInfos map[ProfileReference]*ProfileInfo) (*ProfileInfo, error) {
+	ptpProfileInfos map[ProfileReference]*ProfileInfo,
+	controlledNames map[string]bool) (*ProfileInfo, error) {
 	if profileInfo, ok := ptpProfileInfos[reference]; ok {
 		return profileInfo.Clone(), nil
 	}
@@ -191,7 +229,7 @@ func getMemoizedAndClonedProfileInfo(
 
 	profile := profiles[reference.ProfileIndex]
 
-	profileInfo, err := parsePtpProfile(profile, reference)
+	profileInfo, err := parsePtpProfile(profile, reference, controlledNames)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse PTP profile %s: %w", reference.ProfileName, err)
 	}

--- a/tests/cnf/ran/ptp/internal/profiles/parser.go
+++ b/tests/cnf/ran/ptp/internal/profiles/parser.go
@@ -14,7 +14,11 @@ type configSections = map[string]map[string]string
 
 // parsePtpProfile parses the PTP profile and the ptp4l information to get the interfaces and their types before making
 // a determination on the profile type. Maps in the parsedPtp4lConf struct are guaranteed to not be nil when returned.
-func parsePtpProfile(profile ptpv1.PtpProfile, reference ProfileReference) (*ProfileInfo, error) {
+func parsePtpProfile(
+	profile ptpv1.PtpProfile,
+	reference ProfileReference,
+	controlledNames map[string]bool,
+) (*ProfileInfo, error) {
 	profileInfo := &ProfileInfo{
 		Reference: reference,
 	}
@@ -49,7 +53,7 @@ func parsePtpProfile(profile ptpv1.PtpProfile, reference ProfileReference) (*Pro
 		interfaceInfo.Profile = profileInfo
 	}
 
-	profileInfo.ProfileType, err = determineProfileType(profileInfo.Interfaces, profile)
+	profileInfo.ProfileType, err = determineProfileType(profileInfo.Interfaces, profile, controlledNames)
 	if err != nil {
 		return nil, fmt.Errorf("failed to determine profile type: %w", err)
 	}
@@ -146,10 +150,14 @@ func getInterfacesFromPtp4lSections(clientFlag bool, sections configSections) ma
 	return interfaces
 }
 
-// determineProfileType determines the PTP profile type based on the number of interfaces and their clock types.
-// Additionally, it makes use of ts2phc settings to determine if the profile is GM or MultiNICGM. An error is returned
-// if the profile type cannot be determined.
-func determineProfileType(interfaces map[iface.Name]*InterfaceInfo, profile ptpv1.PtpProfile) (PtpProfileType, error) {
+// determineProfileType determines the PTP profile type based on the number of interfaces, their clock types, and
+// cross-profile context. The controlledNames map contains profile names referenced by a TBC transmitter's
+// controllingProfile setting, enabling distinction between T-BC receivers and standalone T-TSC/OC profiles.
+func determineProfileType(
+	interfaces map[iface.Name]*InterfaceInfo,
+	profile ptpv1.PtpProfile,
+	controlledNames map[string]bool,
+) (PtpProfileType, error) {
 	// If the profile has chronyd configuration, it is a NTP fallback profile. This must be checked before the GM
 	// profile is determined, otherwise the profile would be incorrectly identified as a GM profile.
 	if profile.ChronydConf != nil && *profile.ChronydConf != "" {
@@ -186,7 +194,18 @@ func determineProfileType(interfaces map[iface.Name]*InterfaceInfo, profile ptpv
 		}
 	}
 
+	profileName := ""
+	if profile.Name != nil {
+		profileName = *profile.Name
+	}
+
 	switch {
+	// If the profile has one client interface and is referenced by a TBC transmitter, return ProfileTypeTBCReceiver.
+	case numInterfaces == 1 && numClientInterfaces == 1 && controlledNames[profileName]:
+		return ProfileTypeTBCReceiver, nil
+	// If the profile has one client interface with ts2phc and phc2sys (telecom slave), return ProfileTypeTTSC.
+	case numInterfaces == 1 && numClientInterfaces == 1 && hasTelecomSlaveConfig(profile):
+		return ProfileTypeTTSC, nil
 	// If the profile has one interface and one client interface, return ProfileTypeOC.
 	case numInterfaces == 1 && numClientInterfaces == 1:
 		return ProfileTypeOC, nil
@@ -196,6 +215,9 @@ func determineProfileType(interfaces map[iface.Name]*InterfaceInfo, profile ptpv
 	// If the profile has at least two interfaces and only one client interface, return ProfileTypeBC.
 	case numInterfaces >= 2 && numClientInterfaces == 1:
 		return ProfileTypeBC, nil
+	// If all interfaces are server, return ProfileTypeTBCTransmitter.
+	case numInterfaces >= 1 && numServerInterfaces == numInterfaces:
+		return ProfileTypeTBCTransmitter, nil
 	// All other profile types are considered unsupported.
 	default:
 		return 0, fmt.Errorf("unable to determine PTP profile type based on defined rules")
@@ -235,4 +257,19 @@ func hasClientFlag(ptp4lOpts *string) bool {
 	}
 
 	return false
+}
+
+// hasTelecomSlaveConfig checks whether a profile has the configuration markers of a Telecom Time Slave Clock
+// (ITU-T G.8275.1): ts2phc for hardware timestamping and phc2sys for system clock synchronization, without
+// being a ts2phc master (which would indicate a GM profile).
+func hasTelecomSlaveConfig(profile ptpv1.PtpProfile) bool {
+	if profile.Ts2PhcConf == nil || profile.Phc2sysOpts == nil {
+		return false
+	}
+
+	if strings.Contains(*profile.Ts2PhcConf, "ts2phc.master 1") {
+		return false
+	}
+
+	return true
 }

--- a/tests/cnf/ran/ptp/internal/profiles/plugins.go
+++ b/tests/cnf/ran/ptp/internal/profiles/plugins.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/ptp"
 	ptpv1 "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/ptp/v1"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/iface"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
 // PinStateType enumerates the supported pin states.
@@ -153,4 +154,87 @@ func GetPluginTypesFromProfile(profile *ptpv1.PtpProfile) ([]ptp.PluginType, err
 	}
 
 	return pluginTypes, nil
+}
+
+// HoldoverPluginSettings groups the PTP plugin settings that control holdover behavior.
+type HoldoverPluginSettings struct {
+	LocalHoldoverTimeout   uint
+	LocalMaxHoldoverOffSet uint
+	MaxInSpecOffset        uint
+}
+
+// GetHoldoverPluginSettings reads the holdover plugin settings from the E810 plugin in the profile.
+// Uses the typed IntelPlugin struct for safe deserialization.
+func GetHoldoverPluginSettings(profile *ptpv1.PtpProfile) (*HoldoverPluginSettings, error) {
+	intelPlugin, err := getIntelPlugin(profile, ptp.PluginTypeE810)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Intel plugin for holdover settings: %w", err)
+	}
+
+	if intelPlugin.DpllSettings == nil {
+		return nil, fmt.Errorf("E810 plugin has no settings")
+	}
+
+	localHoldoverTimeout, timeoutFound := intelPlugin.DpllSettings["LocalHoldoverTimeout"]
+	if !timeoutFound {
+		return nil, fmt.Errorf("'LocalHoldoverTimeout' not found in plugin settings")
+	}
+
+	localMaxHoldoverOffset, offsetFound := intelPlugin.DpllSettings["LocalMaxHoldoverOffSet"]
+	if !offsetFound {
+		return nil, fmt.Errorf("'LocalMaxHoldoverOffSet' not found in plugin settings")
+	}
+
+	maxInSpecOffset, specFound := intelPlugin.DpllSettings["MaxInSpecOffset"]
+	if !specFound {
+		return nil, fmt.Errorf("'MaxInSpecOffset' not found in plugin settings")
+	}
+
+	return &HoldoverPluginSettings{
+		LocalHoldoverTimeout:   uint(localHoldoverTimeout),
+		LocalMaxHoldoverOffSet: uint(localMaxHoldoverOffset),
+		MaxInSpecOffset:        uint(maxInSpecOffset),
+	}, nil
+}
+
+// SetHoldoverPluginSettings patches the holdover plugin settings on the E810 plugin in the profile.
+func SetHoldoverPluginSettings(profile *ptpv1.PtpProfile, settings HoldoverPluginSettings) error {
+	intelPlugin, err := getIntelPlugin(profile, ptp.PluginTypeE810)
+	if err != nil {
+		return fmt.Errorf("failed to get Intel plugin for holdover settings: %w", err)
+	}
+
+	if intelPlugin.DpllSettings == nil {
+		intelPlugin.DpllSettings = make(map[string]uint64)
+	}
+
+	intelPlugin.DpllSettings["LocalHoldoverTimeout"] = uint64(settings.LocalHoldoverTimeout)
+	intelPlugin.DpllSettings["LocalMaxHoldoverOffSet"] = uint64(settings.LocalMaxHoldoverOffSet)
+	intelPlugin.DpllSettings["MaxInSpecOffset"] = uint64(settings.MaxInSpecOffset)
+
+	raw, err := json.Marshal(intelPlugin)
+	if err != nil {
+		return fmt.Errorf("failed to marshal E810 plugin: %w", err)
+	}
+
+	profile.Plugins[string(ptp.PluginTypeE810)] = &apiextv1.JSON{Raw: raw}
+
+	return nil
+}
+
+// GetUpstreamPort returns the upstream port from the E810 plugin's interconnections. Returns the first
+// interconnection entry that has an upstreamPort set.
+func GetUpstreamPort(profile *ptpv1.PtpProfile) (iface.Name, error) {
+	intelPlugin, err := getIntelPlugin(profile, ptp.PluginTypeE810)
+	if err != nil {
+		return "", fmt.Errorf("failed to get Intel plugin for upstream port: %w", err)
+	}
+
+	for _, interconnection := range intelPlugin.InputDelays {
+		if interconnection.UpstreamPort != "" {
+			return iface.Name(interconnection.UpstreamPort), nil
+		}
+	}
+
+	return "", fmt.Errorf("no upstream port found in E810 plugin interconnections")
 }

--- a/tests/cnf/ran/ptp/internal/profiles/profiles.go
+++ b/tests/cnf/ran/ptp/internal/profiles/profiles.go
@@ -43,6 +43,16 @@ const (
 	// ProfileTypeNTPFallback refers to a PTP profile that is configured to fall back to NTP when GNSS sync is lost.
 	// This is the same as a GM profile but with chronyd configured.
 	ProfileTypeNTPFallback
+	// ProfileTypeTBCTransmitter refers to the time-transmitter side of a Telecom Boundary Clock pair. It has
+	// multiple server interfaces and no client interfaces, and is linked to the receiver profile via the
+	// controllingProfile PTP setting.
+	ProfileTypeTBCTransmitter
+	// ProfileTypeTBCReceiver refers to the time-receiver side of a Telecom Boundary Clock pair. It is
+	// identified by being referenced as the controllingProfile from a TBC transmitter profile.
+	ProfileTypeTBCReceiver
+	// ProfileTypeTTSC refers to a Telecom Time Slave Clock (ITU-T G.8275.1). It has ts2phc and phc2sys
+	// configurations for hardware timestamping and holdover, but is not part of a T-BC pair.
+	ProfileTypeTTSC
 )
 
 // PtpClockType enumerates the roles of each interface. It is different from the roles in metrics, which include extra

--- a/tests/cnf/ran/ptp/internal/tsparams/consts.go
+++ b/tests/cnf/ran/ptp/internal/tsparams/consts.go
@@ -25,6 +25,8 @@ const (
 	LabelStability = "stability"
 	// LabelLogReduction is the label for all tests in the PTP log reduction suite.
 	LabelLogReduction = "log-reduction"
+	// LabelTBCTSCHoldover is the label for T-BC and T-TSC upstream clock loss holdover tests.
+	LabelTBCTSCHoldover = "tbc-tsc-holdover"
 
 	// LeapConfigmapName is the name of the leap configmap.
 	LeapConfigmapName = "leap-configmap"

--- a/tests/cnf/ran/ptp/tests/ptp-holdover.go
+++ b/tests/cnf/ran/ptp/tests/ptp-holdover.go
@@ -1,0 +1,780 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	eventptp "github.com/redhat-cne/sdk-go/pkg/event/ptp"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/ptp"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	ptpv1 "github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/ptp/v1"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/querier"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/raninittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/ranparam"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/version"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/consumer"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/daemonlogs"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/events"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/iface"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/metrics"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/profiles"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/tsparams"
+	"k8s.io/klog/v2"
+)
+
+const holdoverTestTimeout = 7 * time.Minute
+
+var (
+	holdoverPluginSettingsNoOutOfSpec = profiles.HoldoverPluginSettings{
+		LocalHoldoverTimeout:   360,
+		MaxInSpecOffset:        14401,
+		LocalMaxHoldoverOffSet: 14400,
+	}
+	holdoverPluginSettingsWithOutOfSpec = profiles.HoldoverPluginSettings{
+		LocalHoldoverTimeout:   360,
+		MaxInSpecOffset:        1800,
+		LocalMaxHoldoverOffSet: 14400,
+	}
+)
+
+// holdoverTestData groups the per-node test context that is discovered once in BeforeEach and shared
+// by all test cases within a Context block.
+type holdoverTestData struct {
+	prometheusAPI prometheusv1.API
+	nodeName      string
+	ptpConfig     *ptp.PtpConfigBuilder
+	profileIndex  int
+	upstreamIface iface.Name
+}
+
+// holdoverExpectedClockClasses groups the expected clock class values for each holdover state.
+type holdoverExpectedClockClasses struct {
+	Locked            metrics.PtpClockClass
+	HoldoverInSpec    metrics.PtpClockClass
+	HoldoverOutOfSpec metrics.PtpClockClass
+	Freerun           metrics.PtpClockClass
+}
+
+// TBCClockClasses returns the standard clock class values for T-BC tests.
+func TBCClockClasses() holdoverExpectedClockClasses {
+	return holdoverExpectedClockClasses{
+		Locked:            metrics.ClockClass6,
+		HoldoverInSpec:    metrics.ClockClass135,
+		HoldoverOutOfSpec: metrics.ClockClass165,
+		Freerun:           metrics.ClockClass248,
+	}
+}
+
+// TTSCClockClasses returns clock class values for T-TSC tests on 4.21+. Clock class does not change and
+// remains 255 throughout all states.
+func TTSCClockClasses() holdoverExpectedClockClasses {
+	return holdoverExpectedClockClasses{
+		Locked:            metrics.ClockClass255,
+		HoldoverInSpec:    metrics.ClockClass255,
+		HoldoverOutOfSpec: metrics.ClockClass255,
+		Freerun:           metrics.ClockClass255,
+	}
+}
+
+// backCompatTTSCClockClasses returns clock class values for T-TSC tests on 4.20, where T-TSC clock class
+// values match T-BC (6, 135, 165, 248).
+func backCompatTTSCClockClasses() holdoverExpectedClockClasses {
+	return TBCClockClasses()
+}
+
+var _ = Describe("PTP Holdover", Label(tsparams.LabelTBCTSCHoldover), func() {
+	var prometheusAPI prometheusv1.API
+
+	BeforeEach(func() {
+		var err error
+
+		By("creating a Prometheus API client")
+
+		prometheusAPI, err = querier.CreatePrometheusAPIForCluster(RANConfig.Spoke1APIClient)
+		Expect(err).ToNot(HaveOccurred(), "Failed to create Prometheus API client")
+
+		By("checking if PTP operator version supports holdover tests")
+
+		inRange, err := version.IsVersionStringInRange(
+			RANConfig.Spoke1OperatorVersions[ranparam.PTP], "4.20.0-0", "")
+		Expect(err).ToNot(HaveOccurred(), "Failed to parse PTP operator version")
+
+		if !inRange {
+			Skip("Test is valid from version 4.20")
+		}
+	})
+
+	Context("t-bc upstream clock loss & unassisted holdover", func() {
+		var testData holdoverTestData
+
+		timeout := holdoverTestTimeout
+
+		BeforeEach(func() {
+			By("getting node info map")
+
+			discovered := discoverHoldoverTestData(prometheusAPI, profiles.ProfileTypeTBCReceiver)
+			if discovered == nil {
+				Skip("No T-BC configuration found for holdover tests")
+			}
+
+			testData = *discovered
+
+			klog.V(tsparams.LogLevel).Infof(
+				"T-BC holdover test on node %s, upstream interface %s", testData.nodeName, testData.upstreamIface)
+		})
+
+		// 83297 - Verifies t-bc transition from holdover-in-spec to locked when upstream clock recovers
+		It("verifies t-bc transition from holdover-in-spec to locked when upstream clock recovers",
+			reportxml.ID("83297"), func() {
+				assertHoldoverInSpecToLocked(testData, holdoverPluginSettingsNoOutOfSpec,
+					timeout, TBCClockClasses(), true)
+			})
+
+		// 83298 - Verifies t-bc transition from holdover-in-spec to freerun when localmaxholdoveroffset reached
+		It("verifies t-bc transition from holdover-in-spec to freerun when localmaxholdoveroffset reached",
+			reportxml.ID("83298"), func() {
+				assertHoldoverInSpecToFreerun(testData, holdoverPluginSettingsNoOutOfSpec,
+					timeout, TBCClockClasses(), true)
+			})
+
+		// 83299 - Verifies t-bc transition from holdover-in-spec to holdover-out-of-spec when maxinspecoffset reached
+		It("verifies t-bc transition from holdover-in-spec to holdover-out-of-spec when maxinspecoffset reached",
+			reportxml.ID("83299"), func() {
+				assertHoldoverInSpecToOutOfSpec(testData, holdoverPluginSettingsWithOutOfSpec,
+					timeout, TBCClockClasses(), true)
+			})
+
+		// 83300 - Verifies t-bc transition from holdover-out-of-spec to freerun when localmaxholdoveroffset reached
+		It("verifies t-bc transition from holdover-out-of-spec to freerun when localmaxholdoveroffset reached",
+			reportxml.ID("83300"), func() {
+				assertHoldoverOutOfSpecToFreerun(testData, holdoverPluginSettingsWithOutOfSpec,
+					timeout, TBCClockClasses(), true)
+			})
+	})
+
+	Context("t-tsc upstream clock loss & unassisted holdover", func() {
+		var (
+			testData             holdoverTestData
+			clockClassChanges    bool
+			expectedClockClasses holdoverExpectedClockClasses
+		)
+
+		timeout := holdoverTestTimeout
+
+		BeforeEach(func() {
+			is420, err := version.IsVersionStringInRange(
+				RANConfig.Spoke1OperatorVersions[ranparam.PTP], "4.20.0-0", "4.21.0-0")
+			Expect(err).ToNot(HaveOccurred(), "Failed to check PTP operator version range")
+
+			if is420 {
+				expectedClockClasses = backCompatTTSCClockClasses()
+				clockClassChanges = true
+			} else {
+				expectedClockClasses = TTSCClockClasses()
+				clockClassChanges = false
+			}
+
+			By("getting node info map")
+
+			discovered := discoverHoldoverTestData(prometheusAPI, profiles.ProfileTypeTTSC)
+			if discovered == nil {
+				Skip("No T-TSC configuration found for holdover tests")
+			}
+
+			testData = *discovered
+
+			klog.V(tsparams.LogLevel).Infof(
+				"T-TSC holdover test on node %s, upstream interface %s", testData.nodeName, testData.upstreamIface)
+		})
+
+		// 88274 - Verifies t-tsc transition from holdover-in-spec to locked when upstream clock recovers
+		It("verifies t-tsc transition from holdover-in-spec to locked when upstream clock recovers",
+			reportxml.ID("88274"), func() {
+				assertHoldoverInSpecToLocked(testData, holdoverPluginSettingsNoOutOfSpec,
+					timeout, expectedClockClasses, clockClassChanges)
+			})
+
+		// 88275 - Verifies t-tsc transition from holdover-in-spec to freerun when localmaxholdoveroffset reached
+		It("verifies t-tsc transition from holdover-in-spec to freerun when localmaxholdoveroffset reached",
+			reportxml.ID("88275"), func() {
+				assertHoldoverInSpecToFreerun(testData, holdoverPluginSettingsNoOutOfSpec,
+					timeout, expectedClockClasses, clockClassChanges)
+			})
+
+		// 88276 - Verifies t-tsc transition from holdover-in-spec to holdover-out-of-spec when maxinspecoffset reached
+		It("verifies t-tsc transition from holdover-in-spec to holdover-out-of-spec when maxinspecoffset reached",
+			reportxml.ID("88276"), func() {
+				assertHoldoverInSpecToOutOfSpec(testData, holdoverPluginSettingsWithOutOfSpec,
+					timeout, expectedClockClasses, clockClassChanges)
+			})
+
+		// 88277 - Verifies t-tsc transition from holdover-out-of-spec to freerun when localmaxholdoveroffset reached
+		It("verifies t-tsc transition from holdover-out-of-spec to freerun when localmaxholdoveroffset reached",
+			reportxml.ID("88277"), func() {
+				assertHoldoverOutOfSpecToFreerun(testData, holdoverPluginSettingsWithOutOfSpec,
+					timeout, expectedClockClasses, clockClassChanges)
+			})
+	})
+})
+
+// assertHoldoverInSpecToLocked validates that after upstream clock loss the clock enters holdover-in-spec,
+// then recovers to locked when upstream is restored. No FREERUN events should be generated.
+func assertHoldoverInSpecToLocked(
+	testData holdoverTestData,
+	pluginSettings profiles.HoldoverPluginSettings,
+	timeout time.Duration,
+	expected holdoverExpectedClockClasses,
+	clockClassChanges bool,
+) {
+	GinkgoHelper()
+
+	changeHoldoverPluginSettings(testData, pluginSettings, expected.Locked, clockClassChanges, timeout)
+
+	By("setting upstream clock interface down to enter holdover-in-spec")
+
+	ifaceDownTime := time.Now()
+
+	err := iface.SetInterfaceStatus(RANConfig.Spoke1APIClient, testData.nodeName,
+		testData.upstreamIface, iface.InterfaceStateDown)
+	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interface down")
+
+	DeferCleanup(func() {
+		restoreInterfaceAndWaitForRelock(testData.prometheusAPI, testData.nodeName, testData.upstreamIface)
+	})
+
+	assertHoldoverState(testData.prometheusAPI, testData.nodeName, ifaceDownTime,
+		expected.HoldoverInSpec, clockClassChanges, timeout)
+
+	By("setting upstream clock interface up to return to locked")
+
+	ifaceUpTime := time.Now()
+
+	err = iface.SetInterfaceStatus(RANConfig.Spoke1APIClient, testData.nodeName,
+		testData.upstreamIface, iface.InterfaceStateUp)
+	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interface up")
+
+	assertLockedState(testData.prometheusAPI, testData.nodeName, ifaceUpTime,
+		expected.Locked, clockClassChanges, timeout)
+
+	assertNoFreerunEvent(testData.nodeName, ifaceUpTime)
+}
+
+// assertHoldoverInSpecToFreerun validates that after upstream clock loss the clock enters holdover-in-spec,
+// transitions to freerun when LocalMaxHoldoverOffSet is reached, then recovers to locked when upstream is restored.
+func assertHoldoverInSpecToFreerun(
+	testData holdoverTestData,
+	pluginSettings profiles.HoldoverPluginSettings,
+	timeout time.Duration,
+	expected holdoverExpectedClockClasses,
+	clockClassChanges bool,
+) {
+	GinkgoHelper()
+
+	changeHoldoverPluginSettings(testData, pluginSettings, expected.Locked, clockClassChanges, timeout)
+
+	By("setting upstream clock interface down to enter holdover-in-spec")
+
+	ifaceDownTime := time.Now()
+
+	err := iface.SetInterfaceStatus(RANConfig.Spoke1APIClient, testData.nodeName,
+		testData.upstreamIface, iface.InterfaceStateDown)
+	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interface down")
+
+	DeferCleanup(func() {
+		restoreInterfaceAndWaitForRelock(testData.prometheusAPI, testData.nodeName, testData.upstreamIface)
+	})
+
+	assertHoldoverState(testData.prometheusAPI, testData.nodeName, ifaceDownTime,
+		expected.HoldoverInSpec, clockClassChanges, timeout)
+
+	assertFreerunState(testData.prometheusAPI, testData.nodeName, ifaceDownTime,
+		expected.Freerun, clockClassChanges, timeout)
+
+	By("setting upstream clock interface up to return to locked")
+
+	ifaceUpTime := time.Now()
+
+	err = iface.SetInterfaceStatus(RANConfig.Spoke1APIClient, testData.nodeName,
+		testData.upstreamIface, iface.InterfaceStateUp)
+	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interface up")
+
+	assertLockedState(testData.prometheusAPI, testData.nodeName, ifaceUpTime,
+		expected.Locked, clockClassChanges, timeout)
+}
+
+// assertHoldoverInSpecToOutOfSpec validates that after upstream clock loss the clock enters holdover-in-spec,
+// transitions to holdover-out-of-spec when MaxInSpecOffset is reached, then recovers to locked when upstream
+// is restored. No FREERUN events should be generated.
+func assertHoldoverInSpecToOutOfSpec(
+	testData holdoverTestData,
+	pluginSettings profiles.HoldoverPluginSettings,
+	timeout time.Duration,
+	expected holdoverExpectedClockClasses,
+	clockClassChanges bool,
+) {
+	GinkgoHelper()
+
+	changeHoldoverPluginSettings(testData, pluginSettings, expected.Locked, clockClassChanges, timeout)
+
+	By("setting upstream clock interface down to enter holdover-in-spec")
+
+	ifaceDownTime := time.Now()
+
+	err := iface.SetInterfaceStatus(RANConfig.Spoke1APIClient, testData.nodeName,
+		testData.upstreamIface, iface.InterfaceStateDown)
+	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interface down")
+
+	DeferCleanup(func() {
+		restoreInterfaceAndWaitForRelock(testData.prometheusAPI, testData.nodeName, testData.upstreamIface)
+	})
+
+	assertHoldoverState(testData.prometheusAPI, testData.nodeName, ifaceDownTime,
+		expected.HoldoverInSpec, clockClassChanges, timeout)
+
+	assertHoldoverOutOfSpecClockClass(testData.prometheusAPI, testData.nodeName, ifaceDownTime,
+		expected.HoldoverOutOfSpec, clockClassChanges, timeout)
+
+	By("setting upstream clock interface up to return to locked")
+
+	ifaceUpTime := time.Now()
+
+	err = iface.SetInterfaceStatus(RANConfig.Spoke1APIClient, testData.nodeName,
+		testData.upstreamIface, iface.InterfaceStateUp)
+	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interface up")
+
+	assertLockedState(testData.prometheusAPI, testData.nodeName, ifaceUpTime,
+		expected.Locked, clockClassChanges, timeout)
+
+	assertNoFreerunEvent(testData.nodeName, ifaceUpTime)
+}
+
+// assertHoldoverOutOfSpecToFreerun validates the full cascade: holdover-in-spec -> holdover-out-of-spec -> freerun,
+// then recovery to locked when upstream is restored.
+func assertHoldoverOutOfSpecToFreerun(
+	testData holdoverTestData,
+	pluginSettings profiles.HoldoverPluginSettings,
+	timeout time.Duration,
+	expected holdoverExpectedClockClasses,
+	clockClassChanges bool,
+) {
+	GinkgoHelper()
+
+	changeHoldoverPluginSettings(testData, pluginSettings, expected.Locked, clockClassChanges, timeout)
+
+	By("setting upstream clock interface down to enter holdover-in-spec")
+
+	ifaceDownTime := time.Now()
+
+	err := iface.SetInterfaceStatus(RANConfig.Spoke1APIClient, testData.nodeName,
+		testData.upstreamIface, iface.InterfaceStateDown)
+	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interface down")
+
+	DeferCleanup(func() {
+		restoreInterfaceAndWaitForRelock(testData.prometheusAPI, testData.nodeName, testData.upstreamIface)
+	})
+
+	assertHoldoverState(testData.prometheusAPI, testData.nodeName, ifaceDownTime,
+		expected.HoldoverInSpec, clockClassChanges, timeout)
+
+	assertHoldoverOutOfSpecClockClass(testData.prometheusAPI, testData.nodeName, ifaceDownTime,
+		expected.HoldoverOutOfSpec, clockClassChanges, timeout)
+
+	assertFreerunState(testData.prometheusAPI, testData.nodeName, ifaceDownTime,
+		expected.Freerun, clockClassChanges, timeout)
+
+	By("setting upstream clock interface up to return to locked")
+
+	ifaceUpTime := time.Now()
+
+	err = iface.SetInterfaceStatus(RANConfig.Spoke1APIClient, testData.nodeName,
+		testData.upstreamIface, iface.InterfaceStateUp)
+	Expect(err).ToNot(HaveOccurred(), "Failed to set upstream clock interface up")
+
+	assertLockedState(testData.prometheusAPI, testData.nodeName, ifaceUpTime,
+		expected.Locked, clockClassChanges, timeout)
+}
+
+// restoreInterfaceAndWaitForRelock brings the upstream interface back up and waits for the T-BC clock to return
+// to LOCKED state with a 5-second stable duration, matching the OC 2-port restore pattern. The process label
+// is T-BC because the linuxptp-daemon uses the clockType from PtpSettings (set to "T-BC" for T-BC profiles)
+// as the process label for clock state metrics. T-TSC profiles use the same shared helpers and the same process
+// label because cnf-gotests uses ProcessTBC for both T-BC and T-TSC holdover metric assertions.
+func restoreInterfaceAndWaitForRelock(
+	prometheusAPI prometheusv1.API,
+	nodeName string,
+	upstreamIface iface.Name,
+) {
+	GinkgoHelper()
+
+	By("restoring upstream interface and waiting for relock")
+
+	err := iface.SetInterfaceStatus(RANConfig.Spoke1APIClient, nodeName,
+		upstreamIface, iface.InterfaceStateUp)
+	Expect(err).ToNot(HaveOccurred(), "Failed to restore upstream clock interface")
+
+	clockStateQuery := metrics.ClockStateQuery{
+		Node:    metrics.Equals(nodeName),
+		Process: metrics.Equals(metrics.ProcessTBC),
+	}
+	err = metrics.AssertQuery(context.TODO(), prometheusAPI, clockStateQuery, metrics.ClockStateLocked,
+		metrics.AssertWithStableDuration(5*time.Second),
+		metrics.AssertWithTimeout(3*time.Minute))
+	Expect(err).ToNot(HaveOccurred(), "Clock did not return to LOCKED after restoration")
+}
+
+// assertHoldoverState waits for the HOLDOVER event and optional clock class change event, then validates
+// the corresponding Prometheus metrics.
+func assertHoldoverState(
+	prometheusAPI prometheusv1.API,
+	nodeName string,
+	sinceTime time.Time,
+	expectedClockClass metrics.PtpClockClass,
+	clockClassChanges bool,
+	timeout time.Duration,
+) {
+	GinkgoHelper()
+
+	By("waiting for clock state HOLDOVER event")
+
+	eventPod, err := consumer.GetConsumerPodforNode(RANConfig.Spoke1APIClient, nodeName)
+	Expect(err).ToNot(HaveOccurred(), "Failed to get consumer pod for node")
+
+	holdoverFilter := events.All(
+		events.IsType(eventptp.PtpStateChange),
+		events.HasValue(events.WithSyncState(eventptp.HOLDOVER)),
+	)
+	err = events.WaitForEvent(eventPod, sinceTime, timeout, holdoverFilter)
+	Expect(err).ToNot(HaveOccurred(), "Failed to wait for HOLDOVER event")
+
+	if clockClassChanges {
+		By(fmt.Sprintf("waiting for clock class %d event", expectedClockClass))
+
+		clockClassFilter := events.All(
+			events.IsType(eventptp.PtpClockClassChange),
+			events.HasValue(events.WithMetric(int64(expectedClockClass))),
+		)
+		err = events.WaitForEvent(eventPod, sinceTime, timeout, clockClassFilter)
+		Expect(err).ToNot(HaveOccurred(), "Failed to wait for clock class %d event", expectedClockClass)
+	}
+
+	By(fmt.Sprintf("validating metrics: clock class %d, clock state HOLDOVER", expectedClockClass))
+
+	clockStateQuery := metrics.ClockStateQuery{
+		Node:    metrics.Equals(nodeName),
+		Process: metrics.Equals(metrics.ProcessTBC),
+	}
+	err = metrics.AssertQuery(context.TODO(), prometheusAPI, clockStateQuery, metrics.ClockStateHoldover,
+		metrics.AssertWithTimeout(1*time.Minute))
+	Expect(err).ToNot(HaveOccurred(), "Failed to assert clock state HOLDOVER in metrics")
+
+	clockClassQuery := metrics.ClockClassQuery{
+		Node:    metrics.Equals(nodeName),
+		Process: metrics.Equals(metrics.ProcessPTP4L),
+	}
+	err = metrics.AssertQuery(context.TODO(), prometheusAPI, clockClassQuery, expectedClockClass,
+		metrics.AssertWithTimeout(1*time.Minute))
+	Expect(err).ToNot(HaveOccurred(), "Failed to assert clock class %d in metrics", expectedClockClass)
+}
+
+// assertLockedState waits for the LOCKED event and optional clock class change event, then validates
+// the corresponding Prometheus metrics.
+func assertLockedState(
+	prometheusAPI prometheusv1.API,
+	nodeName string,
+	sinceTime time.Time,
+	expectedClockClass metrics.PtpClockClass,
+	clockClassChanges bool,
+	timeout time.Duration,
+) {
+	GinkgoHelper()
+
+	By("waiting for clock state LOCKED event")
+
+	eventPod, err := consumer.GetConsumerPodforNode(RANConfig.Spoke1APIClient, nodeName)
+	Expect(err).ToNot(HaveOccurred(), "Failed to get consumer pod for node")
+
+	lockedFilter := events.All(
+		events.IsType(eventptp.PtpStateChange),
+		events.HasValue(events.WithSyncState(eventptp.LOCKED)),
+	)
+	err = events.WaitForEvent(eventPod, sinceTime, timeout, lockedFilter)
+	Expect(err).ToNot(HaveOccurred(), "Failed to wait for LOCKED event")
+
+	if clockClassChanges {
+		By(fmt.Sprintf("waiting for clock class %d event", expectedClockClass))
+
+		clockClassFilter := events.All(
+			events.IsType(eventptp.PtpClockClassChange),
+			events.HasValue(events.WithMetric(int64(expectedClockClass))),
+		)
+		err = events.WaitForEvent(eventPod, sinceTime, timeout, clockClassFilter)
+		Expect(err).ToNot(HaveOccurred(), "Failed to wait for clock class %d event", expectedClockClass)
+	}
+
+	By(fmt.Sprintf("validating metrics: clock class %d, clock state LOCKED", expectedClockClass))
+
+	clockStateQuery := metrics.ClockStateQuery{
+		Node:    metrics.Equals(nodeName),
+		Process: metrics.Equals(metrics.ProcessTBC),
+	}
+	err = metrics.AssertQuery(context.TODO(), prometheusAPI, clockStateQuery, metrics.ClockStateLocked,
+		metrics.AssertWithTimeout(1*time.Minute))
+	Expect(err).ToNot(HaveOccurred(), "Failed to assert clock state LOCKED in metrics")
+
+	clockClassQuery := metrics.ClockClassQuery{
+		Node:    metrics.Equals(nodeName),
+		Process: metrics.Equals(metrics.ProcessPTP4L),
+	}
+	err = metrics.AssertQuery(context.TODO(), prometheusAPI, clockClassQuery, expectedClockClass,
+		metrics.AssertWithTimeout(1*time.Minute))
+	Expect(err).ToNot(HaveOccurred(), "Failed to assert clock class %d in metrics", expectedClockClass)
+}
+
+// assertFreerunState waits for the FREERUN event and optional clock class change event, then validates
+// the corresponding Prometheus metrics.
+func assertFreerunState(
+	prometheusAPI prometheusv1.API,
+	nodeName string,
+	sinceTime time.Time,
+	expectedClockClass metrics.PtpClockClass,
+	clockClassChanges bool,
+	timeout time.Duration,
+) {
+	GinkgoHelper()
+
+	By("waiting for clock state FREERUN event")
+
+	eventPod, err := consumer.GetConsumerPodforNode(RANConfig.Spoke1APIClient, nodeName)
+	Expect(err).ToNot(HaveOccurred(), "Failed to get consumer pod for node")
+
+	freerunFilter := events.All(
+		events.IsType(eventptp.PtpStateChange),
+		events.HasValue(events.WithSyncState(eventptp.FREERUN)),
+	)
+	err = events.WaitForEvent(eventPod, sinceTime, timeout, freerunFilter)
+	Expect(err).ToNot(HaveOccurred(), "Failed to wait for FREERUN event")
+
+	if clockClassChanges {
+		By(fmt.Sprintf("waiting for clock class %d event", expectedClockClass))
+
+		clockClassFilter := events.All(
+			events.IsType(eventptp.PtpClockClassChange),
+			events.HasValue(events.WithMetric(int64(expectedClockClass))),
+		)
+		err = events.WaitForEvent(eventPod, sinceTime, timeout, clockClassFilter)
+		Expect(err).ToNot(HaveOccurred(), "Failed to wait for clock class %d event", expectedClockClass)
+	}
+
+	By(fmt.Sprintf("validating metrics: clock class %d, clock state FREERUN", expectedClockClass))
+
+	clockStateQuery := metrics.ClockStateQuery{
+		Node:    metrics.Equals(nodeName),
+		Process: metrics.Equals(metrics.ProcessTBC),
+	}
+	err = metrics.AssertQuery(context.TODO(), prometheusAPI, clockStateQuery, metrics.ClockStateFreerun,
+		metrics.AssertWithTimeout(1*time.Minute))
+	Expect(err).ToNot(HaveOccurred(), "Failed to assert clock state FREERUN in metrics")
+
+	clockClassQuery := metrics.ClockClassQuery{
+		Node:    metrics.Equals(nodeName),
+		Process: metrics.Equals(metrics.ProcessPTP4L),
+	}
+	err = metrics.AssertQuery(context.TODO(), prometheusAPI, clockClassQuery, expectedClockClass,
+		metrics.AssertWithTimeout(1*time.Minute))
+	Expect(err).ToNot(HaveOccurred(), "Failed to assert clock class %d in metrics", expectedClockClass)
+}
+
+// assertHoldoverOutOfSpecClockClass waits for the clock class to transition to holdover-out-of-spec and
+// validates that the clock state remains HOLDOVER in metrics.
+func assertHoldoverOutOfSpecClockClass(
+	prometheusAPI prometheusv1.API,
+	nodeName string,
+	sinceTime time.Time,
+	expectedClockClass metrics.PtpClockClass,
+	clockClassChanges bool,
+	timeout time.Duration,
+) {
+	GinkgoHelper()
+
+	if clockClassChanges {
+		By(fmt.Sprintf("waiting for clock class %d event (holdover-out-of-spec)", expectedClockClass))
+
+		eventPod, err := consumer.GetConsumerPodforNode(RANConfig.Spoke1APIClient, nodeName)
+		Expect(err).ToNot(HaveOccurred(), "Failed to get consumer pod for node")
+
+		clockClassFilter := events.All(
+			events.IsType(eventptp.PtpClockClassChange),
+			events.HasValue(events.WithMetric(int64(expectedClockClass))),
+		)
+		err = events.WaitForEvent(eventPod, sinceTime, timeout, clockClassFilter)
+		Expect(err).ToNot(HaveOccurred(), "Failed to wait for clock class %d event", expectedClockClass)
+	}
+
+	By(fmt.Sprintf("validating metrics: clock class %d, clock state HOLDOVER", expectedClockClass))
+
+	clockStateQuery := metrics.ClockStateQuery{
+		Node:    metrics.Equals(nodeName),
+		Process: metrics.Equals(metrics.ProcessTBC),
+	}
+	err := metrics.AssertQuery(context.TODO(), prometheusAPI, clockStateQuery, metrics.ClockStateHoldover,
+		metrics.AssertWithTimeout(1*time.Minute))
+	Expect(err).ToNot(HaveOccurred(), "Failed to assert clock state HOLDOVER in metrics")
+
+	clockClassQuery := metrics.ClockClassQuery{
+		Node:    metrics.Equals(nodeName),
+		Process: metrics.Equals(metrics.ProcessPTP4L),
+	}
+	err = metrics.AssertQuery(context.TODO(), prometheusAPI, clockClassQuery, expectedClockClass,
+		metrics.AssertWithTimeout(1*time.Minute))
+	Expect(err).ToNot(HaveOccurred(), "Failed to assert clock class %d in metrics", expectedClockClass)
+}
+
+// assertNoFreerunEvent validates that no FREERUN ptp-state-change event is generated within 30 seconds.
+func assertNoFreerunEvent(nodeName string, sinceTime time.Time) {
+	GinkgoHelper()
+
+	By("validating no FREERUN event is generated")
+
+	eventPod, err := consumer.GetConsumerPodforNode(RANConfig.Spoke1APIClient, nodeName)
+	Expect(err).ToNot(HaveOccurred(), "Failed to get consumer pod for node")
+
+	freerunFilter := events.All(
+		events.IsType(eventptp.PtpStateChange),
+		events.HasValue(events.WithSyncState(eventptp.FREERUN)),
+	)
+	err = events.WaitForEvent(eventPod, sinceTime, 30*time.Second, freerunFilter)
+	Expect(err).To(HaveOccurred(), "Expected no FREERUN event, but one was received")
+}
+
+// changeHoldoverPluginSettings configures holdover thresholds on a PTP profile and waits for the config to
+// take effect. If the desired settings already match the current settings, the function returns immediately.
+// Otherwise, it updates the PtpConfig CR, waits for the daemon to reload profiles, and then waits for the
+// clock to return to LOCKED state with stable metrics. The original settings are restored via DeferCleanup.
+func changeHoldoverPluginSettings(
+	testData holdoverTestData,
+	desired profiles.HoldoverPluginSettings,
+	expectedLockedClass metrics.PtpClockClass,
+	clockClassChanges bool,
+	timeout time.Duration,
+) {
+	GinkgoHelper()
+
+	profile := &testData.ptpConfig.Definition.Spec.Profile[testData.profileIndex]
+
+	current, err := profiles.GetHoldoverPluginSettings(profile)
+	Expect(err).ToNot(HaveOccurred(), "Failed to get current holdover plugin settings")
+
+	if desired == *current {
+		return
+	}
+
+	original := *current
+
+	By("setting test case PTP profile plugin settings")
+
+	err = profiles.SetHoldoverPluginSettings(profile, desired)
+	Expect(err).ToNot(HaveOccurred(), "Failed to set holdover plugin settings")
+
+	_, err = testData.ptpConfig.Update()
+	Expect(err).ToNot(HaveOccurred(), "Failed to update PtpConfig with new plugin settings")
+
+	DeferCleanup(func() {
+		By("restoring original plugin settings")
+
+		restoreErr := profiles.SetHoldoverPluginSettings(profile, original)
+		Expect(restoreErr).ToNot(HaveOccurred(), "Failed to restore original plugin settings")
+
+		restoreTime := time.Now()
+
+		_, restoreErr = testData.ptpConfig.Update()
+		Expect(restoreErr).ToNot(HaveOccurred(), "Failed to update PtpConfig with restored plugin settings")
+
+		By("waiting for daemon to reload and re-lock after restoring plugin settings")
+
+		restoreErr = daemonlogs.WaitForProfileLoad(RANConfig.Spoke1APIClient, testData.nodeName,
+			daemonlogs.WithStartTime(restoreTime),
+			daemonlogs.WithTimeout(5*time.Minute))
+		Expect(restoreErr).ToNot(HaveOccurred(), "Daemon did not reload profiles after restoring plugin settings")
+
+		restoreTime = time.Now()
+
+		assertLockedState(testData.prometheusAPI, testData.nodeName, restoreTime,
+			expectedLockedClass, clockClassChanges, timeout)
+	})
+
+	setTime := time.Now()
+
+	By("waiting for daemon to reload profiles after config change")
+
+	err = daemonlogs.WaitForProfileLoad(RANConfig.Spoke1APIClient, testData.nodeName,
+		daemonlogs.WithStartTime(setTime),
+		daemonlogs.WithTimeout(3*time.Minute))
+	Expect(err).ToNot(HaveOccurred(), "Daemon did not reload profiles after config change")
+
+	setTime = time.Now()
+
+	assertLockedState(testData.prometheusAPI, testData.nodeName, setTime,
+		expectedLockedClass, clockClassChanges, timeout)
+}
+
+// discoverHoldoverTestData finds the first node with a matching profile type that supports holdover tests
+// and returns the test context. Returns nil if no suitable profile is found.
+func discoverHoldoverTestData(
+	prometheusAPI prometheusv1.API,
+	profileType profiles.PtpProfileType,
+) *holdoverTestData {
+	nodeInfoMap, err := profiles.GetNodeInfoMap(RANConfig.Spoke1APIClient)
+	Expect(err).ToNot(HaveOccurred(), "Failed to get node info map")
+
+	for name, nodeInfo := range nodeInfoMap {
+		matchingProfiles := nodeInfo.GetProfilesByTypes(profileType)
+
+		for _, profileInfo := range matchingProfiles {
+			profile, pullErr := profileInfo.PullProfile(RANConfig.Spoke1APIClient)
+			Expect(pullErr).ToNot(HaveOccurred())
+
+			if isUnsupportedPlugin(profile) {
+				continue
+			}
+
+			upstreamPort, upstreamErr := profiles.GetUpstreamPort(profile)
+			if upstreamErr != nil {
+				continue
+			}
+
+			ptpConfigBuilder, pullErr := profileInfo.Reference.PullPtpConfig(RANConfig.Spoke1APIClient)
+			Expect(pullErr).ToNot(HaveOccurred())
+
+			return &holdoverTestData{
+				prometheusAPI: prometheusAPI,
+				nodeName:      name,
+				ptpConfig:     ptpConfigBuilder,
+				profileIndex:  profileInfo.Reference.ProfileIndex,
+				upstreamIface: upstreamPort,
+			}
+		}
+	}
+
+	return nil
+}
+
+// isUnsupportedPlugin checks whether the profile uses a plugin type that does not support holdover tests
+// (e825 or e830).
+func isUnsupportedPlugin(profile *ptpv1.PtpProfile) bool {
+	pluginTypes, err := profiles.GetPluginTypesFromProfile(profile)
+	if err != nil {
+		return false
+	}
+
+	for _, pluginType := range pluginTypes {
+		if pluginType == ptp.PluginTypeE825 || pluginType == ptp.PluginTypeE830 {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
Closes https://redhat.atlassian.net/browse/CNF-20475

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added T-BC Transmitter profile type and improved profile parsing to better detect T-BC/T-TSC roles
  * Added holdover plugin settings management and automatic upstream-port detection for profiles
  * Added holdover label for PTP metric identification
  * Extended PTP metrics with additional clock class values and a new process type

* **Bug Fixes**
  * Fixed consumer service address formatting to improve connectivity

* **Tests**
  * Added end-to-end holdover behavior tests for T-BC and T-TSC (gated for operator 4.20+)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/eco-gotests/pull/1381)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->