### PR TITLE
nmstate: add nmstate altnames tests

### DIFF
--- a/tests/cnf/core/network/internal/netnmstate/netnmstate.go
+++ b/tests/cnf/core/network/internal/netnmstate/netnmstate.go
@@ -64,12 +64,7 @@ func CreatePolicyAndWaitUntilItsAvailable(timeout time.Duration, nmstatePolicy *
 
 	klog.V(90).Infof("Waiting for the policy to reach the Available state.")
 
-	err = nmstatePolicy.WaitUntilCondition(nmstateShared.NodeNetworkConfigurationPolicyConditionAvailable, timeout)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return nmstatePolicy.WaitUntilCondition(nmstateShared.NodeNetworkConfigurationPolicyConditionAvailable, timeout)
 }
 
 // UpdatePolicyAndWaitUntilItsAvailable updates NodeNetworkConfigurationPolicy and waits until
@@ -91,12 +86,7 @@ func UpdatePolicyAndWaitUntilItsAvailable(timeout time.Duration, nmstatePolicy *
 
 	klog.V(90).Infof("Waiting for the policy to reach the Available state.")
 
-	err = nmstatePolicy.WaitUntilCondition(nmstateShared.NodeNetworkConfigurationPolicyConditionAvailable, timeout)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return nmstatePolicy.WaitUntilCondition(nmstateShared.NodeNetworkConfigurationPolicyConditionAvailable, timeout)
 }
 
 // ConfigureVFsAndWaitUntilItsConfigured creates NodeNetworkConfigurationPolicy with VFs configuration and waits until
@@ -113,12 +103,7 @@ func ConfigureVFsAndWaitUntilItsConfigured(
 	nmstatePolicy := nmstate.NewPolicyBuilder(
 		APIClient, policyName, nodeLabel).WithInterfaceAndVFs(sriovInterfaceName, numberOfVFs)
 
-	err := CreatePolicyAndWaitUntilItsAvailable(timeout, nmstatePolicy)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return CreatePolicyAndWaitUntilItsAvailable(timeout, nmstatePolicy)
 }
 
 // AreVFsCreated verifies that the specified number of VFs has been created by NMState
@@ -538,4 +523,19 @@ func isNMStateDeployedAndReady(timeout time.Duration) error {
 	}
 
 	return nil
+}
+
+// CreatePolicyAndWaitUntilItsDegraded creates NodeNetworkConfigurationPolicy and waits until
+// it is in Degraded state.
+func CreatePolicyAndWaitUntilItsDegraded(timeout time.Duration, nmstatePolicy *nmstate.PolicyBuilder) error {
+	klog.V(90).Infof("Creating an NMState policy and wait for its Degraded state.")
+
+	nmstatePolicy, err := nmstatePolicy.Create()
+	if err != nil {
+		return err
+	}
+
+	klog.V(90).Infof("Waiting for the policy to reach the Degraded state.")
+
+	return nmstatePolicy.WaitUntilCondition(nmstateShared.NodeNetworkConfigurationPolicyConditionDegraded, timeout)
 }

--- a/tests/cnf/core/network/nmstate/internal/tsparams/consts.go
+++ b/tests/cnf/core/network/nmstate/internal/tsparams/consts.go
@@ -1,0 +1,10 @@
+package tsparams
+
+const (
+	// LabelSuite represents nmstate label that can be used for test cases selection.
+	LabelSuite = "nmstate"
+	// TestNamespaceName is the namespace where nmstate test cases are performed.
+	TestNamespaceName = "nmstate-tests"
+	// LabelAltnames represents nmstate altnames label that can be used for test cases selection.
+	LabelAltnames = "nmstate-altnames"
+)

