### PR TITLE
system-tests: fix boot ID validation in kdump tests

### DIFF
--- a/tests/system-tests/rdscore/internal/rdscorecommon/kernel-crash-kdump.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/kernel-crash-kdump.go
@@ -254,6 +254,18 @@ func crashNodeKDump(ctx SpecContext, nodeLabel string) {
 		// Re-fetch node after reboot to get fresh object for WaitUntilReady
 		rebootedNode := fetchNodeWithRetry(ctx, nodeName)
 
+		// Defensive validation: ensure node object is valid before proceeding
+		Expect(rebootedNode).ToNot(BeNil(),
+			fmt.Sprintf("Failed to retrieve node %q after reboot: node object is nil", nodeName))
+		Expect(rebootedNode.Definition).ToNot(BeNil(),
+			fmt.Sprintf("Failed to retrieve node %q after reboot: node definition is nil", nodeName))
+		Expect(rebootedNode.Definition.Name).ToNot(BeEmpty(),
+			fmt.Sprintf("Failed to retrieve node %q after reboot: node name is empty", nodeName))
+
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+			"Successfully retrieved node %q after reboot, waiting for Ready state",
+			rebootedNode.Definition.Name)
+
 		err = rebootedNode.WaitUntilReady(5 * time.Minute)
 		Expect(err).ToNot(HaveOccurred(), "Error waiting for node to go into Ready state")
 

--- a/tests/system-tests/rdscore/internal/rdscorecommon/node-crash-helpers.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/node-crash-helpers.go
@@ -68,6 +68,17 @@ func waitForBootIDChange(ctx SpecContext, nodeName, originalBootID string, timeo
 		}
 
 		newBootID := currentNode.Object.Status.NodeInfo.BootID
