### PR TITLE
cnf:network add lacp env var nativevlan

### DIFF
--- a/tests/cnf/core/network/README.md
+++ b/tests/cnf/core/network/README.md
@@ -72,6 +72,7 @@ All network environmental variables can be found 'tests/cnf/core/network/interna
 # export ECO_TEST_VERBOSE='true'
 # export ECO_VERBOSE_LEVEL=100
 # export ECO_CNF_CORE_NET_VLAN=VLAN_ID
+# export ECO_CNF_CORE_NET_NATIVE_VLAN=92   # numeric native (untagged) VLAN on lab switch trunks; use netconfig.GetNativeVLANID() where needed (e.g. LACP); separate from ECO_CNF_CORE_NET_VLAN when they differ
 # export ECO_CNF_CORE_NET_SRIOV_INTERFACE_LIST=List SR-IOV interfaces under test # example "eno1,eno2"
 # export ECO_CNF_CORE_NET_MLB_ADDR_LIST=LIST of ip addresses # example 10.66.66.88,10.66.66.89,10.66.66.90,2666:66:0:2e51::88,2666:66:0:2e51::89,2666:66:0:2e51::90
 # export ECO_CNF_CORE_NET_SWITCH_IP="switch_ip_address"

--- a/tests/cnf/core/network/internal/netconfig/config.go
+++ b/tests/cnf/core/network/internal/netconfig/config.go
@@ -43,9 +43,12 @@ type NetworkConfig struct {
 	SriovInterfaces             string `envconfig:"ECO_CNF_CORE_NET_SRIOV_INTERFACE_LIST"`
 	FrrImage                    string `yaml:"frr_image" envconfig:"ECO_CNF_CORE_NET_FRR_IMAGE"`
 	VLAN                        string `envconfig:"ECO_CNF_CORE_NET_VLAN"`
-	BMCHostNames                string `envconfig:"ECO_CNF_CORE_NET_BMC_HOST_NAMES"`
-	BMCHostUser                 string `envconfig:"ECO_CNF_CORE_NET_BMC_HOST_USER"`
-	BMCHostPass                 string `envconfig:"ECO_CNF_CORE_NET_BMC_HOST_PASS"`
+	// NativeVLAN is the physical switch native (untagged) VLAN ID for lab uplinks toward workers
+	// (e.g. 802.1Q native-vlan-id on a trunk).
+	NativeVLAN   string `envconfig:"ECO_CNF_CORE_NET_NATIVE_VLAN"`
+	BMCHostNames string `envconfig:"ECO_CNF_CORE_NET_BMC_HOST_NAMES"`
+	BMCHostUser  string `envconfig:"ECO_CNF_CORE_NET_BMC_HOST_USER"`
+	BMCHostPass  string `envconfig:"ECO_CNF_CORE_NET_BMC_HOST_PASS"`
 }
 
 // NewNetConfig returns instance of NetworkConfig config type.
@@ -120,6 +123,41 @@ func (netConfig *NetworkConfig) GetVLAN() (uint16, error) {
 	}
 
 	return uint16(vlanInt), nil
+}
+
+// GetNativeVLANID returns ECO_CNF_CORE_NET_NATIVE_VLAN as an integer after optional numeric suffix parsing,
+// with 802.1Q range validation (1–4094). Empty or invalid values return an error.
+func (netConfig *NetworkConfig) GetNativeVLANID() (int, error) {
+	vlanText := strings.TrimSpace(netConfig.NativeVLAN)
+	if vlanText == "" {
+		return 0, fmt.Errorf(
+			"native VLAN is empty: set ECO_CNF_CORE_NET_NATIVE_VLAN")
+	}
+
+	vlanInt, err := strconv.Atoi(parseEnvVlanNumericSuffix(vlanText))
+	if err != nil {
+		return 0, fmt.Errorf("invalid native VLAN id %q: %w", vlanText, err)
+	}
+
+	const min8021QVLAN, max8021QVLAN = 1, 4094
+	if vlanInt < min8021QVLAN || vlanInt > max8021QVLAN {
+		return 0, fmt.Errorf(
+			"native VLAN id %d is out of range (allowed %d-%d per 802.1Q)",
+			vlanInt, min8021QVLAN, max8021QVLAN)
+	}
+
+	return vlanInt, nil
+}
+
+// parseEnvVlanNumericSuffix trims raw. If raw looks like "NAME=92" (placeholder copied into the value), it
+// returns the substring after the last '=' so strconv can parse a VLAN id.
+func parseEnvVlanNumericSuffix(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if idx := strings.LastIndex(trimmed, "="); idx >= 0 {
+		trimmed = strings.TrimSpace(trimmed[idx+1:])
+	}
+
+	return trimmed
 }
 
 // GetSwitchUser checks the environmental variable ECO_CNF_CORE_NET_SWITCH_USER and returns the value in string.

--- a/tests/cnf/core/network/sriov/tests/lacp.go
+++ b/tests/cnf/core/network/sriov/tests/lacp.go
@@ -3,7 +3,6 @@ package tests
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -1498,9 +1497,9 @@ func enableLACPOnSwitchInterfaces(credentials *sriovenv.SwitchCredentials, lacpI
 	}
 	defer jnpr.Close()
 
-	vlan, err := strconv.Atoi(NetConfig.VLAN)
+	vlan, err := NetConfig.GetNativeVLANID()
 	if err != nil {
-		return fmt.Errorf("failed to convert VLAN value: %w", err)
+		return fmt.Errorf("native VLAN: %w", err)
 	}
 
 	var commands []string


### PR DESCRIPTION
Backport [#1371](https://github.com/rh-ecosystem-edge/eco-gotests/pull/1371) onto release-4.21.

Introduces ECO_CNF_CORE_NET_NATIVE_VLAN and GetNativeVLANID() so LACP switch configuration uses the lab’s native (untagged) VLAN for trunk native-vlan-id and VLAN members, instead of ECO_CNF_CORE_NET_VLAN. On clusters where native and service VLANs differ, this aligns Juniper LACP setup with the physical switch and avoids LACP / PF Status Relay test failures in CI.