--- a/tests/cnf/core/network/nmstate/internal/tsparams/nmstatevars.go
+++ b/tests/cnf/core/network/nmstate/internal/tsparams/nmstatevars.go
@@ -1,0 +1,39 @@
+package tsparams
+
+import (
+	"time"
+
+	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	sriovv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
+	nmstateV1 "github.com/nmstate/kubernetes-nmstate/api/v1"
+	nmstateV1beta1 "github.com/nmstate/kubernetes-nmstate/api/v1beta1"
+	"github.com/openshift-kni/k8sreporter"
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netinittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netparam"
+)
+
+var (
+	// Labels represents the range of labels that can be used for test cases selection.
+	Labels = append(netparam.Labels, LabelSuite)
+	// DefaultTimeout represents the default timeout for most of Eventually/PollImmediate functions.
+	DefaultTimeout = 300 * time.Second
+	// ReporterCRDsToDump tells to the reporter what CRs to dump.
+	ReporterCRDsToDump = []k8sreporter.CRData{
+		{Cr: &mcfgv1.MachineConfigPoolList{}},
+		{Cr: &nmstateV1.NMStateList{}},
+		{Cr: &nmstateV1.NodeNetworkConfigurationPolicyList{}},
+		{Cr: &nmstateV1beta1.NodeNetworkStateList{}},
+		{Cr: &nmstateV1beta1.NodeNetworkConfigurationEnactmentList{}},
+		{Cr: &nadv1.NetworkAttachmentDefinitionList{}, Namespace: &NetConfig.NMStateOperatorNamespace},
+		{Cr: &sriovv1.SriovNetworkNodePolicyList{}},
+		{Cr: &corev1.NodeList{}},
+	}
+	// ReporterNamespacesToDump tells to the reporter what namespaces to dump.
+	ReporterNamespacesToDump = map[string]string{
+		NetConfig.NMStateOperatorNamespace: NetConfig.NMStateOperatorNamespace,
+		TestNamespaceName:                  "other",
+	}
+)

--- a/tests/cnf/core/network/nmstate/nmstate_suite_test.go
+++ b/tests/cnf/core/network/nmstate/nmstate_suite_test.go
@@ -1,0 +1,89 @@
+package nmstate
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/deployment"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/namespace"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netinittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/nmstate/internal/tsparams"
+	_ "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/nmstate/tests"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/cluster"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/params"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/reporter"
+)
+
+var (
+	_, currentFile, _, _ = runtime.Caller(0)
+	testNS               = namespace.NewBuilder(APIClient, tsparams.TestNamespaceName)
+)
+
+func TestNMState(t *testing.T) {
+	_, reporterConfig := GinkgoConfiguration()
+	reporterConfig.JUnitReport = NetConfig.GetJunitReportPath(currentFile)
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "NMState", Label(tsparams.Labels...), reporterConfig)
+}
+
+var _ = BeforeSuite(func() {
+	By("Creating test namespace with privileged labels")
+
+	for key, value := range params.PrivilegedNSLabels {
+		testNS.WithLabel(key, value)
+	}
+
+	_, err := testNS.Create()
+	Expect(err).ToNot(HaveOccurred(), "error to create test namespace")
+
+	By("Verifying if nmstate tests can be executed on given cluster")
+
+	err = verifyNMStateOperatorDeployed()
+	Expect(err).ToNot(HaveOccurred(), "Cluster doesn't support nmstate test cases")
+
+	By("Pulling test images on cluster before running test cases")
+
+	err = cluster.PullTestImageOnNodes(APIClient, NetConfig.WorkerLabel, NetConfig.CnfNetTestContainer, 300)
+	Expect(err).ToNot(HaveOccurred(), "Failed to pull test image on nodes")
+})
+
+var _ = AfterSuite(func() {
+	By("Deleting test namespace")
+
+	err := testNS.DeleteAndWait(tsparams.DefaultTimeout)
+	Expect(err).ToNot(HaveOccurred(), "error to delete test namespace")
+})
+
+var _ = JustAfterEach(func() {
+	reporter.ReportIfFailed(
+		CurrentSpecReport(), currentFile, tsparams.ReporterNamespacesToDump, tsparams.ReporterCRDsToDump)
+})
+
+var _ = ReportAfterSuite("", func(report Report) {
+	reportxml.Create(report, NetConfig.GetReportPath(), NetConfig.TCPrefix)
+})
+
+func verifyNMStateOperatorDeployed() error {
+	nmstateNS := namespace.NewBuilder(APIClient, NetConfig.NMStateOperatorNamespace)
+	if !nmstateNS.Exists() {
+		return fmt.Errorf("NMState namespace %s doesn't exist", nmstateNS.Definition.Name)
+	}
+
+	nmstateOperatorDeployment, err := deployment.Pull(
+		APIClient, "nmstate-operator", NetConfig.NMStateOperatorNamespace)
+	if err != nil {
+		return fmt.Errorf("error to pull nmstate-operator deployment from the cluster: %w", err)
+	}
+
+	if !nmstateOperatorDeployment.IsReady(30 * time.Second) {
+		return fmt.Errorf("nmstate-operator deployment is not in ready state")
+	}
+
+	return nil
+}