+
+		// Empty boot ID indicates node is in transient state (rebooting/starting)
+		// We must wait for a valid non-empty boot ID that differs from original
+		if newBootID == "" {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+				"Node %q boot ID is empty (node in transient state, waiting for reboot to complete)",
+				nodeName)
+
+			return false
+		}
+
 		if newBootID != originalBootID {
 			klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
 				"Node %q boot ID changed: %s -> %s (reboot confirmed)",

--- a/tests/system-tests/rdscore/tests/00_validate_top_level.go
+++ b/tests/system-tests/rdscore/tests/00_validate_top_level.go
@@ -62,7 +62,7 @@ var _ = Describe(
 
 			It("Verifies KDump service on Control Plane node",
 				Label("kdump", "kdump-cp"), reportxml.ID("75620"),
-				rdscorecommon.VerifyKDumpOnControlPlane, SpecTimeout(15*time.Minute))
+				rdscorecommon.VerifyKDumpOnControlPlane, SpecTimeout(25*time.Minute))
 
 			It("Cleanup UnexpectedAdmission pods after KDump test on Control Plane node",
 				Label("kdump", "kdump-cp", "kdump-cp-cleanup"),
@@ -71,7 +71,7 @@ var _ = Describe(
 
 			It("Verifies KDump service on Worker node",
 				Label("kdump", "kdump-worker"), reportxml.ID("75621"),
-				rdscorecommon.VerifyKDumpOnWorkerMCP, SpecTimeout(15*time.Minute))
+				rdscorecommon.VerifyKDumpOnWorkerMCP, SpecTimeout(25*time.Minute))
 
 			It("Cleanup UnexpectedAdmission pods after KDump test on Worker node",
 				Label("kdump", "kdump-worker", "kdump-worker-cleanup"),
@@ -80,7 +80,7 @@ var _ = Describe(
 
 			It("Verifies KDump service on CNF node",
 				Label("kdump", "kdump-cnf"), reportxml.ID("75622"),
-				rdscorecommon.VerifyKDumpOnCNFMCP, SpecTimeout(15*time.Minute))
+				rdscorecommon.VerifyKDumpOnCNFMCP, SpecTimeout(25*time.Minute))
 
 			It("Cleanup UnexpectedAdmission pods after KDump test on CNF node",
 				Label("kdump", "kdump-cnf", "kdump-cnf-cleanup"),
@@ -89,7 +89,7 @@ var _ = Describe(
 
 			It("Verifies NMI RedFish trigger on Control Plane node",
 				Label("nmi-redfish", "nmi-redfish-cp"), reportxml.ID("86253"),
-				rdscorecommon.VerifyNMIRedfishOnControlPlane, SpecTimeout(15*time.Minute))
+				rdscorecommon.VerifyNMIRedfishOnControlPlane, SpecTimeout(30*time.Minute))
 
 			It("Cleanup UnexpectedAdmission pods after NMI RedFish test on Control Plane node",
 				Label("nmi-redfish", "nmi-redfish-cp", "nmi-redfish-cp-cleanup"),
@@ -98,7 +98,7 @@ var _ = Describe(
 
 			It("Verifies NMI RedFish trigger on Worker node",
 				Label("nmi-redfish", "nmi-redfish-worker"), reportxml.ID("86254"),
-				rdscorecommon.VerifyNMIRedfishOnWorkerMCP, SpecTimeout(15*time.Minute))
+				rdscorecommon.VerifyNMIRedfishOnWorkerMCP, SpecTimeout(30*time.Minute))
 
 			It("Cleanup UnexpectedAdmission pods after NMI RedFish test on Worker node",
 				Label("nmi-redfish", "nmi-redfish-worker", "nmi-redfish-worker-cleanup"),
@@ -107,7 +107,7 @@ var _ = Describe(
 
 			It("Verifies NMI RedFish trigger on CNF node",
 				Label("nmi-redfish", "nmi-redfish-cnf"), reportxml.ID("86255"),
-				rdscorecommon.VerifyNMIRedfishOnCNFMCP, SpecTimeout(15*time.Minute))
+				rdscorecommon.VerifyNMIRedfishOnCNFMCP, SpecTimeout(30*time.Minute))
 
 			It("Cleanup UnexpectedAdmission pods after NMI RedFish test on CNF node",
 				Label("nmi-redfish", "nmi-redfish-cnf", "nmi-redfish-cnf-cleanup"),


### PR DESCRIPTION
KDump test 75620 was failing with "resource name may not be empty" errors after kernel crash. The waitForBootIDChange() function incorrectly accepted an empty boot ID as evidence of reboot when the node was in a transient state, causing:
  boot ID changed: 634bd82e-... ->  (reboot confirmed)

This led to fetchNodeWithRetry() returning an invalid node object.

Additionally, SpecTimeout (15min) was insufficient for the actual operation duration: waitForBootIDChange (15min) + WaitUntilReady (5min) + verify (5min) = 25min total.

Changes:
- Add empty boot ID validation in waitForBootIDChange() before comparison (node-crash-helpers.go:70-77)
- Increase KDump test timeouts from 15min to 25min for CP/Worker/CNF tests (00_validate_top_level.go:65,74,83)
- Increase NMI test timeouts from 15min to 30min for CP/Worker/CNF tests (00_validate_top_level.go:92,101,110)
- Add defensive node validation after fetchNodeWithRetry() with clear errors (kernel-crash-kdump.go:after line 255)

The fix ensures waitForBootIDChange() only accepts valid non-empty boot IDs that differ from the original, treating empty boot IDs as transient states requiring continued polling. This follows the same pattern as the existing fetchNodeBootIDWithRetry() function.

Timeout increases accommodate the actual operation sequences and align with patterns used in NMI/hard reboot tests (25-30min).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened crash recovery checks to verify node identity after reboot before waiting for readiness
  * Improved detection of node restart by handling transient empty boot identifiers during polling
  * Increased timeouts for hardware failure verification to reduce flakiness in long-running scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/eco-gotests/pull/1404?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->