### PR TITLE
CAPOA TLS profile tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -141,6 +141,7 @@ linters:
         - github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/raninittools
         - github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran-deployment/internal/raninittools
         - github.com/rh-ecosystem-edge/eco-gotests/tests/assisted/ztp/internal/ztpinittools
+        - github.com/rh-ecosystem-edge/eco-gotests/tests/assisted/ztp/capoa-tls/internal/inittools
         - github.com/rh-ecosystem-edge/eco-gotests/tests/system-tests/ipsec/internal/ipsecinittools
         - github.com/rh-ecosystem-edge/eco-gotests/tests/system-tests/ran-du/internal/randuinittools
         - github.com/rh-ecosystem-edge/eco-gotests/tests/system-tests/internal/systemtestsinittools
@@ -185,6 +186,9 @@ linters:
       - linters:
           - gochecknoinits
         path: tests/assisted/ztp/internal/ztpinittools
+      - linters:
+          - gochecknoinits
+        path: tests/assisted/ztp/capoa-tls/internal/inittools
       - linters:
           - gochecknoinits
         path: tests/system-tests/ipsec/internal/ipsecinittools
@@ -257,6 +261,9 @@ linters:
       - linters:
           - depguard
         path: tests/system-tests/vcore/internal/.*
+      - linters:
+          - depguard
+        path: tests/assisted/ztp/internal/tlsprofile
       - linters:
           - depguard
         path: tests/lca/imagebasedupgrade/cnf/internal/validations

--- a/tests/assisted/ztp/capoa-tls/capoa_tls_suite_test.go
+++ b/tests/assisted/ztp/capoa-tls/capoa_tls_suite_test.go
@@ -1,0 +1,45 @@
+package capoa_tls_test
+
+import (
+	"runtime"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/assisted/ztp/capoa-tls/internal/inittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/assisted/ztp/capoa-tls/internal/tsparams"
+	_ "github.com/rh-ecosystem-edge/eco-gotests/tests/assisted/ztp/capoa-tls/tests"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/reporter"
+)
+
+var _, currentFile, _, _ = runtime.Caller(0)
+
+func TestCAPOATLS(t *testing.T) {
+	_, reporterConfig := GinkgoConfiguration()
+	reporterConfig.JUnitReport = GeneralConfig.GetJunitReportPath(currentFile)
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CAPOA TLS Profile Suite", Label(tsparams.Labels...), reporterConfig)
+}
+
+var _ = BeforeSuite(func() {
+	By("Check if hub has valid apiClient")
+
+	if HubAPIClient == nil {
+		Skip("Cannot run CAPOA TLS Profile suite when hub has nil api client")
+	}
+})
+
+var _ = ReportAfterSuite("", func(report Report) {
+	reportxml.Create(report, GeneralConfig.GetReportPath(), GeneralConfig.TCPrefix)
+})
+
+var _ = JustAfterEach(func() {
+	reporter.ReportIfFailed(
+		CurrentSpecReport(),
+		currentFile,
+		tsparams.ReporterNamespacesToDump,
+		tsparams.ReporterCRDsToDump)
+})

--- a/tests/assisted/ztp/capoa-tls/internal/inittools/inittools.go
+++ b/tests/assisted/ztp/capoa-tls/internal/inittools/inittools.go
@@ -1,0 +1,28 @@
+package inittools
+
+import (
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/config"
+	"k8s.io/klog/v2"
+)
+
+var (
+	// HubAPIClient provides API access to hub cluster via KUBECONFIG env var.
+	HubAPIClient *clients.Settings
+	// GeneralConfig provides access to general configuration parameters.
+	GeneralConfig *config.GeneralConfig
+)
+
+func init() {
+	if GeneralConfig = config.NewConfig(); GeneralConfig == nil {
+		klog.Fatalf("failed to initialize GeneralConfig: config.NewConfig returned nil")
+	}
+
+	if HubAPIClient = clients.New(""); HubAPIClient == nil {
+		if GeneralConfig.DryRun {
+			return
+		}
+
+		klog.Fatalf("failed to initialize HubAPIClient: clients.New returned nil")
+	}
+}

--- a/tests/assisted/ztp/capoa-tls/internal/tsparams/capoa-tls-vars.go
+++ b/tests/assisted/ztp/capoa-tls/internal/tsparams/capoa-tls-vars.go
@@ -1,0 +1,23 @@
+package tsparams
+
+import (
+	"github.com/openshift-kni/k8sreporter"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/assisted/ztp/internal/ztpparams"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var (
+	// Labels represents the range of labels that can be used for test cases selection.
+	Labels = append(ztpparams.Labels, LabelSuite)
+
+	// ReporterNamespacesToDump tells to the reporter from where to collect logs.
+	ReporterNamespacesToDump = map[string]string{
+		"multicluster-engine": "mce",
+		TestNamespace:         "capoa-tls webhook test namespace",
+	}
+
+	// ReporterCRDsToDump tells to the reporter what CRs to dump.
+	ReporterCRDsToDump = []k8sreporter.CRData{
+		{Cr: &corev1.PodList{}},
+	}
+)

--- a/tests/assisted/ztp/capoa-tls/internal/tsparams/const.go
+++ b/tests/assisted/ztp/capoa-tls/internal/tsparams/const.go
@@ -1,0 +1,9 @@
+package tsparams
+
+const (
+	// LabelSuite represents the capoa-tls label that can be used for test cases selection.
+	LabelSuite = "capoa-tls"
+
+	// TestNamespace is the namespace used for webhook validation tests.
+	TestNamespace = "tls-test-capoa"
+)

