### PR TITLE
cnf-network: add IPv6 single-stack support for MetalLB and security tests

### DIFF
--- a/tests/cnf/core/network/metallb/internal/tsparams/consts.go
+++ b/tests/cnf/core/network/metallb/internal/tsparams/consts.go
@@ -87,6 +87,9 @@ bfd
 	ETPLocal = "Local"
 	// ETPCluster represents externalTrafficPolicy Cluster.
 	ETPCluster = "Cluster"
+	// DefaultBGPRouterID represents the default BGP router-id used on IPv6-only clusters
+	// where FRR cannot auto-derive a router-id from a non-existent IPv4 address.
+	DefaultBGPRouterID = "10.10.10.10"
 	// MetalLBIPv6 represents IPv6 label that can be used for test cases selection.
 	MetalLBIPv6 = "metallbipv6"
 	// MetalLBDual represents dual label that can be used for test cases selection.

--- a/tests/cnf/core/network/metallb/tests/bfd-test.go
+++ b/tests/cnf/core/network/metallb/tests/bfd-test.go
@@ -45,6 +45,7 @@ var _ = Describe("BFD", Ordered, Label(tsparams.LabelBFDTestCases), ContinueOnFa
 
 	BeforeAll(func() {
 		validateEnvVarAndGetNodeList()
+		validateIPFamilySupport(netparam.IPV4Family)
 
 		By("Creating a new instance of MetalLB Speakers on workers")
 

--- a/tests/cnf/core/network/metallb/tests/bgp-connect-time-tests.go
+++ b/tests/cnf/core/network/metallb/tests/bgp-connect-time-tests.go
@@ -29,6 +29,7 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelBGPTestCases), ContinueOnFa
 
 	BeforeAll(func() {
 		validateEnvVarAndGetNodeList()
+		validateIPFamilySupport(netparam.IPV4Family)
 	})
 
 	BeforeEach(func() {

--- a/tests/cnf/core/network/metallb/tests/bgp-multiservice.go
+++ b/tests/cnf/core/network/metallb/tests/bgp-multiservice.go
@@ -38,6 +38,7 @@ var _ = Describe("MetalLB BGP", Ordered, Label(tsparams.LabelBGPTestCases), Cont
 		}
 
 		validateEnvVarAndGetNodeList()
+		validateIPFamilySupport(netparam.IPV4Family)
 
 		By("Creating a new instance of MetalLB Speakers on workers")
 

--- a/tests/cnf/core/network/metallb/tests/bgp-remote-as-dynamic.go
+++ b/tests/cnf/core/network/metallb/tests/bgp-remote-as-dynamic.go
@@ -38,6 +38,7 @@ var _ = Describe("BGP remote-dynamicAS", Ordered, Label(tsparams.LabelDynamicRem
 			}
 
 			validateEnvVarAndGetNodeList()
+			validateIPFamilySupport(netparam.IPV4Family)
 		})
 
 		AfterAll(func() {

--- a/tests/cnf/core/network/metallb/tests/bgp-tests.go
+++ b/tests/cnf/core/network/metallb/tests/bgp-tests.go
@@ -70,37 +70,42 @@ var _ = Describe("BGP", Ordered, Label(tsparams.LabelBGPTestCases), ContinueOnFa
 
 	It("Session State: Verify the BGP peering status between worker nodes and their two expected BGP neighbors",
 		reportxml.ID("85987"), func() {
+			ipStack := preferredIPFamily()
+			prefixLen := defaultAggLen[ipStack]
+
 			if len(workerNodeList) < 2 {
 				Skip("Skipping test as there are less than 2 worker nodes")
 			}
 
 			By("Setting up test environment")
 
-			_, extFrrPod, _ := setupTestEnv(ipv4, 32, false)
+			_, extFrrPod, _ := setupTestEnv(ipStack, prefixLen, false)
+
+			peerAddrs := removePrefixFromIPList(nodeAddrList[ipStack])
+			Expect(len(peerAddrs)).To(BeNumerically(">=", 2),
+				"Expected at least 2 peer addresses for selected IP family")
 
 			By("Shutdown the BGP session on the external FRR pod for the second worker node")
 
-			workerNode1Address := workerNodeList[1].Object.Status.Addresses[0].Address
-			err := frr.ShutdownBGPNeighbor(extFrrPod, workerNode1Address, tsparams.LocalBGPASN)
+			err := frr.ShutdownBGPNeighbor(extFrrPod, peerAddrs[1], tsparams.LocalBGPASN)
 			Expect(err).ToNot(HaveOccurred(), "Failed to shutdown BGP connection")
 
 			By("Verify the BGP session is down on the second worker node")
-			verifyMetalLbBGPSessionsAreDownOnFrrPod(extFrrPod, []string{workerNodeList[1].Object.Status.Addresses[0].Address})
-			validateBGPSessionState("Active", "N/A", metallbAddrList[ipv4][0], []*nodes.Builder{workerNodeList[1]})
+			verifyMetalLbBGPSessionsAreDownOnFrrPod(extFrrPod, []string{nodeAddrList[ipStack][1]})
+			validateBGPSessionState("Active", "N/A", metallbAddrList[ipStack][0], []*nodes.Builder{workerNodeList[1]})
 
 			By("Verify the BGP session is up on the first worker node")
-			verifyMetalLbBGPSessionsAreUPOnFrrPod(extFrrPod, []string{workerNodeList[0].Object.Status.Addresses[0].Address})
-			validateBGPSessionState("Established", "N/A", metallbAddrList[ipv4][0], []*nodes.Builder{workerNodeList[0]})
+			verifyMetalLbBGPSessionsAreUPOnFrrPod(extFrrPod, []string{nodeAddrList[ipStack][0]})
+			validateBGPSessionState("Established", "N/A", metallbAddrList[ipStack][0], []*nodes.Builder{workerNodeList[0]})
 
 			By("Restart the BGP session on the second worker node")
 
-			err = frr.NoShutdownBGPNeighbor(
-				extFrrPod, workerNodeList[1].Object.Status.Addresses[0].Address, tsparams.LocalBGPASN)
+			err = frr.NoShutdownBGPNeighbor(extFrrPod, peerAddrs[1], tsparams.LocalBGPASN)
 			Expect(err).ToNot(HaveOccurred(), "Failed to restart BGP connection")
 
 			By("Verify the BGP session is up on the second worker node")
-			verifyMetalLbBGPSessionsAreUPOnFrrPod(extFrrPod, []string{workerNodeList[1].Object.Status.Addresses[0].Address})
-			validateBGPSessionState("Established", "N/A", metallbAddrList[ipv4][0], workerNodeList)
+			verifyMetalLbBGPSessionsAreUPOnFrrPod(extFrrPod, []string{nodeAddrList[ipStack][1]})
+			validateBGPSessionState("Established", "N/A", metallbAddrList[ipStack][0], workerNodeList)
 
 			By("Remove BGP peer and verify there are no BGP sessions")
 
@@ -112,7 +117,7 @@ var _ = Describe("BGP", Ordered, Label(tsparams.LabelBGPTestCases), ContinueOnFa
 			for _, workerNode := range workerNodeList {
 				Eventually(func() error {
 					_, err := metallb.PullBGPSessionStateByNodeAndPeer(
-						APIClient, workerNode.Definition.Name, metallbAddrList[ipv4][0])
+						APIClient, workerNode.Definition.Name, metallbAddrList[ipStack][0])
 
 					return err
 				}, 60*time.Second, tsparams.DefaultRetryInterval).Should(HaveOccurred(), "BGP session should not exist")
@@ -146,7 +151,8 @@ var _ = Describe("BGP", Ordered, Label(tsparams.LabelBGPTestCases), ContinueOnFa
 		)
 
 		It("provides Prometheus BGP metrics", reportxml.ID("47202"), func() {
-			frrk8sPods, _, _ := setupTestEnv(ipv4, 32, false)
+			ipStack := preferredIPFamily()
+			frrk8sPods, _, _ := setupTestEnv(ipStack, defaultAggLen[ipStack], false)
 
 			By("Label namespace")
 
@@ -331,6 +337,8 @@ var _ = Describe("BGP", Ordered, Label(tsparams.LabelBGPTestCases), ContinueOnFa
 		)
 
 		It("BGP Timer update", reportxml.ID("47180"), func() {
+			validateIPFamilySupport(netparam.IPV4Family)
+
 			frrk8sPods, extFrrPod, _ := setupTestEnv(ipv4, 32, false)
 
 			By("Verify BGP Timers of neighbors in external FRR Pod")

--- a/tests/cnf/core/network/metallb/tests/bgp-unnumbered.go
+++ b/tests/cnf/core/network/metallb/tests/bgp-unnumbered.go
@@ -47,6 +47,7 @@ var _ = Describe("BGP Unnumbered", Ordered, Label(tsparams.LabelBGPUnnumbered),
 			}
 
 			validateEnvVarAndGetNodeList()
+			validateIPFamilySupport(netparam.IPV4Family)
 
 			By("Creating a new instance of MetalLB Speakers on workers")
 

--- a/tests/cnf/core/network/metallb/tests/common.go
+++ b/tests/cnf/core/network/metallb/tests/common.go
@@ -82,6 +82,34 @@ func clusterSupportsIPv4() bool {
 	return clusterIPVersion == netparam.IPV4Family || clusterIPVersion == netparam.DualIPFamily
 }
 
+func preferredIPFamily() string {
+	if clusterSupportsIPv4() {
+		return ipv4
+	}
+
+	return ipv6
+}
+
+// validateIPFamilySupport checks if the cluster supports the requested IP family and skips the test if not.
+func validateIPFamilySupport(ipStack string) {
+	switch ipStack {
+	case netparam.DualIPFamily:
+		if !clusterSupportsIPv4() || !clusterSupportsIPv6() {
+			Skip(fmt.Sprintf("Cluster does not support dual-stack (IPv4 + IPv6) - required for %s tests", ipStack))
+		}
+	case netparam.IPV6Family:
+		if !clusterSupportsIPv6() {
+			Skip(fmt.Sprintf("Cluster does not support IPv6 - required for %s tests", ipStack))
+		}
+	case netparam.IPV4Family:
+		if !clusterSupportsIPv4() {
+			Skip(fmt.Sprintf("Cluster does not support IPv4 - required for %s tests", ipStack))
+		}
+	default:
+		Skip(fmt.Sprintf("Unknown IP stack type: %s", ipStack))
+	}
+}
+
 // Initializes and validates Vars:
 // ipv4metalLbIPList, ipv6metalLbIPList,
 // ipv4NodeAddrList, ipv6NodeAddrList,
@@ -257,6 +285,10 @@ func createBGPPeerAndVerifyIfItsReady(
 
 	if len(disableMP) > 0 && disableMP[0] {
 		bgpPeer.WithDisableMP(true)
+	}
+
+	if !clusterSupportsIPv4() {
+		bgpPeer.WithRouterID(tsparams.DefaultBGPRouterID)
 	}
 
 	_, err := bgpPeer.Create()

--- a/tests/cnf/core/network/metallb/tests/frrk8-tests.go
+++ b/tests/cnf/core/network/metallb/tests/frrk8-tests.go
@@ -82,6 +82,8 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelFRRTestCases), ContinueOnFa
 		)
 
 		BeforeAll(func() {
+			validateIPFamilySupport(netparam.IPV4Family)
+
 			By("Setting test iteration parameters")
 
 			_, _, _, nodeAddrList, addressPool, _, err =
@@ -326,6 +328,8 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelFRRTestCases), ContinueOnFa
 		)
 
 		BeforeEach(func() {
+			validateIPFamilySupport(netparam.IPV4Family)
+
 			By("Cleaning up any existing NMState policies from previous test runs")
 
 			err := nmstate.CleanAllNMStatePolicies(APIClient)
@@ -721,6 +725,8 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelFRRTestCases), ContinueOnFa
 		)
 
 		BeforeAll(func() {
+			validateIPFamilySupport(netparam.IPV4Family)
+
 			By("Enabling OVN-K RouteAdvertisements on the cluster")
 			enableOVNKRouteAdvertisements()
 

--- a/tests/cnf/core/network/metallb/tests/ip-forwarding.go
+++ b/tests/cnf/core/network/metallb/tests/ip-forwarding.go
@@ -182,6 +182,7 @@ var _ = Describe("IP Forwarding per Interface", Ordered,
 			var nncpPolicy *nmstate.PolicyBuilder
 
 			BeforeAll(func() {
+				validateIPFamilySupport(netparam.IPV4Family)
 				By("Creating NMState policy with VLAN interfaces on the second worker node")
 
 				nncpPolicy = nmstate.NewPolicyBuilder(APIClient, ipFwdNNCPName,

--- a/tests/cnf/core/network/metallb/tests/layer2-test.go
+++ b/tests/cnf/core/network/metallb/tests/layer2-test.go
@@ -43,6 +43,7 @@ var _ = Describe("Layer2", Ordered, Label(tsparams.LabelLayer2TestCases), Contin
 		}
 
 		validateEnvVarAndGetNodeList()
+		validateIPFamilySupport(netparam.IPV4Family)
 
 		By("Creating a new instance of MetalLB Speakers on workers")
 

--- a/tests/cnf/core/network/metallb/tests/metallb-crds.go
+++ b/tests/cnf/core/network/metallb/tests/metallb-crds.go
@@ -48,6 +48,7 @@ var _ = Describe("MetalLb New CRDs", Ordered, Label("newcrds"), ContinueOnFailur
 		}
 
 		validateEnvVarAndGetNodeList()
+		validateIPFamilySupport(netparam.IPV4Family)
 
 		firstMasterNode := masterNodeList[0]
 

--- a/tests/cnf/core/network/metallb/tests/metallb-nodeSelector.go
+++ b/tests/cnf/core/network/metallb/tests/metallb-nodeSelector.go
@@ -50,6 +50,7 @@ var _ = Describe("MetalLB NodeSelector", Ordered, Label(tsparams.LabelBGPTestCas
 		}
 
 		validateEnvVarAndGetNodeList()
+		validateIPFamilySupport(netparam.IPV4Family)
 
 		By("Collecting information before test")
 

--- a/tests/cnf/core/network/metallb/tests/pool-selector.go
+++ b/tests/cnf/core/network/metallb/tests/pool-selector.go
@@ -290,26 +290,6 @@ var _ = Describe("BGP", Ordered, Label("pool-selector"), ContinueOnFailure, func
 	})
 })
 
-// validateIPFamilySupport checks if the cluster supports the requested IP family and skips the test if not.
-func validateIPFamilySupport(ipStack string) {
-	switch ipStack {
-	case netparam.DualIPFamily:
-		if !clusterSupportsIPv4() || !clusterSupportsIPv6() {
-			Skip(fmt.Sprintf("Cluster does not support dual-stack (IPv4 + IPv6) - required for %s tests", ipStack))
-		}
-	case netparam.IPV6Family:
-		if !clusterSupportsIPv6() {
-			Skip(fmt.Sprintf("Cluster does not support IPv6 - required for %s tests", ipStack))
-		}
-	case netparam.IPV4Family:
-		if !clusterSupportsIPv4() {
-			Skip(fmt.Sprintf("Cluster does not support IPv4 - required for %s tests", ipStack))
-		}
-	default:
-		Skip(fmt.Sprintf("Unknown IP stack type: %s", ipStack))
-	}
-}
-
 func activateSCTPModuleOnMasterNodes() {
 	_, err := cluster.ExecCmdWithStdout(APIClient, "modprobe sctp",
 		metav1.ListOptions{LabelSelector: labels.Set(NetConfig.ControlPlaneLabelMap).String()})

--- a/tests/cnf/core/network/metallb/tests/system-metallb.go
+++ b/tests/cnf/core/network/metallb/tests/system-metallb.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/service"
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netinittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netparam"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/metallb/internal/metallbenv"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/metallb/internal/tsparams"
 )
@@ -24,6 +25,7 @@ var _ = Describe("BGP", Ordered, Label("pool-selector"), ContinueOnFailure, func
 		}
 
 		validateEnvVarAndGetNodeList()
+		validateIPFamilySupport(netparam.IPV4Family)
 
 		By("Creating a new instance of MetalLB Speakers on workers")
 

--- a/tests/cnf/core/network/security/tests/nftables-custom-firewall-test.go
+++ b/tests/cnf/core/network/security/tests/nftables-custom-firewall-test.go
@@ -66,6 +66,15 @@ var _ = Describe("nftables", Ordered, Label(tsparams.LabelNftablesTestCases), Co
 			Skip("Skipping test on SNO (Single Node OpenShift) cluster - requires 2+ workers")
 		}
 
+		By("Checking if cluster supports IPv4")
+
+		clusterIPFamily, err := netenv.GetClusterIPFamily(APIClient)
+		Expect(err).ToNot(HaveOccurred(), "Failed to get cluster IP family")
+
+		if clusterIPFamily == netparam.IPV6Family {
+			Skip("Skipping nftables test on IPv6-only cluster - test requires IPv4")
+		}
+
 		By("List CNF worker nodes in cluster")
 
 		cnfWorkerNodeList, err = nodes.List(APIClient,


### PR DESCRIPTION
Add skip guards for IPv4-only tests on IPv6-only clusters using the existing validateIPFamilySupport() pattern. Set explicit BGP router-id via the BGPPeer CR on IPv6-only clusters to work around FRR defaulting to 0.0.0.0 (invalid per RFC 4271/6286). Convert BGP Session State and Prometheus metrics tests to run on any IP family.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added IPv4 support checks across MetalLB and network security suites and improved IP-family handling to skip or adapt tests when clusters lack required IP capabilities.
  * Introduced dynamic IP-family selection in several BGP/Prometheus tests for better dual-stack coverage and stability.

* **Chores**
  * Consolidated and reused IP-family validation helpers across tests; reduced duplicate helpers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/eco-gotests/pull/1394?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->