### PR TITLE
fix(kmm): register v1beta1 scheme in filesToSign webhook test

### DIFF
--- a/tests/hw-accel/kmm/modules/tests/webhook-test.go
+++ b/tests/hw-accel/kmm/modules/tests/webhook-test.go
@@ -383,6 +383,9 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSani
 			It("should reject Module when sign is set but filesToSign is empty", reportxml.ID("88318"), func() {
 				By("Preparing Module with Sign but no filesToSign")
 
+				err := APIClient.AttachScheme(v1beta1.AddToScheme)
+				Expect(err).ToNot(HaveOccurred(), "error attaching v1beta1 scheme")
+
 				image := fmt.Sprintf("%s/%s/%s:$KERNEL_FULL_VERSION",
 					tsparams.LocalImageRegistry, kmmparams.WebhookModuleTestNamespace, "sign-no-files")
 
@@ -412,7 +415,7 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSani
 
 				By("Create Module")
 
-				err := APIClient.Create(context.TODO(), module)
+				err = APIClient.Create(context.TODO(), module)
 				Expect(err).To(HaveOccurred(), "module should be rejected by webhook")
 				klog.V(kmmparams.KmmLogLevel).Infof("err is: %s", err)
 				Expect(err.Error()).To(ContainSubstring("filesToSign"))


### PR DESCRIPTION
## Summary
- The `should reject Module when sign is set but filesToSign is empty` webhook test creates a `v1beta1.Module` directly (bypassing `NewModuleBuilder`) because `WithSign()` rejects empty `filesToSign` at the builder level — but that empty-filesToSign scenario is exactly what the webhook should validate.
- `APIClient.Create()` fails with `no kind is registered for the type v1beta1.Module` because the scheme is only registered lazily by `NewModuleBuilder` via `AttachScheme`.
- Fix: call `APIClient.AttachScheme(v1beta1.AddToScheme)` before the direct create.

## Test plan
- [ ] CI run with `secureboot` label filter passes step #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test reliability for module creation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/eco-gotests/pull/1397?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->