--- a/tests/cnf/core/network/nmstate/tests/altnames.go
+++ b/tests/cnf/core/network/nmstate/tests/altnames.go
@@ -1,0 +1,516 @@
+package tests
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nad"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/namespace"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nmstate"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nodes"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/define"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netinittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netnmstate"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netparam"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/nmstate/internal/tsparams"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/cluster"
+	"gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/types"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+var _ = Describe("NMState Altnames:", Ordered, Label(tsparams.LabelAltnames), func() {
+	var (
+		workerNodes     []*nodes.Builder
+		sriovInterfaces []string
+		sriovIf0        string
+		sriovIf1        string
+		worker0LabelMap map[string]string
+	)
+
+	BeforeAll(func() {
+		By("Discover worker nodes")
+
+		var err error
+
+		workerNodes, err = nodes.List(APIClient,
+			metav1.ListOptions{LabelSelector: labels.Set(NetConfig.WorkerLabelMap).String()})
+		Expect(err).ToNot(HaveOccurred(), "Fail to discover nodes")
+		Expect(len(workerNodes)).To(BeNumerically(">=", 1), "Cluster must have at least 1 worker node")
+
+		worker0LabelMap = map[string]string{corev1.LabelHostname: workerNodes[0].Object.Name}
+
+		By("Collecting SR-IOV interfaces for altnames testing")
+
+		sriovInterfaces, err = NetConfig.GetSriovInterfaces(2)
+		Expect(err).ToNot(HaveOccurred(), "Failed to retrieve SR-IOV interfaces for testing")
+
+		sriovIf0 = sriovInterfaces[0]
+		sriovIf1 = sriovInterfaces[1]
+	})
+
+	AfterEach(func() {
+		By("Cleaning all NMState policies after each test")
+
+		err := nmstate.CleanAllNMStatePolicies(APIClient)
+		Expect(err).ToNot(HaveOccurred(), "Failed to remove all NMState policies")
+	})
+
+	Context("configure altnames", func() {
+		It("add and remove altnames without mac/pci identifiers", reportxml.ID("86293"), func() {
+			policyName := "nncp-86293-altnames"
+			removalPolicyName := "nncp-86293-remove-altnames"
+			primaryIfaceAltnames := []string{"t86293-iface0-alt-a", "t86293-iface0-alt-b"}
+			secondaryIfaceAltnames := []string{"t86293-iface1-alt-a", "t86293-iface1-alt-b"}
+
+			By("Creating NMState policy for altnames without identifiers")
+
+			nncp := nmstate.NewPolicyBuilder(APIClient, policyName, worker0LabelMap).
+				WithInterfaceAltnames(sriovIf0, primaryIfaceAltnames).
+				WithInterfaceAltnames(sriovIf1, secondaryIfaceAltnames)
+
+			err := netnmstate.CreatePolicyAndWaitUntilItsAvailable(netparam.DefaultTimeout, nncp)
+			Expect(err).ToNot(HaveOccurred(), "Failed to create NMState policy")
+
+			By("Verifying altnames without identifiers")
+
+			nnstates, err := getNodeNetworkStates(worker0LabelMap)
+			Expect(err).ToNot(HaveOccurred(), "Failed to get NodeNetwork states")
+
+			for _, nnstate := range nnstates {
+				validateAltnamesFromNodeNetworkState(nnstate, sriovIf0, primaryIfaceAltnames, false)(Default)
+				validateAltnamesFromNodeNetworkState(nnstate, sriovIf1, secondaryIfaceAltnames, false)(Default)
+			}
+
+			By("Delete Existing NNCP and Create a new one with altnames removed")
+
+			deletePriorPoliciesApplyRemovalPolicyAndVerify(
+				removalPolicyName,
+				worker0LabelMap,
+				[]*nmstate.PolicyBuilder{nncp},
+				[]string{sriovIf0, sriovIf1},
+				[][]string{primaryIfaceAltnames, secondaryIfaceAltnames},
+			)
+		})
+
+		It("add and remove altnames with identifiers mac-address and pci-address", reportxml.ID("86294"), func() {
+			policyName := "nncp-86294-altnames"
+			removalPolicyName := "nncp-86294-remove-altnames"
+			altnames1 := []string{"t86294-iface0-alt-a", "t86294-iface0-alt-b"}
+			altnames2 := []string{"t86294-iface1-alt-a", "t86294-iface1-alt-b"}
+
+			By("Getting MAC addresses and PCI addresses of SR-IOV interfaces")
+
+			if0MacAddress, _, err := getInterfaceIdentifiersOfNode(workerNodes[0].Object.Name, sriovIf0)
+			Expect(err).ToNot(HaveOccurred(), "Failed to get MAC and PCI addresses of SR-IOV interface")
+			_, if1PciAddress, err := getInterfaceIdentifiersOfNode(workerNodes[0].Object.Name, sriovIf1)
+			Expect(err).ToNot(HaveOccurred(), "Failed to get MAC and PCI addresses of SR-IOV interface")
+
+			nncp := nmstate.NewPolicyBuilder(APIClient, policyName, worker0LabelMap).
+				WithMACAddressAltnames("dummy0", if0MacAddress, altnames1).
+				WithPCIAddressAltnames("dummy1", if1PciAddress, altnames2)
+
+			err = netnmstate.CreatePolicyAndWaitUntilItsAvailable(netparam.DefaultTimeout, nncp)
+			Expect(err).ToNot(HaveOccurred(), "Failed to create NMState policy")
+
+			nnstate, err := nmstate.PullNodeNetworkState(APIClient, workerNodes[0].Object.Name)
+			Expect(err).ToNot(HaveOccurred(), "Failed to get NodeNetwork state")
+
+			validateAltnamesFromNodeNetworkState(nnstate, sriovIf0, altnames1, false)(Default)
+			validateAltnamesFromNodeNetworkState(nnstate, sriovIf1, altnames2, false)(Default)
+
+			By("Delete Existing NNCP and Create a new one with altnames removed")
+
+			deletePriorPoliciesApplyRemovalPolicyAndVerify(
+				removalPolicyName,
+				worker0LabelMap,
+				[]*nmstate.PolicyBuilder{nncp},
+				[]string{sriovIf0, sriovIf1},
+				[][]string{altnames1, altnames2},
+			)
+		})
+
+		It("delete altname of an interface that is manually configured", reportxml.ID("86299"), func() {
+			policyName := "nncp-86299-remove-altnames"
+			altnames1 := []string{"t86299-manual-alt-a"}
+
+			_, err := cluster.ExecCmdWithStdout(
+				APIClient,
+				fmt.Sprintf("ip link property add altname %s dev %s", altnames1[0], sriovIf0),
+				metav1.ListOptions{LabelSelector: labels.Set(worker0LabelMap).String()})
+			Expect(err).ToNot(HaveOccurred(),
+				"Failed to add altname to interface (see ip-link altname support for %s)", sriovIf0)
+
+			DeferCleanup(func() {
+				By("Removing manually-added altname from interface if still present")
+
+				// Best-effort: the altname may already have been removed by the NNCP policy.
+				_, _ = cluster.ExecCmdWithStdout(
+					APIClient,
+					fmt.Sprintf("ip link property del altname %s dev %s", altnames1[0], sriovIf0),
+					metav1.ListOptions{LabelSelector: labels.Set(worker0LabelMap).String()})
+			})
+
+			Eventually(validateAltnamesOnNode(
+				workerNodes[0].Object.Name, sriovIf0, altnames1, false)).
+				WithTimeout(netparam.DefaultTimeout).WithPolling(5 * time.Second).Should(Succeed())
+
+			nncp := nmstate.NewPolicyBuilder(APIClient, policyName, worker0LabelMap).
+				RemoveInterfaceAltname(sriovIf0, altnames1)
+
+			err = netnmstate.CreatePolicyAndWaitUntilItsAvailable(netparam.DefaultTimeout, nncp)
+			Expect(err).ToNot(HaveOccurred(), "Failed to update NMState policy")
+
+			Eventually(validateAltnamesOnNode(
+				workerNodes[0].Object.Name, sriovIf0, altnames1, true)).
+				WithTimeout(netparam.DefaultTimeout).WithPolling(5 * time.Second).Should(Succeed())
+
+			_, err = nncp.Delete()
+			Expect(err).ToNot(HaveOccurred(), "Failed to delete NMState policy")
+		})
+
+		It("remove physical interface that has altnames to verify altnames are removed", reportxml.ID("86298"), func() {
+			configurePolicyName := "nncp-86298-altnames"
+			absentPolicyName := "nncp-86298-absent"
+			restorePolicyName := "nncp-86298-restore"
+			altnames1 := []string{"t86298-iface0-alt-a", "t86298-iface0-alt-b"}
+
+			By("Creating NMState policy for altnames without identifiers")
+
+			nncp := nmstate.NewPolicyBuilder(APIClient, configurePolicyName, worker0LabelMap).
+				WithInterfaceAltnames(sriovIf0, altnames1)
+
+			err := netnmstate.CreatePolicyAndWaitUntilItsAvailable(netparam.DefaultTimeout, nncp)
+			Expect(err).ToNot(HaveOccurred(), "Failed to create NMState policy")
+
+			By("Verifying altnames without identifiers")
+
+			nnstates, err := getNodeNetworkStates(worker0LabelMap)
+			Expect(err).ToNot(HaveOccurred(), "Failed to get NodeNetwork states")
+
+			for _, nnstate := range nnstates {
+				validateAltnamesFromNodeNetworkState(nnstate, sriovIf0, altnames1, false)(Default)
+			}
+
+			By("Delete Existing NNCP and Create a new one with physical interface removed")
+
+			_, err = nncp.Delete()
+			Expect(err).ToNot(HaveOccurred(), "Failed to delete NMState policy")
+
+			nncp = nmstate.NewPolicyBuilder(APIClient, absentPolicyName, worker0LabelMap).
+				WithAbsentInterface(sriovIf0)
+
+			err = netnmstate.CreatePolicyAndWaitUntilItsAvailable(netparam.DefaultTimeout, nncp)
+			Expect(err).ToNot(HaveOccurred(), "Failed to create NMState policy")
+
+			By("Verifying physical interface removed")
+
+			nnstates, err = getNodeNetworkStates(worker0LabelMap)
+			Expect(err).ToNot(HaveOccurred(), "Failed to get NodeNetwork states")
+
+			for _, nnstate := range nnstates {
+				validateAltnamesFromNodeNetworkState(nnstate, sriovIf0, altnames1, true)(Default)
+			}
+
+			By("Restoring the physical interface to up state")
+
+			_, err = nncp.Delete()
+			Expect(err).ToNot(HaveOccurred(), "Failed to delete absent NMState policy")
+
+			nncp = nmstate.NewPolicyBuilder(APIClient, restorePolicyName, worker0LabelMap).
+				WithInterfaceUp(sriovIf0)
+
+			err = netnmstate.CreatePolicyAndWaitUntilItsAvailable(netparam.DefaultTimeout, nncp)
+			Expect(err).ToNot(HaveOccurred(), "Failed to create NMState policy to restore interface")
+		})
+	})
+
+	Context("negative tests", func() {
+		It("NNCP should be Degraded when duplicate altnames are added", reportxml.ID("86296"), func() {
+			degradedPolicyName := "nncp-86296-altnames"
+			removalPolicyName := "nncp-86296-remove-altnames"
+			altnames1 := []string{"t86296-dup-alt-a", "t86296-dup-alt-a"}
+			altnames2 := []string{"t86296-dup-alt-a"}
+
+			By("Creating NMState policy with duplicate altnames to trigger Degraded state")
+
+			nncp := nmstate.NewPolicyBuilder(APIClient, degradedPolicyName, worker0LabelMap).
+				WithInterfaceAltnames(sriovIf0, altnames1)
+
+			err := netnmstate.CreatePolicyAndWaitUntilItsDegraded(netparam.DefaultTimeout, nncp)
+			Expect(err).ToNot(HaveOccurred(), "Failed to create NMState policy")
+
+			By("Deleting the NMState policy")
+
+			_, err = nncp.Delete()
+			Expect(err).ToNot(HaveOccurred(), "Failed to delete NMState policy")
+
+			deletePriorPoliciesApplyRemovalPolicyAndVerify(
+				removalPolicyName,
+				worker0LabelMap,
+				nil,
+				[]string{sriovIf0},
+				[][]string{altnames2},
+			)
+		})
+
+		It("NNCP should be Degraded when using non-existent mac-address or pci-address", reportxml.ID("86295"), func() {
+			policyName := "nncp-86295-altnames"
+			altnames1 := []string{"t86295-invalid-id-alt-a", "t86295-invalid-id-alt-b"}
+
+			By("Creating NMState policy with non-existent MAC and PCI identifiers to trigger Degraded state")
+
+			nncp := nmstate.NewPolicyBuilder(APIClient, policyName, worker0LabelMap).
+				WithMACAddressAltnames("dummy-mac-address", "00:00:00:00:00:00", altnames1).
+				WithPCIAddressAltnames("dummy-pci-address", "0000:00:00.0", altnames1)
+
+			err := netnmstate.CreatePolicyAndWaitUntilItsDegraded(netparam.DefaultTimeout, nncp)
+			Expect(err).ToNot(HaveOccurred(), "Failed to create NMState policy")
+
+			By("Deleting the NMState policy")
+
+			_, err = nncp.Delete()
+			Expect(err).ToNot(HaveOccurred(), "Failed to delete NMState policy")
+		})
+	})
+
+	Context("refer interface with altname", func() {
+		It("add and remove altnames for interface using its altname", reportxml.ID("88006"), func() {
+			policyName1 := "nncp-88006-altnames"
+			policyName2 := "nncp-88006-altnames-ref"
+			removalPolicyName := "nncp-88006-remove-altnames"
+			altnames1 := []string{"t88006-base-alt-a"}
+			altnames2 := []string{"t88006-ref-alt-b"}
+			combinedAltnames := []string{"t88006-base-alt-a", "t88006-ref-alt-b"}
+
+			By("Creating NMState policy for altnames without identifiers")
+
+			nncp1 := nmstate.NewPolicyBuilder(APIClient, policyName1, worker0LabelMap).
+				WithInterfaceAltnames(sriovIf0, altnames1)
+
+			err := netnmstate.CreatePolicyAndWaitUntilItsAvailable(netparam.DefaultTimeout, nncp1)
+			Expect(err).ToNot(HaveOccurred(), "Failed to create NMState policy")
+
+			By("Verifying the altname is added")
+
+			nnstates, err := getNodeNetworkStates(worker0LabelMap)
+			Expect(err).ToNot(HaveOccurred(), "Failed to get NodeNetwork states")
+
+			for _, nnstate := range nnstates {
+				validateAltnamesFromNodeNetworkState(nnstate, sriovIf0, altnames1, false)(Default)
+			}
+
+			nncp2 := nmstate.NewPolicyBuilder(APIClient, policyName2, worker0LabelMap).
+				WithInterfaceAltnames(altnames1[0], altnames2)
+
+			err = netnmstate.CreatePolicyAndWaitUntilItsAvailable(netparam.DefaultTimeout, nncp2)
+			Expect(err).ToNot(HaveOccurred(), "Failed to create NMState policy")
+
+			By("Verifying the altname is added")
+
+			nnstates, err = getNodeNetworkStates(worker0LabelMap)
+			Expect(err).ToNot(HaveOccurred(), "Failed to get NodeNetwork states")
+
+			for _, nnstate := range nnstates {
+				validateAltnamesFromNodeNetworkState(nnstate, sriovIf0, combinedAltnames, false)(Default)
+			}
+
+			By("Deleting the NMState policy")
+			deletePriorPoliciesApplyRemovalPolicyAndVerify(
+				removalPolicyName,
+				worker0LabelMap,
+				[]*nmstate.PolicyBuilder{nncp1, nncp2},
+				[]string{sriovIf0},
+				[][]string{combinedAltnames},
+			)
+		})
+
+		It("use altname for network-attachment-definition of type host-device", reportxml.ID("88008"), func() {
+			policyName := "nncp-88008-altnames"
+			removalPolicyName := "nncp-88008-remove-altnames"
+			altnames1 := []string{"t88008-hostdev-alt-a"}
+
+			By("Creating NMState policy to create altnames for interface")
+
+			nncp := nmstate.NewPolicyBuilder(APIClient, policyName, worker0LabelMap).
+				WithInterfaceAltnames(sriovIf0, altnames1)
+
+			err := netnmstate.CreatePolicyAndWaitUntilItsAvailable(netparam.DefaultTimeout, nncp)
+			Expect(err).ToNot(HaveOccurred(), "Failed to create NMState policy")
+
+			By("Verifying the altname is added")
+
+			nnstates, err := getNodeNetworkStates(worker0LabelMap)
+			Expect(err).ToNot(HaveOccurred(), "Failed to get NodeNetwork states")
+
+			for _, nnstate := range nnstates {
+				validateAltnamesFromNodeNetworkState(nnstate, sriovIf0, altnames1, false)(Default)
+			}
+
+			By("Creating NetworkAttachmentDefinition of type host-device with altname as interface name")
+
+			_, err = define.HostDeviceNad(
+				APIClient,
+				"host-device-with-altname",
+				altnames1[0],
+				tsparams.TestNamespaceName,
+			)
+			Expect(err).ToNot(HaveOccurred(), "Failed to create a network-attachment-definition")
+
+			By("creating pod with network-attachment-definition of type host-device with altname as interface name")
+
+			testPod, err := pod.NewBuilder(APIClient, "testpod", tsparams.TestNamespaceName, NetConfig.CnfNetTestContainer).
+				DefineOnNode(workerNodes[0].Object.Name).
+				WithSecondaryNetwork([]*types.NetworkSelectionElement{
+					{
+						Name: "host-device-with-altname",
+					},
+				}).
+				CreateAndWaitUntilRunning(netparam.DefaultTimeout)
+			Expect(err).ToNot(HaveOccurred(), "Failed to create pod")
+
+			By("verifying the pod's secondary interface is available")
+
+			_, err = testPod.ExecCommand([]string{"ip", "addr", "show", "net1"})
+			Expect(err).ToNot(HaveOccurred(), "Failed to execute ip addr show command")
+
+			By("clean test resources")
+
+			testNs, err := namespace.Pull(APIClient, tsparams.TestNamespaceName)
+			Expect(err).ToNot(HaveOccurred(), "Failed to pull namespace")
+			err = testNs.CleanObjects(netparam.DefaultTimeout, nad.GetGVR(), pod.GetGVR())
+			Expect(err).ToNot(HaveOccurred(), "Failed to clean test resources")
+
+			By("Deleting the NMState policy")
+			deletePriorPoliciesApplyRemovalPolicyAndVerify(
+				removalPolicyName,
+				worker0LabelMap,
+				[]*nmstate.PolicyBuilder{nncp},
+				[]string{sriovIf0},
+				[][]string{altnames1},
+			)
+		})
+	})
+})
+
+func getNodeNetworkStates(label map[string]string) ([]*nmstate.StateBuilder, error) {
+	nodesList, err := nodes.List(APIClient, metav1.ListOptions{LabelSelector: labels.Set(label).String()})
+	if err != nil {
+		return nil, err
+	}
+
+	var nnstates []*nmstate.StateBuilder
+
+	for _, node := range nodesList {
+		nnstate, err := nmstate.PullNodeNetworkState(APIClient, node.Object.Name)
+		if err != nil {
+			return nil, err
+		}
+
+		nnstates = append(nnstates, nnstate)
+	}
+
+	return nnstates, nil
+}
+
+// validateAltnamesOnNode returns a Gomega assertion function that pulls fresh NodeNetworkState on each poll,
+// for use with Eventually(...).Should(Succeed()).
+func validateAltnamesOnNode(nodeName, interfaceName string, altnames []string, absent bool) func(Gomega) {
+	return func(g Gomega) {
+		nnstate, err := nmstate.PullNodeNetworkState(APIClient, nodeName)
+		g.Expect(err).ToNot(HaveOccurred(), "Failed to get NodeNetwork state for node %q", nodeName)
+		validateAltnamesFromNodeNetworkState(nnstate, interfaceName, altnames, absent)(g)
+	}
+}
+
+// validateAltnamesFromNodeNetworkState returns a Gomega assertion function for use with
+// Eventually(fn).Should(Succeed())
+// or a single synchronous check via validate...(Default).
+func validateAltnamesFromNodeNetworkState(
+	nnstate *nmstate.StateBuilder, interfaceName string, altnames []string, absent bool) func(Gomega) {
+	return func(gomega Gomega) {
+		altnamesFromNodeNetworkState, err := nnstate.GetInterfaceAltnames(interfaceName)
+		gomega.Expect(err).ToNot(HaveOccurred(),
+			"get interface altnames for %q on NodeNetworkState %q", interfaceName, nnstate.Object.Name)
+
+		if absent {
+			gomega.Expect(altnamesFromNodeNetworkState).Should(Not(ContainElements(altnames)),
+				"interface %q on NodeNetworkState %q should not list altnames %v; actual altnames: %v",
+				interfaceName, nnstate.Object.Name, altnames, altnamesFromNodeNetworkState)
+		} else {
+			gomega.Expect(altnamesFromNodeNetworkState).To(ContainElements(altnames),
+				"interface %q on NodeNetworkState %q should list altnames %v; actual altnames: %v",
+				interfaceName, nnstate.Object.Name, altnames, altnamesFromNodeNetworkState)
+		}
+	}
+}
+
+func getInterfaceIdentifiersOfNode(name string, interfaceName string) (string, string, error) {
+	nnstate, err := nmstate.PullNodeNetworkState(APIClient, name)
+	if err != nil {
+		return "", "", err
+	}
+
+	macAddress, err := nnstate.GetInterfaceMACAddress(interfaceName)
+	if err != nil {
+		return "", "", err
+	}
+
+	pciAddress, err := nnstate.GetInterfacePCIAddress(interfaceName)
+	if err != nil {
+		return "", "", err
+	}
+
+	return macAddress, pciAddress, nil
+}
+
+// deletePriorPoliciesApplyRemovalPolicyAndVerify deletes any prior NMState policies, creates removalPolicyName with
+// RemoveInterfaceAltname calls derived from interfaceNames/altnames, waits until available, verifies each pair
+// shows altnames absent, then deletes the removal policy. Callers should issue any desired By() (e.g. before
+// deletes) before invoking this helper.
+func deletePriorPoliciesApplyRemovalPolicyAndVerify(
+	removalPolicyName string,
+	nodeLabel map[string]string,
+	priorPolicies []*nmstate.PolicyBuilder,
+	interfaceNames []string,
+	altnames [][]string,
+) {
+	Expect(len(interfaceNames)).To(Equal(len(altnames)),
+		"interfaceNames and altnames should have the same number of entries")
+
+	for _, p := range priorPolicies {
+		_, err := p.Delete()
+		Expect(err).ToNot(HaveOccurred(), "Failed to delete NMState policy")
+	}
+
+	By("Removing the altname")
+
+	nncp := nmstate.NewPolicyBuilder(APIClient, removalPolicyName, nodeLabel)
+	for i, iface := range interfaceNames {
+		nncp = nncp.RemoveInterfaceAltname(iface, altnames[i])
+	}
+
+	err := netnmstate.CreatePolicyAndWaitUntilItsAvailable(netparam.DefaultTimeout, nncp)
+	Expect(err).ToNot(HaveOccurred(), "Failed to create NMState policy")
+
+	By("Verifying altnames removed")
+
+	nnstates, err := getNodeNetworkStates(nodeLabel)
+	Expect(err).ToNot(HaveOccurred(), "Failed to get NodeNetwork states")
+
+	for _, nnstate := range nnstates {
+		for i, iface := range interfaceNames {
+			validateAltnamesFromNodeNetworkState(nnstate, iface, altnames[i], true)(Default)
+		}
+	}
+
+	By("Deleting the NMState policy")
+
+	_, err = nncp.Delete()
+	Expect(err).ToNot(HaveOccurred(), "Failed to delete NMState policy")
+}


### PR DESCRIPTION
## nmstate: add altnames test suite

### Summary

- Add a new NMState test suite that validates interface alternative names (altnames) lifecycle management via `NodeNetworkConfigurationPolicy` (NNCP)
- Add `CreatePolicyAndWaitUntilItsDegraded` helper to `netnmstate` for negative test scenarios, and simplify existing helpers by removing redundant error-return patterns

### Test coverage

**Configure altnames:**
- Add/remove altnames without identifiers (ID 86293)
- Add/remove altnames with MAC-address and PCI-address identifiers (ID 86294)
- Remove a manually-configured altname via NNCP (ID 86299)
- Remove a physical interface that has altnames and verify cleanup (ID 86298)

**Negative tests:**
- NNCP enters Degraded state on duplicate altnames (ID 86296)
- NNCP enters Degraded state with non-existent MAC/PCI identifiers (ID 86295)

**Refer interface with altname:**
- Add altnames to an interface referenced by its existing altname (ID 88006)
- Use an altname in a host-device NetworkAttachmentDefinition and verify pod connectivity (ID 88008)