--- a/tests/assisted/ztp/capoa-tls/tests/capoa_tls_profile.go
+++ b/tests/assisted/ztp/capoa-tls/tests/capoa_tls_profile.go
@@ -1,0 +1,489 @@
+package capoa_tls_test
+
+import (
+	"context"
+	"crypto/tls"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/apiservers"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/namespace"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/assisted/ztp/capoa-tls/internal/inittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/assisted/ztp/capoa-tls/internal/tsparams"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/assisted/ztp/internal/tlsprofile"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var customCiphers = []string{
+	"ECDHE-RSA-AES128-GCM-SHA256",
+	"ECDHE-RSA-AES256-GCM-SHA384",
+	"ECDHE-ECDSA-AES128-GCM-SHA256",
+	"ECDHE-ECDSA-AES256-GCM-SHA384",
+}
+
+func customTLSProfile(ciphers []string) configv1.TLSSecurityProfile {
+	return configv1.TLSSecurityProfile{
+		Type: configv1.TLSProfileCustomType,
+		Custom: &configv1.CustomTLSProfile{
+			TLSProfileSpec: configv1.TLSProfileSpec{
+				Ciphers:       ciphers,
+				MinTLSVersion: configv1.VersionTLS12,
+			},
+		},
+	}
+}
+
+var capoa = &tlsprofile.Component{
+	Name:        "CAPOA",
+	Namespace:   "multicluster-engine",
+	RestartMode: tlsprofile.RestartModeContainerRestart,
+	Endpoints: []tlsprofile.Endpoint{
+		{
+			ServiceName:    "capoa-bootstrap-webhook-service",
+			LocalPort:      19443,
+			RemotePort:     9443,
+			DeploymentName: "capoa-bootstrap-controller-manager",
+		},
+		{
+			ServiceName:    "capoa-controlplane-webhook-service",
+			LocalPort:      19444,
+			RemotePort:     9443,
+			DeploymentName: "capoa-controlplane-controller-manager",
+		},
+	},
+	Deployments: []tlsprofile.Deployment{
+		{Name: "capoa-bootstrap-controller-manager", ContainerName: "manager"},
+		{Name: "capoa-controlplane-controller-manager", ContainerName: "manager"},
+	},
+	ListPods: func(client *clients.Settings, ns string) ([]*pod.Builder, error) {
+		return pod.ListByNamePattern(client, "capoa", ns)
+	},
+	ExpectedHealthyPods: 2,
+	PodReadyTimeout:     5 * time.Minute,
+	AutoRestartTimeout:  10 * time.Minute,
+	HonoringLogPattern:  "honoring cluster-wide TLS profile",
+	AllowedCipher:       tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	AllowedCipherAlt:    tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	DisallowedCipher:    tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+	OldProfileCipher:    tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+}
+
+const defaultsLogPattern = "using defaults"
+
+func ensureTLSAdherence() {
+	builder, err := apiservers.PullAPIServer(HubAPIClient)
+	Expect(err).ToNot(HaveOccurred(), "failed to pull apiserver/cluster")
+
+	if builder.Definition.Spec.TLSAdherence == configv1.TLSAdherencePolicyStrictAllComponents {
+		return
+	}
+
+	By("Setting tlsAdherence to StrictAllComponents")
+	tlsprofile.PatchTLSAdherence(HubAPIClient, configv1.TLSAdherencePolicyStrictAllComponents)
+}
+
+// Tests are ordered to minimize TLS profile changes and cluster churn.
+// Flow: Intermediate → Old → Modern → Custom → (reuse) → reconciliation → restore
+// → LegacyAdheringComponentsOnly/StrictAllComponents adherence transitions → restore.
+var _ = Describe(
+	"CAPOA TLS Profile",
+	Ordered, ContinueOnFailure,
+	Label(tsparams.LabelSuite), func() {
+		BeforeAll(func() {
+			By("Verifying hub API client is available")
+
+			if HubAPIClient == nil {
+				Skip("Hub API client is nil")
+			}
+
+			By("Ensuring TLS adherence is set on the cluster")
+			ensureTLSAdherence()
+
+			By("Waiting for cluster to stabilize")
+			tlsprofile.WaitForClusterStability(HubAPIClient, 15*time.Minute)
+
+			By("Ensuring Intermediate baseline")
+			tlsprofile.RemoveAPIServerTLSProfile(HubAPIClient)
+
+			By("Verifying CAPOA pods are running")
+
+			pods, err := capoa.ListPods(HubAPIClient, capoa.Namespace)
+			Expect(err).ToNot(HaveOccurred(), "failed to list CAPOA pods")
+
+			if len(pods) == 0 {
+				Skip("CAPOA pods not found — not deployed")
+			}
+
+			tlsprofile.WaitPodsReady(HubAPIClient, capoa)
+		})
+
+		AfterAll(func() {
+			By("Restoring default Intermediate TLS profile")
+			tlsprofile.RemoveAPIServerTLSProfile(HubAPIClient)
+			tlsprofile.StopAllPortForwards()
+		})
+
+		// 1. Intermediate (no profile change — already baseline)
+		It("Verifies default Intermediate TLS profile on CAPOA endpoints",
+			reportxml.ID("88843"), func() {
+				By("Verifying controller logs show honoring message")
+
+				for _, d := range capoa.Deployments {
+					tlsprofile.AssertControllerLogsContain(HubAPIClient, capoa,
+						d, capoa.HonoringLogPattern)
+				}
+
+				for _, endpoint := range capoa.Endpoints {
+					By("Probing TLS 1.2 on " + endpoint.ServiceName)
+					tlsprofile.AssertTLSConnects(HubAPIClient, capoa, endpoint,
+						tls.VersionTLS12, tls.VersionTLS12, nil)
+
+					By("Probing TLS 1.3 on " + endpoint.ServiceName)
+					tlsprofile.AssertTLSConnects(HubAPIClient, capoa, endpoint,
+						tls.VersionTLS13, tls.VersionTLS13, nil)
+				}
+
+				By("Verifying TLS 1.1 is rejected")
+				tlsprofile.AssertTLSRejectedVersion(HubAPIClient, capoa,
+					capoa.Endpoints[0], tls.VersionTLS11)
+
+				By("Verifying TLS 1.0 is rejected")
+				tlsprofile.AssertTLSRejectedVersion(HubAPIClient, capoa,
+					capoa.Endpoints[0], tls.VersionTLS10)
+			})
+
+		// 2. Intermediate → Old (1 change)
+		It("Verifies Old TLS profile enables broader cipher set on CAPOA",
+			reportxml.ID("88844"), func() {
+				By("Applying Old TLS profile")
+				tlsprofile.PatchAPIServerTLSProfile(HubAPIClient,
+					configv1.TLSSecurityProfile{
+						Type: configv1.TLSProfileOldType,
+						Old:  &configv1.OldTLSProfile{},
+					})
+
+				By("Waiting for CAPOA pods to pick up Old profile")
+				tlsprofile.WaitPodsRestarted(HubAPIClient, capoa)
+
+				By("Verifying controller logs show VersionTLS10")
+
+				for _, d := range capoa.Deployments {
+					tlsprofile.AssertControllerLogsContain(HubAPIClient, capoa,
+						d, "VersionTLS10")
+				}
+
+				for _, endpoint := range capoa.Endpoints {
+					By("Verifying Old-specific cipher connects on " + endpoint.ServiceName)
+					tlsprofile.AssertTLSConnects(HubAPIClient, capoa, endpoint,
+						tls.VersionTLS12, tls.VersionTLS12,
+						[]uint16{capoa.OldProfileCipher})
+				}
+			})
+
+		// 3. Old → Modern (1 change)
+		It("Verifies Modern TLS profile restricts to TLS 1.3 only on CAPOA",
+			reportxml.ID("88845"), func() {
+				By("Applying Modern TLS profile")
+				tlsprofile.PatchAPIServerTLSProfile(HubAPIClient,
+					configv1.TLSSecurityProfile{
+						Type:   configv1.TLSProfileModernType,
+						Modern: &configv1.ModernTLSProfile{},
+					})
+
+				By("Waiting for CAPOA pods to pick up Modern profile")
+				tlsprofile.WaitPodsRestarted(HubAPIClient, capoa)
+
+				By("Verifying controller logs show VersionTLS13")
+
+				for _, d := range capoa.Deployments {
+					tlsprofile.AssertControllerLogsContain(HubAPIClient, capoa,
+						d, "VersionTLS13")
+				}
+
+				for _, endpoint := range capoa.Endpoints {
+					By("Verifying TLS 1.3 connects on " + endpoint.ServiceName)
+					tlsprofile.AssertTLSConnects(HubAPIClient, capoa, endpoint,
+						tls.VersionTLS13, tls.VersionTLS13, nil)
+
+					By("Verifying TLS 1.2 is rejected on " + endpoint.ServiceName)
+					tlsprofile.AssertTLSRejected(HubAPIClient, capoa, endpoint, nil)
+				}
+			})
+
+		// 4. Modern → Custom (1 change)
+		It("Verifies Custom TLS profile restricts to specified ciphers on CAPOA",
+			reportxml.ID("88846"), func() {
+				By("Applying Custom TLS profile")
+				tlsprofile.PatchAPIServerTLSProfile(HubAPIClient,
+					customTLSProfile(customCiphers))
+
+				By("Waiting for CAPOA pods to pick up Custom profile")
+				tlsprofile.WaitPodsRestarted(HubAPIClient, capoa)
+
+				for _, endpoint := range capoa.Endpoints {
+					By("Verifying allowed cipher connects on " + endpoint.ServiceName)
+					tlsprofile.AssertTLSConnects(HubAPIClient, capoa, endpoint,
+						tls.VersionTLS12, tls.VersionTLS12,
+						[]uint16{capoa.AllowedCipher})
+
+					By("Verifying disallowed cipher is rejected on " + endpoint.ServiceName)
+					tlsprofile.AssertTLSRejected(HubAPIClient, capoa, endpoint,
+						[]uint16{capoa.DisallowedCipher})
+				}
+			})
+
+		// 5. Custom (no change — reuse from 88846)
+		It("Verifies webhook validation works after TLS profile change on CAPOA",
+			reportxml.ID("88848"), func() {
+				By("Ensuring test namespace does not exist")
+
+				nsBuilder := namespace.NewBuilder(HubAPIClient, tsparams.TestNamespace)
+				_ = nsBuilder.DeleteAndWait(2 * time.Minute)
+
+				By("Creating test namespace")
+
+				_, err := nsBuilder.Create()
+				Expect(err).ToNot(HaveOccurred(), "failed to create test namespace")
+
+				DeferCleanup(func() {
+					_ = nsBuilder.DeleteAndWait(2 * time.Minute)
+				})
+
+				By("Creating valid OpenshiftAssistedConfig")
+
+				resource := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha2",
+						"kind":       "OpenshiftAssistedConfig",
+						"metadata": map[string]interface{}{
+							"name":      "test-webhook-validation",
+							"namespace": tsparams.TestNamespace,
+						},
+						"spec": map[string]interface{}{
+							"cpuArchitecture": "x86_64",
+						},
+					},
+				}
+
+				err = HubAPIClient.Create(context.TODO(), resource)
+				Expect(err).ToNot(HaveOccurred(),
+					"valid OpenshiftAssistedConfig should be accepted")
+
+				By("Attempting to update spec (should be rejected)")
+
+				mutationPatch := []byte(
+					`{"spec":{"cpuArchitecture":"aarch64"}}`)
+				err = HubAPIClient.Patch(context.TODO(), resource,
+					runtimeclient.RawPatch(types.MergePatchType, mutationPatch))
+				Expect(err).To(HaveOccurred(),
+					"spec update should be rejected by webhook")
+				Expect(err.Error()).To(ContainSubstring("immutable"),
+					"rejection reason should mention immutable")
+
+				By("Updating metadata only (should succeed)")
+
+				labelPatch := []byte(
+					`{"metadata":{"labels":{"tls-profile-test":"validation"}}}`)
+				err = HubAPIClient.Patch(context.TODO(), resource,
+					runtimeclient.RawPatch(types.MergePatchType, labelPatch))
+				Expect(err).ToNot(HaveOccurred(),
+					"metadata update should be accepted")
+
+				By("Deleting the resource")
+
+				err = HubAPIClient.Delete(context.TODO(), resource)
+				Expect(err).ToNot(HaveOccurred(), "deletion should succeed")
+			})
+
+		// 6. Custom → Intermediate → Custom (2 changes, test auto-restart)
+		It("Verifies SecurityProfileWatcher triggers restart on CAPOA",
+			reportxml.ID("88858"), func() {
+				By("Ensuring Intermediate baseline")
+				tlsprofile.RemoveAPIServerTLSProfile(HubAPIClient)
+				tlsprofile.WaitPodsRestarted(HubAPIClient, capoa)
+
+				By("Changing TLS profile to Custom")
+				tlsprofile.PatchAPIServerTLSProfile(HubAPIClient,
+					customTLSProfile(customCiphers))
+
+				By("Waiting for automatic restart")
+				tlsprofile.WaitPodsRestarted(HubAPIClient, capoa)
+
+				By("Verifying controllers honour the new profile")
+
+				for _, d := range capoa.Deployments {
+					tlsprofile.AssertControllerLogsContain(HubAPIClient, capoa,
+						d, capoa.HonoringLogPattern)
+				}
+			})
+
+		// 7. Custom → single-cipher Custom → Intermediate (3 changes, reconciliation)
+		It("Verifies profile change triggers automatic reconciliation on CAPOA",
+			reportxml.ID("88847"), func() {
+				By("Recording baseline cipher connectivity")
+				tlsprofile.AssertTLSConnects(HubAPIClient, capoa, capoa.Endpoints[0],
+					tls.VersionTLS12, tls.VersionTLS12,
+					[]uint16{capoa.AllowedCipher})
+
+				singleCiphers := []string{
+					"ECDHE-RSA-AES128-GCM-SHA256",
+					"ECDHE-ECDSA-AES128-GCM-SHA256",
+				}
+
+				By("Switching to Custom single-cipher profile")
+				tlsprofile.PatchAPIServerTLSProfile(HubAPIClient,
+					customTLSProfile(singleCiphers))
+
+				By("Waiting for automatic reconciliation (no manual pod restart)")
+				tlsprofile.WaitPodsRestarted(HubAPIClient, capoa)
+				tlsprofile.WaitForClusterStability(HubAPIClient, 25*time.Minute)
+
+				for _, d := range capoa.Deployments {
+					tlsprofile.AssertControllerLogsContain(HubAPIClient, capoa,
+						d, capoa.HonoringLogPattern)
+				}
+
+				By("Verifying AES256 is now rejected")
+				tlsprofile.AssertTLSRejected(HubAPIClient, capoa, capoa.Endpoints[0],
+					[]uint16{capoa.AllowedCipherAlt})
+
+				By("Switching back to Intermediate")
+				tlsprofile.RemoveAPIServerTLSProfile(HubAPIClient)
+				tlsprofile.WaitPodsRestarted(HubAPIClient, capoa)
+				tlsprofile.WaitForClusterStability(HubAPIClient, 25*time.Minute)
+
+				By("Verifying AES256 is restored under Intermediate")
+				tlsprofile.AssertTLSConnects(HubAPIClient, capoa, capoa.Endpoints[0],
+					tls.VersionTLS12, tls.VersionTLS12,
+					[]uint16{capoa.AllowedCipherAlt})
+			})
+
+		// 8. Intermediate (no change — verify restore from 88847)
+		It("Verifies restore to default profile on CAPOA",
+			reportxml.ID("88850"), func() {
+				By("Waiting for cluster to stabilize after previous profile changes")
+				tlsprofile.WaitForClusterStability(HubAPIClient, 15*time.Minute)
+
+				By("Verifying no tlsSecurityProfile remains on apiserver")
+
+				builder, err := apiservers.PullAPIServer(HubAPIClient)
+				Expect(err).ToNot(HaveOccurred(), "failed to pull apiserver/cluster")
+				Expect(builder.Definition.Spec.TLSSecurityProfile).To(BeNil(),
+					"tlsSecurityProfile should be nil after restore")
+
+				By("Verifying controller logs show VersionTLS12")
+
+				for _, d := range capoa.Deployments {
+					tlsprofile.AssertControllerLogsContain(HubAPIClient, capoa,
+						d, "VersionTLS12")
+				}
+
+				By("Verifying Intermediate ciphers are available")
+				tlsprofile.AssertTLSConnects(HubAPIClient, capoa, capoa.Endpoints[0],
+					tls.VersionTLS12, tls.VersionTLS12,
+					[]uint16{capoa.AllowedCipher})
+				tlsprofile.AssertTLSConnects(HubAPIClient, capoa, capoa.Endpoints[0],
+					tls.VersionTLS13, tls.VersionTLS13, nil)
+			})
+
+		// 9. LegacyAdheringComponentsOnly ignores profile, StrictAllComponents enforces it
+		It("Verifies non-honoring adherence ignores TLS profile and StrictAllComponents enforces it on CAPOA",
+			reportxml.ID("89003"), func() {
+				Skip("Blocked by ACM-34017: SecurityProfileWatcher restart loop — https://redhat.atlassian.net/browse/ACM-34017")
+
+				By("Setting adherence to LegacyAdheringComponentsOnly")
+				tlsprofile.PatchTLSAdherence(HubAPIClient, configv1.TLSAdherencePolicyLegacyAdheringComponentsOnly)
+
+				By("Waiting for CAPOA pods to restart after adherence change")
+				tlsprofile.WaitPodsRestarted(HubAPIClient, capoa)
+
+				By("Applying Modern TLS profile (TLS 1.3 only)")
+				tlsprofile.PatchAPIServerTLSProfile(HubAPIClient,
+					configv1.TLSSecurityProfile{
+						Type:   configv1.TLSProfileModernType,
+						Modern: &configv1.ModernTLSProfile{},
+					})
+
+				By("Waiting for CAPOA pods to restart after profile change")
+				tlsprofile.WaitPodsRestarted(HubAPIClient, capoa)
+
+				By("Verifying controller logs show defaults path (not honoring)")
+
+				for _, d := range capoa.Deployments {
+					tlsprofile.AssertControllerLogsContain(HubAPIClient, capoa,
+						d, defaultsLogPattern)
+				}
+
+				By("Verifying TLS 1.2 still connects (Modern profile is ignored)")
+				tlsprofile.AssertTLSConnects(HubAPIClient, capoa, capoa.Endpoints[0],
+					tls.VersionTLS12, tls.VersionTLS12, nil)
+
+				By("Switching adherence to StrictAllComponents")
+				tlsprofile.PatchTLSAdherence(HubAPIClient, configv1.TLSAdherencePolicyStrictAllComponents)
+
+				By("Waiting for CAPOA pods to restart after adherence change")
+				tlsprofile.WaitPodsRestarted(HubAPIClient, capoa)
+
+				By("Verifying controller logs show honoring message")
+
+				for _, d := range capoa.Deployments {
+					tlsprofile.AssertControllerLogsContain(HubAPIClient, capoa,
+						d, capoa.HonoringLogPattern)
+				}
+
+				By("Verifying TLS 1.2 is now rejected (Modern profile enforced)")
+				tlsprofile.AssertTLSRejected(HubAPIClient, capoa, capoa.Endpoints[0], nil)
+
+				By("Verifying TLS 1.3 connects")
+				tlsprofile.AssertTLSConnects(HubAPIClient, capoa, capoa.Endpoints[0],
+					tls.VersionTLS13, tls.VersionTLS13, nil)
+			})
+
+		// 10. StrictAllComponents → LegacyAdheringComponentsOnly reverts to Intermediate defaults
+		It("Verifies switching to non-honoring adherence reverts CAPOA to Intermediate defaults",
+			reportxml.ID("89004"), func() {
+				Skip("Blocked by ACM-34017: SecurityProfileWatcher restart loop — https://redhat.atlassian.net/browse/ACM-34017")
+
+				By("Ensuring StrictAllComponents + Modern baseline from previous test")
+				tlsprofile.WaitPodsReady(HubAPIClient, capoa)
+
+				By("Verifying TLS 1.2 is rejected under Modern profile")
+				tlsprofile.AssertTLSRejected(HubAPIClient, capoa, capoa.Endpoints[0], nil)
+
+				By("Switching adherence to LegacyAdheringComponentsOnly")
+				tlsprofile.PatchTLSAdherence(HubAPIClient, configv1.TLSAdherencePolicyLegacyAdheringComponentsOnly)
+
+				By("Waiting for CAPOA pods to restart after adherence change")
+				tlsprofile.WaitPodsRestarted(HubAPIClient, capoa)
+
+				By("Verifying controller logs show defaults path")
+
+				for _, d := range capoa.Deployments {
+					tlsprofile.AssertControllerLogsContain(HubAPIClient, capoa,
+						d, defaultsLogPattern)
+				}
+
+				By("Verifying TLS 1.2 connects again (Intermediate defaults)")
+				tlsprofile.AssertTLSConnects(HubAPIClient, capoa, capoa.Endpoints[0],
+					tls.VersionTLS12, tls.VersionTLS12, nil)
+
+				By("Verifying TLS 1.3 also connects")
+				tlsprofile.AssertTLSConnects(HubAPIClient, capoa, capoa.Endpoints[0],
+					tls.VersionTLS13, tls.VersionTLS13, nil)
+
+				By("Restoring StrictAllComponents for suite cleanup")
+				tlsprofile.PatchTLSAdherence(HubAPIClient, configv1.TLSAdherencePolicyStrictAllComponents)
+				tlsprofile.WaitPodsRestarted(HubAPIClient, capoa)
+
+				By("Removing Modern profile to restore Intermediate baseline")
+				tlsprofile.RemoveAPIServerTLSProfile(HubAPIClient)
+				tlsprofile.WaitPodsRestarted(HubAPIClient, capoa)
+			})
+	})

--- a/tests/assisted/ztp/capoa-tls/tests/capoa_tls_profile.go
+++ b/tests/assisted/ztp/capoa-tls/tests/capoa_tls_profile.go
@@ -163,7 +163,7 @@ var _ = Describe(
 		It("Verifies Old TLS profile enables broader cipher set on CAPOA",
 			reportxml.ID("88844"), func() {
 				By("Applying Old TLS profile")
-				tlsprofile.PatchAPIServerTLSProfile(HubAPIClient,
+				tlsprofile.SetAPIServerTLSProfile(HubAPIClient,
 					configv1.TLSSecurityProfile{
 						Type: configv1.TLSProfileOldType,
 						Old:  &configv1.OldTLSProfile{},
@@ -191,7 +191,7 @@ var _ = Describe(
 		It("Verifies Modern TLS profile restricts to TLS 1.3 only on CAPOA",
 			reportxml.ID("88845"), func() {
 				By("Applying Modern TLS profile")
-				tlsprofile.PatchAPIServerTLSProfile(HubAPIClient,
+				tlsprofile.SetAPIServerTLSProfile(HubAPIClient,
 					configv1.TLSSecurityProfile{
 						Type:   configv1.TLSProfileModernType,
 						Modern: &configv1.ModernTLSProfile{},
@@ -221,7 +221,7 @@ var _ = Describe(
 		It("Verifies Custom TLS profile restricts to specified ciphers on CAPOA",
 			reportxml.ID("88846"), func() {
 				By("Applying Custom TLS profile")
-				tlsprofile.PatchAPIServerTLSProfile(HubAPIClient,
+				tlsprofile.SetAPIServerTLSProfile(HubAPIClient,
 					customTLSProfile(customCiphers))
 
 				By("Waiting for CAPOA pods to pick up Custom profile")
@@ -310,7 +310,7 @@ var _ = Describe(
 				tlsprofile.WaitPodsRestarted(HubAPIClient, capoa)
 
 				By("Changing TLS profile to Custom")
-				tlsprofile.PatchAPIServerTLSProfile(HubAPIClient,
+				tlsprofile.SetAPIServerTLSProfile(HubAPIClient,
 					customTLSProfile(customCiphers))
 
 				By("Waiting for automatic restart")
@@ -338,7 +338,7 @@ var _ = Describe(
 				}
 
 				By("Switching to Custom single-cipher profile")
-				tlsprofile.PatchAPIServerTLSProfile(HubAPIClient,
+				tlsprofile.SetAPIServerTLSProfile(HubAPIClient,
 					customTLSProfile(singleCiphers))
 
 				By("Waiting for automatic reconciliation (no manual pod restart)")
@@ -405,7 +405,7 @@ var _ = Describe(
 				tlsprofile.WaitPodsRestarted(HubAPIClient, capoa)
 
 				By("Applying Modern TLS profile (TLS 1.3 only)")
-				tlsprofile.PatchAPIServerTLSProfile(HubAPIClient,
+				tlsprofile.SetAPIServerTLSProfile(HubAPIClient,
 					configv1.TLSSecurityProfile{
 						Type:   configv1.TLSProfileModernType,
 						Modern: &configv1.ModernTLSProfile{},

--- a/tests/assisted/ztp/internal/tlsprofile/helpers.go
+++ b/tests/assisted/ztp/internal/tlsprofile/helpers.go
@@ -12,8 +12,8 @@ import (
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
 )
 
-// PatchAPIServerTLSProfile applies the given TLS security profile to the cluster APIServer.
-func PatchAPIServerTLSProfile(client *clients.Settings, profile configv1.TLSSecurityProfile) {
+// SetAPIServerTLSProfile applies the given TLS security profile to the cluster APIServer.
+func SetAPIServerTLSProfile(client *clients.Settings, profile configv1.TLSSecurityProfile) {
 	builder, err := apiservers.PullAPIServer(client)
 	Expect(err).ToNot(HaveOccurred(), "failed to pull apiserver")
 

--- a/tests/assisted/ztp/internal/tlsprofile/helpers.go
+++ b/tests/assisted/ztp/internal/tlsprofile/helpers.go
@@ -1,0 +1,84 @@
+package tlsprofile
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/apiservers"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+)
+
+// PatchAPIServerTLSProfile applies the given TLS security profile to the cluster APIServer.
+func PatchAPIServerTLSProfile(client *clients.Settings, profile configv1.TLSSecurityProfile) {
+	builder, err := apiservers.PullAPIServer(client)
+	Expect(err).ToNot(HaveOccurred(), "failed to pull apiserver")
+
+	_, err = builder.WithTLSSecurityProfile(&profile).Update()
+	Expect(err).ToNot(HaveOccurred(), "failed to update apiserver TLS profile")
+}
+
+// PatchTLSAdherence sets the tlsAdherence policy on the cluster APIServer.
+func PatchTLSAdherence(client *clients.Settings, policy configv1.TLSAdherencePolicy) {
+	builder, err := apiservers.PullAPIServer(client)
+	Expect(err).ToNot(HaveOccurred(), "failed to pull apiserver")
+
+	_, err = builder.WithTLSAdherence(policy).Update()
+	Expect(err).ToNot(HaveOccurred(), "failed to update tlsAdherence to %s", policy)
+}
+
+// RemoveAPIServerTLSProfile removes the tlsSecurityProfile from the cluster APIServer.
+func RemoveAPIServerTLSProfile(client *clients.Settings) {
+	builder, err := apiservers.PullAPIServer(client)
+	Expect(err).ToNot(HaveOccurred(), "failed to pull apiserver")
+
+	builder.Definition.Spec.TLSSecurityProfile = nil
+
+	_, err = builder.Update()
+	Expect(err).ToNot(HaveOccurred(), "failed to remove apiserver TLS profile")
+}
+
+// WaitForClusterStability waits until all cluster operators are Available and not
+// Progressing or Degraded. This prevents test cases from running while the control
+// plane is mid-rollout from a previous TLS profile change.
+func WaitForClusterStability(client *clients.Settings, timeout time.Duration) {
+	By("Waiting for cluster operators to stabilize")
+
+	Eventually(func() string {
+		coList := &configv1.ClusterOperatorList{}
+
+		err := client.List(context.TODO(), coList)
+		if err != nil {
+			return fmt.Sprintf("failed to list cluster operators: %v", err)
+		}
+
+		for i := range coList.Items {
+			operator := &coList.Items[i]
+			available := false
+			progressing := true
+			degraded := true
+
+			for _, cond := range operator.Status.Conditions {
+				switch cond.Type { //nolint:exhaustive
+				case configv1.OperatorAvailable:
+					available = cond.Status == configv1.ConditionTrue
+				case configv1.OperatorProgressing:
+					progressing = cond.Status == configv1.ConditionTrue
+				case configv1.OperatorDegraded:
+					degraded = cond.Status == configv1.ConditionTrue
+				}
+			}
+
+			if !available || progressing || degraded {
+				return fmt.Sprintf("operator %s: available=%v progressing=%v degraded=%v",
+					operator.Name, available, progressing, degraded)
+			}
+		}
+
+		return ""
+	}).WithTimeout(timeout).WithPolling(15*time.Second).
+		Should(BeEmpty(), "cluster operators should be stable")
+}

--- a/tests/assisted/ztp/internal/tlsprofile/pods.go
+++ b/tests/assisted/ztp/internal/tlsprofile/pods.go
@@ -1,0 +1,216 @@
+package tlsprofile
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
+)
+
+// FindPod returns the first pod whose name contains deploymentName.
+func FindPod(client *clients.Settings, component *Component, deploymentName string) *pod.Builder {
+	pods, err := component.ListPods(client, component.Namespace)
+	Expect(err).ToNot(HaveOccurred(), "failed to list %s pods", component.Name)
+
+	for _, p := range pods {
+		if strings.Contains(p.Object.Name, deploymentName) {
+			return p
+		}
+	}
+
+	Fail(fmt.Sprintf("no %s pod found matching %s", component.Name, deploymentName))
+
+	return nil
+}
+
+// WaitPodsReady waits until the expected number of healthy pods is reached.
+func WaitPodsReady(client *clients.Settings, component *Component) {
+	Eventually(func() int {
+		pods, err := component.ListPods(client, component.Namespace)
+		if err != nil {
+			return 0
+		}
+
+		ready := 0
+
+		for _, p := range pods {
+			if p.IsHealthy() {
+				ready++
+			}
+		}
+
+		return ready
+	}).WithTimeout(component.PodReadyTimeout).WithPolling(10*time.Second).
+		Should(BeNumerically(">=", component.ExpectedHealthyPods),
+			"%s pods should be ready", component.Name)
+}
+
+// RestartPods deletes all component pods and waits for them to come back ready.
+func RestartPods(client *clients.Settings, component *Component) {
+	pods, err := component.ListPods(client, component.Namespace)
+	Expect(err).ToNot(HaveOccurred(), "failed to list %s pods", component.Name)
+
+	for _, p := range pods {
+		podName := p.Object.Name
+		_, err := p.DeleteAndWait(component.PodReadyTimeout)
+		Expect(err).ToNot(HaveOccurred(), "failed to delete pod %s", podName)
+	}
+
+	WaitPodsReady(client, component)
+}
+
+// WaitPodsRestarted waits for the component to automatically restart after a TLS profile change.
+func WaitPodsRestarted(client *clients.Settings, component *Component) {
+	switch component.RestartMode {
+	case RestartModeContainerRestart:
+		waitContainerRestart(client, component)
+	case RestartModePodReplacement:
+		waitPodReplacement(client, component)
+	}
+
+	WaitPodsReady(client, component)
+}
+
+func waitContainerRestart(client *clients.Settings, component *Component) {
+	type baseline struct {
+		podUID       string
+		restartCount int32
+	}
+
+	baselines := make(map[string]baseline)
+
+	Eventually(func() bool {
+		for _, deploy := range component.Deployments {
+			uid, count := getContainerRestartInfo(client, component, deploy)
+			if uid == "" {
+				return false
+			}
+
+			baselines[deploy.Name] = baseline{podUID: uid, restartCount: count}
+		}
+
+		return true
+	}).WithTimeout(2*time.Minute).WithPolling(5*time.Second).
+		Should(BeTrue(), "should be able to read %s restart counts", component.Name)
+
+	for _, d := range component.Deployments {
+		deploy := d
+		base := baselines[deploy.Name]
+
+		Eventually(func() bool {
+			uid, count := getContainerRestartInfo(client, component, deploy)
+			if uid == "" {
+				return false
+			}
+
+			if uid != base.podUID {
+				return true
+			}
+
+			return count > base.restartCount
+		}).WithTimeout(component.AutoRestartTimeout).WithPolling(5*time.Second).
+			Should(BeTrue(), "%s %s should have restarted", component.Name, deploy.Name)
+	}
+}
+
+func waitPodReplacement(client *clients.Settings, component *Component) {
+	oldNames := make(map[string]bool)
+
+	Eventually(func() bool {
+		pods, err := component.ListPods(client, component.Namespace)
+		if err != nil || len(pods) == 0 {
+			return false
+		}
+
+		for _, p := range pods {
+			oldNames[p.Object.Name] = true
+		}
+
+		return true
+	}).WithTimeout(2*time.Minute).WithPolling(5*time.Second).
+		Should(BeTrue(), "should be able to list %s pods", component.Name)
+
+	Eventually(func() bool {
+		currentPods, err := component.ListPods(client, component.Namespace)
+		if err != nil {
+			return false
+		}
+
+		for _, p := range currentPods {
+			if oldNames[p.Object.Name] {
+				return false
+			}
+		}
+
+		return len(currentPods) >= component.ExpectedHealthyPods
+	}).WithTimeout(component.AutoRestartTimeout).WithPolling(5*time.Second).
+		Should(BeTrue(), "%s pods should have been replaced", component.Name)
+}
+
+// getContainerRestartInfo returns the pod UID and restart count for the given deployment.
+// Returns ("", 0) if the pod or container cannot be found.
+func getContainerRestartInfo(
+	client *clients.Settings, component *Component, deploy Deployment,
+) (string, int32) {
+	pods, err := component.ListPods(client, component.Namespace)
+	if err != nil {
+		return "", 0
+	}
+
+	for _, p := range pods {
+		if strings.Contains(p.Object.Name, deploy.Name) {
+			uid := string(p.Object.UID)
+
+			for _, cs := range p.Object.Status.ContainerStatuses {
+				if cs.Name == deploy.ContainerName {
+					return uid, cs.RestartCount
+				}
+			}
+
+			return uid, 0
+		}
+	}
+
+	return "", 0
+}
+
+// GetContainerRestartCount returns the restart count of the container for the given deployment.
+// Returns -1 if the pod or container cannot be found (e.g. API timeout during rollout).
+func GetContainerRestartCount(client *clients.Settings, component *Component, deploy Deployment) int32 {
+	uid, count := getContainerRestartInfo(client, component, deploy)
+	if uid == "" {
+		return -1
+	}
+
+	return count
+}
+
+// AssertControllerLogsContain asserts that the deployment's container logs contain the given pattern.
+func AssertControllerLogsContain(client *clients.Settings, component *Component,
+	deploy Deployment, pattern string) {
+	Eventually(func() string {
+		pods, err := component.ListPods(client, component.Namespace)
+		if err != nil {
+			return ""
+		}
+
+		for _, p := range pods {
+			if strings.Contains(p.Object.Name, deploy.Name) {
+				logs, logErr := p.GetFullLog(deploy.ContainerName)
+				if logErr != nil {
+					return ""
+				}
+
+				return logs
+			}
+		}
+
+		return ""
+	}).WithTimeout(30*time.Second).WithPolling(5*time.Second).
+		Should(ContainSubstring(pattern),
+			fmt.Sprintf("%s %s logs should contain %q", component.Name, deploy.Name, pattern))
+}

--- a/tests/assisted/ztp/internal/tlsprofile/portforward.go
+++ b/tests/assisted/ztp/internal/tlsprofile/portforward.go
@@ -1,0 +1,71 @@
+package tlsprofile
+
+import (
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
+)
+
+var portForwardStopFuncs = map[string]func(){}
+
+func portForwardKey(endpoint Endpoint) string {
+	return fmt.Sprintf("%s:%d", endpoint.ServiceName, endpoint.LocalPort)
+}
+
+// StartPortForward sets up a port-forward to the pod behind the endpoint and returns the local address.
+func StartPortForward(client *clients.Settings, component *Component, endpoint Endpoint) string {
+	key := portForwardKey(endpoint)
+	StopPortForward(endpoint)
+
+	targetPod := findPodForEndpoint(client, component, endpoint)
+
+	addr, stop, err := targetPod.PortForward(endpoint.LocalPort, endpoint.RemotePort)
+	Expect(err).ToNot(HaveOccurred(), "failed to port-forward to %s", endpoint.ServiceName)
+
+	portForwardStopFuncs[key] = stop
+
+	return addr
+}
+
+// StopPortForward closes the port-forward for the given endpoint if one is active.
+func StopPortForward(endpoint Endpoint) {
+	key := portForwardKey(endpoint)
+
+	if stop, ok := portForwardStopFuncs[key]; ok {
+		stop()
+		delete(portForwardStopFuncs, key)
+	}
+}
+
+// StopAllPortForwards closes all active port-forwards.
+func StopAllPortForwards() {
+	for key, stop := range portForwardStopFuncs {
+		stop()
+		delete(portForwardStopFuncs, key)
+	}
+}
+
+func findPodForEndpoint(client *clients.Settings, component *Component, endpoint Endpoint) *pod.Builder {
+	pods, err := component.ListPods(client, component.Namespace)
+	Expect(err).ToNot(HaveOccurred(), "failed to list %s pods", component.Name)
+	Expect(pods).ToNot(BeEmpty(), "no %s pods found", component.Name)
+
+	if endpoint.DeploymentName == "" {
+		return pods[0]
+	}
+
+	for _, p := range pods {
+		if strings.Contains(p.Object.Name, endpoint.DeploymentName) {
+			return p
+		}
+	}
+
+	Fail(fmt.Sprintf("no %s pod found matching deployment %s for endpoint %s",
+		component.Name, endpoint.DeploymentName, endpoint.ServiceName))
+
+	return nil
+}

--- a/tests/assisted/ztp/internal/tlsprofile/tls.go
+++ b/tests/assisted/ztp/internal/tlsprofile/tls.go
@@ -1,0 +1,108 @@
+package tlsprofile
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+)
+
+// AssertTLSConnects verifies that a TLS handshake succeeds with the given version and cipher constraints.
+func AssertTLSConnects(client *clients.Settings, component *Component,
+	endpoint Endpoint, minVersion, maxVersion uint16, cipherSuites []uint16) {
+	addr := StartPortForward(client, component, endpoint)
+
+	defer StopPortForward(endpoint)
+
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: true, //nolint:gosec
+		MinVersion:         minVersion,
+		MaxVersion:         maxVersion,
+	}
+
+	if len(cipherSuites) > 0 {
+		tlsConfig.CipherSuites = cipherSuites
+	}
+
+	Eventually(func() error {
+		dialer := &net.Dialer{Timeout: 10 * time.Second}
+
+		conn, dialErr := tls.DialWithDialer(dialer, "tcp", addr, tlsConfig)
+		if dialErr != nil {
+			return dialErr
+		}
+
+		defer conn.Close()
+
+		state := conn.ConnectionState()
+		if !state.HandshakeComplete {
+			return fmt.Errorf("TLS handshake not complete")
+		}
+
+		return nil
+	}).WithTimeout(30*time.Second).WithPolling(2*time.Second).
+		Should(Succeed(), "TLS connection to %s (%s) should succeed",
+			endpoint.ServiceName, component.Name)
+}
+
+// AssertTLSRejectedVersion verifies that a TLS handshake is rejected for the given TLS version.
+func AssertTLSRejectedVersion(client *clients.Settings, component *Component,
+	endpoint Endpoint, version uint16) {
+	AssertTLSRejectedWith(client, component, endpoint, version, version, nil)
+}
+
+// AssertTLSRejected verifies that a TLS 1.2 handshake is rejected with the given cipher suites.
+func AssertTLSRejected(client *clients.Settings, component *Component,
+	endpoint Endpoint, cipherSuites []uint16) {
+	AssertTLSRejectedWith(client, component, endpoint, tls.VersionTLS12, tls.VersionTLS12, cipherSuites)
+}
+
+// AssertTLSRejectedWith verifies that a TLS handshake is rejected with the given version and cipher constraints.
+func AssertTLSRejectedWith(client *clients.Settings, component *Component,
+	endpoint Endpoint, minVersion, maxVersion uint16, cipherSuites []uint16) {
+	addr := StartPortForward(client, component, endpoint)
+
+	defer StopPortForward(endpoint)
+
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: true, //nolint:gosec
+		MinVersion:         minVersion,
+		MaxVersion:         maxVersion,
+	}
+
+	if len(cipherSuites) > 0 {
+		tlsConfig.CipherSuites = cipherSuites
+	}
+
+	Eventually(func() string {
+		dialer := &net.Dialer{Timeout: 10 * time.Second}
+		conn, dialErr := tls.DialWithDialer(dialer, "tcp", addr, tlsConfig)
+
+		if conn != nil {
+			conn.Close()
+		}
+
+		if dialErr == nil {
+			return "connected"
+		}
+
+		errMsg := dialErr.Error()
+		if strings.Contains(errMsg, "connection refused") ||
+			strings.Contains(errMsg, "EOF") ||
+			strings.Contains(errMsg, "connection reset") ||
+			strings.Contains(errMsg, "i/o timeout") ||
+			strings.Contains(errMsg, "context deadline exceeded") ||
+			strings.Contains(errMsg, "timeout") {
+			return "not-ready"
+		}
+
+		return errMsg
+	}).WithTimeout(30*time.Second).WithPolling(2*time.Second).
+		Should(ContainSubstring("tls:"),
+			"TLS connection to %s (%s) should be rejected with TLS error",
+			endpoint.ServiceName, component.Name)
+}

--- a/tests/assisted/ztp/internal/tlsprofile/types.go
+++ b/tests/assisted/ztp/internal/tlsprofile/types.go
@@ -1,0 +1,65 @@
+package tlsprofile
+
+import (
+	"time"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
+)
+
+// RestartMode indicates how a component restarts after TLS profile changes.
+type RestartMode int
+
+const (
+	// RestartModeContainerRestart means the container restarts in-place (same pod UID, restart count increases).
+	RestartModeContainerRestart RestartMode = iota
+	// RestartModePodReplacement means the pod is replaced entirely (new pod name).
+	RestartModePodReplacement
+)
+
+// Endpoint represents a TLS-secured service endpoint to probe.
+type Endpoint struct {
+	ServiceName    string
+	LocalPort      int
+	RemotePort     int
+	DeploymentName string
+}
+
+// Deployment represents a deployment whose pods should be tracked for logs and restarts.
+type Deployment struct {
+	Name          string
+	ContainerName string
+}
+
+// WebhookTestConfig holds details for webhook validation testing after a TLS profile change.
+type WebhookTestConfig struct {
+	TestNamespace      string
+	APIVersion         string
+	Kind               string
+	ResourceName       string
+	CreateSpec         map[string]interface{}
+	MutationPatch      []byte
+	RejectionSubstring string
+}
+
+// Component fully describes a TLS-adherent component for testing.
+type Component struct {
+	Name                string
+	Label               string
+	Namespace           string
+	RestartMode         RestartMode
+	Endpoints           []Endpoint
+	Deployments         []Deployment
+	ListPods            func(*clients.Settings, string) ([]*pod.Builder, error)
+	ExpectedHealthyPods int
+	PodReadyTimeout     time.Duration
+	AutoRestartTimeout  time.Duration
+	HonoringLogPattern  string
+	OldProfileLog       string
+	ModernProfileLog    string
+	WebhookTest         *WebhookTestConfig
+	AllowedCipher       uint16
+	AllowedCipherAlt    uint16
+	DisallowedCipher    uint16
+	OldProfileCipher    uint16
+}


### PR DESCRIPTION

- Add automated test suite (capoa-tls) validating that CAPOA bootstrap and controlplane controllers honor the cluster-wide TLS security profile from the APIServer CR
- Tests cover all four TLS profiles (Intermediate, Old, Modern, Custom), automatic reconciliation on profile changes, SecurityProfileWatcher restart behavior, webhook validation, and tlsAdherence policy changes
- Includes shared internal/tlsprofile/ helper package for TLS probing, port-forwarding, pod lifecycle, and APIServer patching — reusable by future component TLS suites (e.g., IBIO)
- Vendors k8s.io/client-go/tools/portforward for in-process port-forward support

 go vet passes
 golangci-lint passes
 All 9 test cases executed on OCP 4.22 nightly + MCE 2.17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a CAPOA TLS Profile end-to-end test suite with JUnit/XML reporting that validates TLS version/cipher acceptance/rejection, APIServer TLS profile transitions, webhook immutability, controller log assertions, pod restart/reconciliation, and cluster stability.
  * Added reusable test helpers, types, parameters, port‑forwarding utilities, TLS assertion helpers, pod lifecycle checks, and shared test init variables/configuration; suite-specific labels, namespaces, and reporter CRDs.

* **Chores**
  * Updated linter config to whitelist the test init package and add exclusions (including a depguard exclusion) for test packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->