### PR TITLE
system-tests: add commatrix host-firewall validation tests

### DIFF
--- a/tests/system-tests/rdscore/README.md
+++ b/tests/system-tests/rdscore/README.md
@@ -283,6 +283,65 @@ After data is stored in a a volume backed by the PVC deployment is scaled down a
 |rdscore_wlkd_odf_one_selector | Node selector for 1st node | `kubernetes.io/hostname: worker-X` |
 |rdscore_wlkd_odf_two_selector | Node selector for 2nd node | `kubernetes.io/hostname: worker-Y` |
 
+### _VerifyCommatrixHostFirewallArtifacts_
+
+This test verifies `oc commatrix` host-firewall _MachineConfig_ artifacts: direct `mc` output matches butane-rendered
+_MachineConfigs_, and embedded _nftables_ `openshift_filter` rules are present in generated MC payloads.
+
+Test expects `oc commatrix generate` to write under _rdscore_commatrix_output_dir_ (`format-mc` and `format-butane`), the
+butane CLI to render `mc-*.yaml` beside `butane-*.yaml`, and decoded MC payloads to contain host-firewall nftables rules.
+
+**Requires `oc commatrix` on the test runner, a writable output directory, and a cluster that will receive MCs in later specs**
+
+| parameter | description | example |
+|-----------|-------------|---------|
+|rdscore_commatrix_output_dir | Writable directory for `oc commatrix generate` output (_required_) | `/tmp/commatrix-work` |
+|rdscore_commatrix_open_pool_node_label | Label selector for open pool nodes (_optional_; inferred from `mc-*mcp-b*.yaml` when empty) | `` |
+
+API/kubelet/closed ports, MCP wait, and journal keyword are fixed in test code (6443, 10250, 9999, 15m, `firewall`).
+
+Run the ordered commatrix spec: `ginkgo --label-filter=commatrix ./tests/system-tests/rdscore`
+
+### _VerifyCommatrixHostFirewallApply_
+
+This test verifies host-firewall _MachineConfiguration_ apply on the cluster: node disruption policy merge patch,
+selective apply of secure-pool and master _MachineConfigs_, _MachineConfigPool_ stability, and `openshift_filter` chain
+presence on a worker node.
+
+Test expects `format-mc` artifacts from the artifacts spec, including `node-disruption-policy.yaml`, `mc-<secure-pool>.yaml`, and
+`mc-master.yaml`. Other generated `mc-<pool>.yaml` files (e.g. open pool) must remain unapplied so open workers stay
+without host-firewall rules for the open-pool kubelet connectivity check.
+
+**Requires commatrix artifacts and at least one node in each applied _MachineConfigPool_. Reverts cluster changes in AfterAll after all four specs**
+
+Uses commatrix parameters listed under _VerifyCommatrixHostFirewallArtifacts_.
+
+### _VerifyCommatrixHostFirewallConnectivity_
+
+This test verifies host-firewall TCP reachability from the test runner to node _InternalIP_ addresses: API and kubelet
+ports allowed or blocked per pool, and open-pool kubelet reachable when that pool's MC was not applied.
+
+Test expects `nc` on the test runner to reach the control-plane API where allowed, to fail or time out
+to secure-pool worker API ports, to reach kubelet on the secure worker, to fail on a closed test port, and to reach
+kubelet on an open-pool worker.
+
+**Requires applied host-firewall MCs, resolvable master/secure/open worker internal IPs (secure worker is the first node in the applied firewall MCP from apply; open pool via label or inferred MCP), and optionally a second node in an applied firewall MCP for the peer API probe**
+
+Uses commatrix parameters listed under _VerifyCommatrixHostFirewallArtifacts_.
+
+### _VerifyCommatrixHostFirewallJournal_
+
+This test verifies host-firewall kernel logging: rate-limited `firewall` / `firewall ` log-prefix buckets in the
+journal, and a temporary `TCP_TEST` nft log rule with matching journal lines after a probe.
+
+Test expects kernel journal lines on the same secure-worker node as connectivity matching the firewall log keyword, at most five
+lines per bucket in each of two consecutive one-minute windows (`2m–1m ago` and `last 1m`), and at least one `TCP_TEST` line referencing
+the probed destination port after `nc` from the test runner.
+
+**Requires applied host-firewall MCs, connectivity spec run first (same secure-worker node), and firewall traffic or probes sufficient to produce journal lines**
+
+Uses commatrix parameters listed under _VerifyCommatrixHostFirewallArtifacts_.
+
 ### _VerifyNMStateInstanceExists_
 
 Verifies that _NMState_ instance `nmstate` exists

--- a/tests/system-tests/rdscore/README.md
+++ b/tests/system-tests/rdscore/README.md
@@ -296,7 +296,6 @@ butane CLI to render `mc-*.yaml` beside `butane-*.yaml`, and decoded MC payloads
 | parameter | description | example |
 |-----------|-------------|---------|
 |rdscore_commatrix_output_dir | Writable directory for `oc commatrix generate` output (_required_) | `/tmp/commatrix-work` |
-|rdscore_commatrix_open_pool_node_label | Label selector for open pool nodes (_optional_; inferred from `mc-*mcp-b*.yaml` when empty) | `` |
 
 API/kubelet/closed ports, MCP wait, and journal keyword are fixed in test code (6443, 10250, 9999, 15m, `firewall`).
 
@@ -309,8 +308,7 @@ selective apply of secure-pool and master _MachineConfigs_, _MachineConfigPool_ 
 presence on a worker node.
 
 Test expects `format-mc` artifacts from the artifacts spec, including `node-disruption-policy.yaml`, `mc-<secure-pool>.yaml`, and
-`mc-master.yaml`. Other generated `mc-<pool>.yaml` files (e.g. open pool) must remain unapplied so open workers stay
-without host-firewall rules for the open-pool kubelet connectivity check.
+`mc-master.yaml`. Other generated `mc-<pool>.yaml` files may exist; apply selectively per test configuration.
 
 **Requires commatrix artifacts and at least one node in each applied _MachineConfigPool_. Reverts cluster changes in AfterAll after all four specs**
 
@@ -319,13 +317,12 @@ Uses commatrix parameters listed under _VerifyCommatrixHostFirewallArtifacts_.
 ### _VerifyCommatrixHostFirewallConnectivity_
 
 This test verifies host-firewall TCP reachability from the test runner to node _InternalIP_ addresses: API and kubelet
-ports allowed or blocked per pool, and open-pool kubelet reachable when that pool's MC was not applied.
+ports allowed or blocked on master and secure-pool workers.
 
 Test expects `nc` on the test runner to reach the control-plane API where allowed, to fail or time out
-to secure-pool worker API ports, to reach kubelet on the secure worker, to fail on a closed test port, and to reach
-kubelet on an open-pool worker.
+to secure-pool worker API ports, to reach kubelet on the secure worker, and to fail on a closed test port.
 
-**Requires applied host-firewall MCs, resolvable master/secure/open worker internal IPs (secure worker is the first node in the applied firewall MCP from apply; open pool via label or inferred MCP), and optionally a second node in an applied firewall MCP for the peer API probe**
+**Requires host-firewall MCs applied on all MCPs, resolvable master/secure worker internal IPs (secure worker is the first node in the secure firewall MCP), and optionally a second node in an applied firewall MCP for the peer API probe**
 
 Uses commatrix parameters listed under _VerifyCommatrixHostFirewallArtifacts_.
 

--- a/tests/system-tests/rdscore/README.md
+++ b/tests/system-tests/rdscore/README.md
@@ -283,48 +283,20 @@ After data is stored in a a volume backed by the PVC deployment is scaled down a
 |rdscore_wlkd_odf_one_selector | Node selector for 1st node | `kubernetes.io/hostname: worker-X` |
 |rdscore_wlkd_odf_two_selector | Node selector for 2nd node | `kubernetes.io/hostname: worker-Y` |
 
-### _VerifyCommatrixHostFirewallArtifacts_
-
-This test verifies `oc commatrix` host-firewall _MachineConfig_ artifacts: direct `mc` output matches butane-rendered
-_MachineConfigs_, and embedded _nftables_ `openshift_filter` rules are present in generated MC payloads.
-
-Test expects `oc commatrix generate` to write under _rdscore_commatrix_output_dir_ (`format-mc` and `format-butane`), the
-butane CLI to render `mc-*.yaml` beside `butane-*.yaml`, and decoded MC payloads to contain host-firewall nftables rules.
-
-**Requires `oc commatrix` on the test runner, a writable output directory, and a cluster that will receive MCs in later specs**
-
-| parameter | description | example |
-|-----------|-------------|---------|
-|rdscore_commatrix_output_dir | Writable directory for `oc commatrix generate` output (_required_) | `/tmp/commatrix-work` |
-
-API/kubelet/closed ports, MCP wait, and journal keyword are fixed in test code (6443, 10250, 9999, 15m, `firewall`).
-
-Run the ordered commatrix spec: `ginkgo --label-filter=commatrix ./tests/system-tests/rdscore`
-
-### _VerifyCommatrixHostFirewallApply_
-
-This test verifies host-firewall _MachineConfiguration_ apply on the cluster: node disruption policy merge patch,
-selective apply of secure-pool and master _MachineConfigs_, _MachineConfigPool_ stability, and `openshift_filter` chain
-presence on a worker node.
-
-Test expects `format-mc` artifacts from the artifacts spec, including `node-disruption-policy.yaml`, `mc-<secure-pool>.yaml`, and
-`mc-master.yaml`. Other generated `mc-<pool>.yaml` files may exist; apply selectively per test configuration.
-
-**Requires commatrix artifacts and at least one node in each applied _MachineConfigPool_. Reverts cluster changes in AfterAll after all four specs**
-
-Uses commatrix parameters listed under _VerifyCommatrixHostFirewallArtifacts_.
-
 ### _VerifyCommatrixHostFirewallConnectivity_
 
-This test verifies host-firewall TCP reachability from the test runner to node _InternalIP_ addresses: API and kubelet
-ports allowed or blocked on master and secure-pool workers.
+This test verifies host-firewall TCP reachability from the test runner to node external IPs: API and dynamically selected
+open/blocked ports on master and secure-pool workers (ports are read from live `openshift_filter` nftables rules).
 
-Test expects `nc` on the test runner to reach the control-plane API where allowed, to fail or time out
-to secure-pool worker API ports, to reach kubelet on the secure worker, and to fail on a closed test port.
+Test expects TCP dials from the test runner to reach the control-plane API where allowed, to fail on blocked ports,
+to reach an accepted port on the secure worker, and optionally to fail on a second secure-pool worker for peer probes.
 
-**Requires host-firewall MCs applied on all MCPs, resolvable master/secure worker internal IPs (secure worker is the first node in the secure firewall MCP), and optionally a second node in an applied firewall MCP for the peer API probe**
+**Requires commatrix host-firewall MachineConfigs already applied on the cluster, resolvable master/secure worker IPs
+(secure worker is the first node in the inferred secure firewall MCP), and optionally a second node in that MCP for the peer probe**
 
-Uses commatrix parameters listed under _VerifyCommatrixHostFirewallArtifacts_.
+API, kubelet fallback, and closed-port candidates are fixed in test code (6443, 10250, 9999).
+
+Run commatrix specs: `ginkgo --label-filter=commatrix ./tests/system-tests/rdscore`
 
 ### _VerifyCommatrixHostFirewallJournal_
 
@@ -333,11 +305,10 @@ journal, and a temporary `TCP_TEST` nft log rule with matching journal lines aft
 
 Test expects kernel journal lines on the same secure-worker node as connectivity matching the firewall log keyword, at most five
 lines per bucket in each of two consecutive one-minute windows (`2m–1m ago` and `last 1m`), and at least one `TCP_TEST` line referencing
-the probed destination port after `nc` from the test runner.
+the probed destination port after a TCP probe from the test runner.
 
-**Requires applied host-firewall MCs, connectivity spec run first (same secure-worker node), and firewall traffic or probes sufficient to produce journal lines**
-
-Uses commatrix parameters listed under _VerifyCommatrixHostFirewallArtifacts_.
+**Requires commatrix host-firewall MCs on the cluster, connectivity spec run first when possible (same secure-worker node),
+and firewall traffic or probes sufficient to produce journal lines**
 
 ### _VerifyNMStateInstanceExists_
 

--- a/tests/system-tests/rdscore/internal/rdscorecommon/commatrix.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/commatrix.go
@@ -47,6 +47,13 @@ const (
 	commatrixHostFirewallMCNameSubstring = "nftables-commatrix"
 	// commatrixTCPProbeTimeout matches legacy nc -w3 probe wait.
 	commatrixTCPProbeTimeout = 3 * time.Second
+	// commatrixLogMsgPrefix prefixes host-firewall test log lines (matches rdscorecommon action-oriented style).
+	commatrixLogMsgPrefix = "Commatrix host-firewall"
+
+	commatrixNodeRoleLabelWorker       = "node-role.kubernetes.io/worker"
+	commatrixNodeRoleLabelMaster       = "node-role.kubernetes.io/master"
+	commatrixNodeRoleLabelControlPlane = "node-role.kubernetes.io/control-plane"
+	commatrixNodeRoleLabelStorage      = "node-role.kubernetes.io/storage"
 )
 
 // journalShortTimePrefixRe parses journalctl short-iso timestamps for firewall log rate-limit checks.
@@ -75,20 +82,42 @@ type commatrixWorkflowState struct {
 
 var commatrixWorkflow commatrixWorkflowState
 
+// commatrixLogOutputSnippet returns trimmed command output for logs, truncated when very long.
+func commatrixLogOutputSnippet(output string, maxLen int) string {
+	output = strings.TrimSpace(output)
+	if output == "" {
+		return "(empty)"
+	}
+
+	if maxLen <= 0 || len(output) <= maxLen {
+		return output
+	}
+
+	return output[:maxLen] + "...(truncated)"
+}
+
 // commatrixPrimeWorkflowForVerification discovers host-firewall pools from commatrix MachineConfigs on the cluster.
 func commatrixPrimeWorkflowForVerification() error {
 	if commatrixWorkflow.primed {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: workflow already primed (nftProbeNode=%q)",
+			commatrixLogMsgPrefix, commatrixWorkflow.nftProbeNodeName))
+
 		return nil
 	}
 
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: priming verification workflow (discover commatrix MCs matching %q on cluster)",
+		commatrixLogMsgPrefix, commatrixHostFirewallMCNameSubstring))
+
 	poolNames, err := commatrixHostFirewallPoolNamesFromCluster()
 	if err != nil {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: list commatrix host-firewall MachineConfigs failed: %v", commatrixLogMsgPrefix, err))
+
 		return fmt.Errorf("discover host-firewall MachineConfig pools: %w", err)
 	}
 
 	if len(poolNames) == 0 {
 		detail := commatrixHostFirewallMCDiscoveryDetail()
-		klog.Warningf("Commatrix: host-firewall MC discovery failed: %s", detail)
+		klog.Warningf("%s: host-firewall MachineConfig discovery failed: %s", commatrixLogMsgPrefix, detail)
 
 		return fmt.Errorf(
 			"no commatrix host-firewall MachineConfigs on cluster (look for %q in mc names); %s; "+
@@ -96,13 +125,16 @@ func commatrixPrimeWorkflowForVerification() error {
 			commatrixHostFirewallMCNameSubstring, detail)
 	}
 
-	klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
-		"Commatrix: discovered host-firewall MC pools on cluster: %v", poolNames)
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+		"%s: discovered MachineConfig pool name(s) from cluster MCs: %v", commatrixLogMsgPrefix, poolNames))
 
 	commatrixWorkflow.discoveredPoolNames = append([]string(nil), poolNames...)
 
 	securePool := commatrixInferSecureMCPoolNameFromPools(poolNames)
 	if securePool == "" {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: could not infer secure worker MachineConfigPool from discovered pools %v",
+			commatrixLogMsgPrefix, poolNames))
+
 		return fmt.Errorf("could not infer secure/firewall MCP from pools %v", poolNames)
 	}
 
@@ -117,47 +149,82 @@ func commatrixPrimeWorkflowForVerification() error {
 
 	secureNodes, err := commatrixNodesFromMachineConfigPools([]string{securePool})
 	if err != nil {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: list nodes in secure pool %q failed: %v", commatrixLogMsgPrefix, securePool, err))
+
 		return fmt.Errorf("list nodes in secure pool %q: %w", securePool, err)
 	}
 
 	if len(secureNodes) == 0 {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: secure pool %q matched no nodes for connectivity/journal probes",
+			commatrixLogMsgPrefix, securePool))
+
 		return fmt.Errorf("no nodes in secure pool %q for connectivity/journal probes", securePool)
 	}
 
 	commatrixWorkflow.nftProbeNodeName = secureNodes[0]
 	commatrixWorkflow.primed = true
 
-	klog.Infof(
-		"Commatrix: primed verification workflow discoveredPools=%v securePool=%q masterPool=%q probePools=%v nftProbeNode=%q securePoolNodes=%v",
-		poolNames, securePool, masterPool, applyPools, commatrixWorkflow.nftProbeNodeName, secureNodes)
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+		"%s: primed workflow discoveredPools=%v securePool=%q masterPool=%q probePools=%v nftProbeNode=%q securePoolNodes=%v",
+		commatrixLogMsgPrefix,
+		poolNames, securePool, masterPool, applyPools, commatrixWorkflow.nftProbeNodeName, secureNodes))
 
 	return nil
 }
 
 // commatrixMachineConfigPoolRole returns the MachineConfigPool name for a commatrix MC from its role label or name suffix.
 func commatrixMachineConfigPoolRole(mcObj *mcv1.MachineConfig) string {
-	if role := strings.TrimSpace(mcObj.Labels[mcv1.MachineConfigRoleLabelKey]); role != "" {
-		return role
-	}
+	if mcObj == nil {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: cannot resolve pool role from nil MachineConfig", commatrixLogMsgPrefix))
 
-	// Commatrix MC names encode the pool after the marker even when the role label is absent.
-	markerIdx := strings.Index(mcObj.Name, commatrixHostFirewallMCNameSubstring)
-	if markerIdx < 0 {
 		return ""
 	}
 
-	return strings.TrimSpace(strings.TrimPrefix(mcObj.Name[markerIdx+len(commatrixHostFirewallMCNameSubstring):], "-"))
+	if role := strings.TrimSpace(mcObj.Labels[mcv1.MachineConfigRoleLabelKey]); role != "" {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: MachineConfig %q -> pool %q (from %s label)",
+			commatrixLogMsgPrefix, mcObj.Name, role, mcv1.MachineConfigRoleLabelKey))
+
+		return role
+	}
+
+	// Some clusters omit machineconfiguration.openshift.io/role; commatrix names are
+	// <priority>-nftables-commatrix-<pool> and the pool is the suffix after the marker.
+	if !strings.Contains(mcObj.Name, commatrixHostFirewallMCNameSubstring) {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: MachineConfig %q has no role label and name lacks %q; cannot resolve pool",
+			commatrixLogMsgPrefix, mcObj.Name, commatrixHostFirewallMCNameSubstring))
+
+		return ""
+	}
+
+	pool := strings.TrimSpace(strings.TrimPrefix(
+		mcObj.Name[strings.Index(mcObj.Name, commatrixHostFirewallMCNameSubstring)+len(commatrixHostFirewallMCNameSubstring):],
+		"-",
+	))
+	if pool == "" {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: MachineConfig %q has no role label and empty pool suffix after %q",
+			commatrixLogMsgPrefix, mcObj.Name, commatrixHostFirewallMCNameSubstring))
+
+		return ""
+	}
+
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: MachineConfig %q -> pool %q (inferred from metadata.name suffix)",
+		commatrixLogMsgPrefix, mcObj.Name, pool))
+
+	return pool
 }
 
 // commatrixHostFirewallPoolNamesFromCluster lists unique MCP names from commatrix host-firewall MachineConfigs on the cluster.
 func commatrixHostFirewallPoolNamesFromCluster() ([]string, error) {
 	mcList, err := mco.ListMC(APIClient)
 	if err != nil {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: mco.ListMC failed while discovering host-firewall pools: %v", commatrixLogMsgPrefix, err))
+
 		return nil, err
 	}
 
 	seen := make(map[string]struct{})
 	pools := make([]string, 0)
+	var matchedMCNames []string
 
 	for _, mcBuilder := range mcList {
 		if mcBuilder == nil || mcBuilder.Object == nil {
@@ -168,6 +235,8 @@ func commatrixHostFirewallPoolNamesFromCluster() ([]string, error) {
 		if !strings.Contains(mcObj.Name, commatrixHostFirewallMCNameSubstring) {
 			continue
 		}
+
+		matchedMCNames = append(matchedMCNames, mcObj.Name)
 
 		role := commatrixMachineConfigPoolRole(mcObj)
 		if role == "" {
@@ -184,6 +253,10 @@ func commatrixHostFirewallPoolNamesFromCluster() ([]string, error) {
 	}
 
 	sort.Strings(pools)
+
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+		"%s: listed %d commatrix host-firewall MachineConfig(s) %v -> pool name(s) %v",
+		commatrixLogMsgPrefix, len(matchedMCNames), matchedMCNames, pools))
 
 	return pools, nil
 }
@@ -266,28 +339,35 @@ func commatrixDialTCP(host, port string) error {
 func commatrixRunTCPProbeFromRunner(expectConnect bool, host, port string) error {
 	network := commatrixTCPProbeNetwork(host)
 	addr := net.JoinHostPort(host, port)
-	probeDesc := fmt.Sprintf("dial %s %s", network, addr)
+	expectLabel := "connect"
+	if !expectConnect {
+		expectLabel = "blocked"
+	}
 
 	dialErr := commatrixDialTCP(host, port)
 	connected := dialErr == nil
 
 	if expectConnect == connected {
 		if expectConnect {
-			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("probe: %s succeeded", probeDesc)
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+				"%s: TCP probe to %s %s succeeded (expected %s)", commatrixLogMsgPrefix, network, addr, expectLabel))
 		} else {
-			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("probe: %s failed as expected: %v", probeDesc, dialErr)
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+				"%s: TCP probe to %s %s failed as expected: %v", commatrixLogMsgPrefix, network, addr, dialErr))
 		}
 
 		return nil
 	}
 
 	if expectConnect {
-		klog.Infof("probe: %s failed (expected connect): %v", probeDesc, dialErr)
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: TCP probe to %s %s failed (expected %s): %v",
+			commatrixLogMsgPrefix, network, addr, expectLabel, dialErr))
 
 		return dialErr
 	}
 
-	klog.Infof("probe: %s unexpectedly connected (expected blocked)", probeDesc)
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: TCP probe to %s %s unexpectedly connected (expected %s)",
+		commatrixLogMsgPrefix, network, addr, expectLabel))
 
 	return fmt.Errorf("expected connection to %s to fail, but dial succeeded", addr)
 }
@@ -305,6 +385,8 @@ func commatrixProbeLabel(addr string) string {
 // address must succeed; when false, every address must fail to connect.
 func commatrixTryTCPProbesFromRunner(desc string, addrs []string, port string, expectConnect bool) error {
 	if len(addrs) == 0 {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: TCP probe %q skipped: no addresses to probe", commatrixLogMsgPrefix, desc))
+
 		return fmt.Errorf("%s: no internal IP addresses to probe", desc)
 	}
 
@@ -313,12 +395,14 @@ func commatrixTryTCPProbesFromRunner(desc string, addrs []string, port string, e
 
 		for _, addr := range addrs {
 			label := commatrixProbeLabel(addr)
-			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("TCP probe %s via %s -> %s:%s (expect connect)",
-				desc, label, addr, port)
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+				"%s: TCP probe %q via %s -> %s:%s (expect at least one connect)",
+				commatrixLogMsgPrefix, desc, label, addr, port))
 
 			err := commatrixRunTCPProbeFromRunner(true, addr, port)
 			if err == nil {
-				klog.V(rdscoreparams.RDSCoreLogLevel).Infof("TCP probe %s succeeded via %s", desc, label)
+				klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+					"%s: TCP probe %q succeeded via %s", commatrixLogMsgPrefix, desc, label))
 
 				return nil
 			}
@@ -326,16 +410,23 @@ func commatrixTryTCPProbesFromRunner(desc string, addrs []string, port string, e
 			failures = append(failures, fmt.Sprintf("%s: %v", label, err))
 		}
 
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: TCP probe %q failed on all addresses %v: %s",
+			commatrixLogMsgPrefix, desc, addrs, strings.Join(failures, "; ")))
+
 		return fmt.Errorf("%s: none of %v reachable from test runner (%s)",
 			desc, addrs, strings.Join(failures, "; "))
 	}
 
 	for _, addr := range addrs {
 		label := commatrixProbeLabel(addr)
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("TCP probe %s via %s -> %s:%s (expect blocked)",
-			desc, label, addr, port)
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+			"%s: TCP probe %q via %s -> %s:%s (expect blocked on every address)",
+			commatrixLogMsgPrefix, desc, label, addr, port))
 
 		if err := commatrixRunTCPProbeFromRunner(false, addr, port); err != nil {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: TCP probe %q via %s unexpectedly connected (expected blocked): %v",
+				commatrixLogMsgPrefix, desc, label, err))
+
 			return fmt.Errorf("%s via %s: %w", desc, label, err)
 		}
 	}
@@ -345,12 +436,16 @@ func commatrixTryTCPProbesFromRunner(desc string, addrs []string, port string, e
 
 // commatrixRunOnNodeHostDebug runs cmd on the node host via the MCO daemon pod (chroot /rootfs).
 func commatrixRunOnNodeHostDebug(nodeName string, cmd []string) (string, error) {
+	cmdStr := strings.Join(cmd, " ")
 	hostDebugCmdOut, hostDebugCmdErr := remote.ExecuteOnNodeWithDebugPod(cmd, nodeName)
 
 	if hostDebugCmdErr != nil {
-		klog.Infof("node %s exec %v failed: %v\n%s", nodeName, cmd, hostDebugCmdErr, hostDebugCmdOut)
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: node %q debug-pod exec failed: cmd=%q err=%v output=%q",
+			commatrixLogMsgPrefix, nodeName, cmdStr, hostDebugCmdErr,
+			commatrixLogOutputSnippet(hostDebugCmdOut, 500)))
 	} else {
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("node %s exec %v\n%s", nodeName, cmd, hostDebugCmdOut)
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: node %q debug-pod exec succeeded: cmd=%q output=%q",
+			commatrixLogMsgPrefix, nodeName, cmdStr, commatrixLogOutputSnippet(hostDebugCmdOut, 500)))
 	}
 
 	return hostDebugCmdOut, hostDebugCmdErr
@@ -358,9 +453,14 @@ func commatrixRunOnNodeHostDebug(nodeName string, cmd []string) (string, error) 
 
 // commatrixExtractOpenshiftFilterRuleLines returns non-empty nft rule lines from a decoded openshift_filter payload.
 func commatrixExtractOpenshiftFilterRuleLines(nftText string) []string {
+	lines := strings.Split(nftText, "\n")
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+		"%s: parsing openshift_filter nft text (%d line(s), %d byte(s))",
+		commatrixLogMsgPrefix, len(lines), len(nftText)))
+
 	var rules []string
 
-	for _, line := range strings.Split(nftText, "\n") {
+	for _, line := range lines {
 		line = strings.TrimSpace(line)
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
@@ -380,6 +480,18 @@ func commatrixExtractOpenshiftFilterRuleLines(nftText string) []string {
 			rules = append(rules, line)
 		}
 	}
+
+	if len(rules) == 0 {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+			"%s: no openshift_filter rule lines matched filter heuristics; nft text: %q",
+			commatrixLogMsgPrefix, commatrixLogOutputSnippet(nftText, 1000)))
+
+		return rules
+	}
+
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+		"%s: extracted %d openshift_filter rule line(s): %v",
+		commatrixLogMsgPrefix, len(rules), rules))
 
 	return rules
 }
@@ -482,13 +594,17 @@ func commatrixPickBlockedTCPPort(allowed map[int]struct{}) int {
 
 	for _, candidate := range candidates {
 		if _, open := allowed[candidate]; !open {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+				"%s: selected blocked probe port %d (not in nft accept set %v)",
+				commatrixLogMsgPrefix, candidate, commatrixFormatPortSet(allowed)))
+
 			return candidate
 		}
 	}
 
 	klog.Warningf(
-		"Commatrix: all blocked-port candidates %v are in nft accept rules %v; falling back to default closed port %d",
-		candidates, commatrixFormatPortSet(allowed), commatrixClosedTCPPort)
+		"%s: all blocked-port candidates %v are in nft accept rules %v; falling back to default closed port %d",
+		commatrixLogMsgPrefix, candidates, commatrixFormatPortSet(allowed), commatrixClosedTCPPort)
 
 	return commatrixClosedTCPPort
 }
@@ -496,17 +612,29 @@ func commatrixPickBlockedTCPPort(allowed map[int]struct{}) int {
 // commatrixSelectProbePorts picks distinct open (accepted) and blocked probe ports from an nft accept port set.
 func commatrixSelectProbePorts(allowed map[int]struct{}) (openPort, blockedPort int, err error) {
 	if len(allowed) == 0 {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: cannot select probe ports: no accepted tcp dport rules in openshift_filter",
+			commatrixLogMsgPrefix))
+
 		return 0, 0, fmt.Errorf("no accepted tcp dport rules found in openshift_filter")
 	}
 
 	if _, ok := allowed[commatrixKubeletPort]; ok {
 		openPort = commatrixKubeletPort
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+			"%s: selected open probe port %d (kubelet port present in nft accept rules)",
+			commatrixLogMsgPrefix, openPort))
 	} else {
 		openPort = commatrixFormatPortSet(allowed)[0]
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+			"%s: selected open probe port %d (lowest port in nft accept rules %v)",
+			commatrixLogMsgPrefix, openPort, commatrixFormatPortSet(allowed)))
 	}
 
 	blockedPort = commatrixPickBlockedTCPPort(allowed)
 	if blockedPort == openPort {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: cannot select probe ports: open port %d equals blocked port from allowed set %v",
+			commatrixLogMsgPrefix, openPort, commatrixFormatPortSet(allowed)))
+
 		return 0, 0, fmt.Errorf("could not pick distinct open/blocked probe ports from allowed set %v",
 			commatrixFormatPortSet(allowed))
 	}
@@ -518,20 +646,28 @@ func commatrixSelectProbePorts(allowed map[int]struct{}) (openPort, blockedPort 
 func commatrixAllowedTCPDPortsFromNode(nodeName string) (map[int]struct{}, error) {
 	nftListShellCmd := "nft list table inet openshift_filter 2>/dev/null || nft list ruleset 2>/dev/null || true"
 
-	nftOutput, err := commatrixRunOnNodeHostShell(nodeName, nftListShellCmd)
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+		"%s: reading live openshift_filter nftables accept rules on node %q", commatrixLogMsgPrefix, nodeName))
+
+	nftOutput, err := commatrixRunOnNodeHostShell(nodeName, "list openshift_filter nftables rules", nftListShellCmd)
 	if err != nil {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: node %q openshift_filter nft list failed: %v", commatrixLogMsgPrefix, nodeName, err))
+
 		return nil, fmt.Errorf("list openshift_filter nftables on %q: %w", nodeName, err)
 	}
 
 	allowed := commatrixParseAcceptedTCPDPortsFromNFTables(nftOutput)
 	if len(allowed) == 0 {
+		klog.Warningf("%s: node %q has no accepted tcp dport rules in openshift_filter; nft output: %q",
+			commatrixLogMsgPrefix, nodeName, commatrixLogOutputSnippet(nftOutput, 1000))
+
 		return nil, fmt.Errorf(
 			"no accepted tcp dport rules in openshift_filter on %q; nft output:\n%s",
 			nodeName, strings.TrimSpace(nftOutput))
 	}
 
-	klog.Infof("Commatrix: node %q accepted tcp dports from nft: %v",
-		nodeName, commatrixFormatPortSet(allowed))
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: node %q nft accept tcp dports: %v",
+		commatrixLogMsgPrefix, nodeName, commatrixFormatPortSet(allowed)))
 
 	return allowed, nil
 }
@@ -540,19 +676,24 @@ func commatrixAllowedTCPDPortsFromNode(nodeName string) (map[int]struct{}, error
 func commatrixResolveSecureProbePorts(nodeName string) error {
 	allowed, err := commatrixAllowedTCPDPortsFromNode(nodeName)
 	if err != nil {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: node %q probe port resolution failed reading nft accept rules: %v",
+			commatrixLogMsgPrefix, nodeName, err))
+
 		return err
 	}
 
 	openPort, blockedPort, errPick := commatrixSelectProbePorts(allowed)
 	if errPick != nil {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: node %q probe port selection failed: %v", commatrixLogMsgPrefix, nodeName, errPick))
+
 		return errPick
 	}
 
 	commatrixWorkflow.run.SecureOpenPort = openPort
 	commatrixWorkflow.run.SecureBlockedPort = blockedPort
 
-	klog.Infof("Commatrix: secure worker %q probe ports open=%d blocked=%d (from nft accept rules)",
-		nodeName, openPort, blockedPort)
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: secure worker %q probe ports open=%d blocked=%d (from live nft accept rules)",
+		commatrixLogMsgPrefix, nodeName, openPort, blockedPort))
 
 	return nil
 }
@@ -564,13 +705,15 @@ func commatrixFilterPoolsOnCluster(pools []string) []string {
 	for _, poolName := range pools {
 		mcpB, errPull := mco.Pull(APIClient, poolName)
 		if errPull != nil {
-			klog.Infof("Commatrix: skip pool %q from commatrix MC: MachineConfigPool not found: %v", poolName, errPull)
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: skip pool %q (MachineConfigPool not found on cluster): %v",
+				commatrixLogMsgPrefix, poolName, errPull))
 
 			continue
 		}
 
 		if _, errGet := mcpB.Get(); errGet != nil {
-			klog.Infof("Commatrix: skip pool %q from commatrix MC: get MachineConfigPool failed: %v", poolName, errGet)
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: skip pool %q (get MachineConfigPool failed): %v",
+				commatrixLogMsgPrefix, poolName, errGet))
 
 			continue
 		}
@@ -583,41 +726,60 @@ func commatrixFilterPoolsOnCluster(pools []string) []string {
 	return filtered
 }
 
-// commatrixNodeHasControlPlaneRole reports whether a node has control-plane/master role labels.
-func commatrixNodeHasControlPlaneRole(nb *nodes.Builder) bool {
+// commatrixNodeBuilderName returns a node name for logging, or empty when the builder is nil.
+func commatrixNodeBuilderName(nb *nodes.Builder) string {
 	if nb == nil || nb.Object == nil {
+		return ""
+	}
+
+	return nb.Object.Name
+}
+
+// commatrixNodeHasRoleLabel reports whether a node has any of the given node-role.kubernetes.io label keys.
+func commatrixNodeHasRoleLabel(nb *nodes.Builder, roleLabels ...string) bool {
+	nodeName := commatrixNodeBuilderName(nb)
+	roleList := strings.Join(roleLabels, ",")
+
+	if nb == nil || nb.Object == nil {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+			"%s: node %q role label(s) %q -> false (nil node builder)",
+			commatrixLogMsgPrefix, nodeName, roleList))
+
 		return false
 	}
 
 	nodeLabels := nb.Object.Labels
 	if nodeLabels == nil {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+			"%s: node %q role label(s) %q -> false (no labels)",
+			commatrixLogMsgPrefix, nodeName, roleList))
+
 		return false
 	}
 
-	if _, ok := nodeLabels["node-role.kubernetes.io/master"]; ok {
-		return true
+	for _, roleLabel := range roleLabels {
+		if _, ok := nodeLabels[roleLabel]; ok {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+				"%s: node %q role label(s) %q -> true (matched %q)",
+				commatrixLogMsgPrefix, nodeName, roleList, roleLabel))
+
+			return true
+		}
 	}
 
-	_, hasControlPlane := nodeLabels["node-role.kubernetes.io/control-plane"]
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+		"%s: node %q role label(s) %q -> false",
+		commatrixLogMsgPrefix, nodeName, roleList))
 
-	return hasControlPlane
-}
-
-// commatrixNodeHasWorkerRole reports whether a node has the worker role label.
-func commatrixNodeHasWorkerRole(nb *nodes.Builder) bool {
-	if nb == nil || nb.Object == nil || nb.Object.Labels == nil {
-		return false
-	}
-
-	_, ok := nb.Object.Labels["node-role.kubernetes.io/worker"]
-
-	return ok
+	return false
 }
 
 // commatrixPoolNodeBuilders returns node builders for all nodes matched by a MachineConfigPool nodeSelector.
 func commatrixPoolNodeBuilders(poolName string) ([]*nodes.Builder, error) {
 	nodeNames, err := commatrixNodesFromMachineConfigPools([]string{poolName})
 	if err != nil {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: list nodes for pool %q failed: %v", commatrixLogMsgPrefix, poolName, err))
+
 		return nil, err
 	}
 
@@ -626,6 +788,8 @@ func commatrixPoolNodeBuilders(poolName string) ([]*nodes.Builder, error) {
 	for _, nodeName := range nodeNames {
 		nb, errPull := nodes.Pull(APIClient, nodeName)
 		if errPull != nil {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: pull node %q in pool %q failed: %v", commatrixLogMsgPrefix, nodeName, poolName, errPull))
+
 			return nil, fmt.Errorf("pull node %q in pool %q: %w", nodeName, poolName, errPull)
 		}
 
@@ -638,17 +802,35 @@ func commatrixPoolNodeBuilders(poolName string) ([]*nodes.Builder, error) {
 // commatrixPoolIsControlPlaneOnly reports whether every node in the MCP is a control-plane node.
 func commatrixPoolIsControlPlaneOnly(poolName string) bool {
 	nodeBuilders, err := commatrixPoolNodeBuilders(poolName)
-	if err != nil || len(nodeBuilders) == 0 {
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Commatrix: pool %q control-plane check skipped: %v", poolName, err)
+	if err != nil {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+			"%s: pool %q control-plane-only -> false (list nodes failed: %v)",
+			commatrixLogMsgPrefix, poolName, err))
+
+		return false
+	}
+
+	if len(nodeBuilders) == 0 {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+			"%s: pool %q control-plane-only -> false (no nodes)",
+			commatrixLogMsgPrefix, poolName))
 
 		return false
 	}
 
 	for _, nb := range nodeBuilders {
-		if !commatrixNodeHasControlPlaneRole(nb) {
+		if !commatrixNodeHasRoleLabel(nb, commatrixNodeRoleLabelMaster, commatrixNodeRoleLabelControlPlane) {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+				"%s: pool %q control-plane-only -> false (node %q is not control-plane)",
+				commatrixLogMsgPrefix, poolName, commatrixNodeBuilderName(nb)))
+
 			return false
 		}
 	}
+
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+		"%s: pool %q control-plane-only -> true (%d node(s))",
+		commatrixLogMsgPrefix, poolName, len(nodeBuilders)))
 
 	return true
 }
@@ -656,25 +838,59 @@ func commatrixPoolIsControlPlaneOnly(poolName string) bool {
 // commatrixPoolIsStorageOnly reports whether every node in the MCP is storage-role without worker or control-plane roles.
 func commatrixPoolIsStorageOnly(poolName string) bool {
 	nodeBuilders, err := commatrixPoolNodeBuilders(poolName)
-	if err != nil || len(nodeBuilders) == 0 {
+	if err != nil {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+			"%s: pool %q storage-only -> false (list nodes failed: %v)",
+			commatrixLogMsgPrefix, poolName, err))
+
+		return false
+	}
+
+	if len(nodeBuilders) == 0 {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+			"%s: pool %q storage-only -> false (no nodes)",
+			commatrixLogMsgPrefix, poolName))
+
 		return false
 	}
 
 	for _, nb := range nodeBuilders {
 		if nb == nil || nb.Object == nil || nb.Object.Labels == nil {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+				"%s: pool %q storage-only -> false (node %q has nil builder or labels)",
+				commatrixLogMsgPrefix, poolName, commatrixNodeBuilderName(nb)))
+
 			return false
 		}
 
-		nodeLabels := nb.Object.Labels
-		_, hasStorage := nodeLabels["node-role.kubernetes.io/storage"]
-		if !hasStorage {
+		if !commatrixNodeHasRoleLabel(nb, commatrixNodeRoleLabelStorage) {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+				"%s: pool %q storage-only -> false (node %q lacks storage role)",
+				commatrixLogMsgPrefix, poolName, commatrixNodeBuilderName(nb)))
+
 			return false
 		}
 
-		if commatrixNodeHasWorkerRole(nb) || commatrixNodeHasControlPlaneRole(nb) {
+		if commatrixNodeHasRoleLabel(nb, commatrixNodeRoleLabelWorker) {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+				"%s: pool %q storage-only -> false (node %q has worker role)",
+				commatrixLogMsgPrefix, poolName, commatrixNodeBuilderName(nb)))
+
+			return false
+		}
+
+		if commatrixNodeHasRoleLabel(nb, commatrixNodeRoleLabelMaster, commatrixNodeRoleLabelControlPlane) {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+				"%s: pool %q storage-only -> false (node %q has control-plane role)",
+				commatrixLogMsgPrefix, poolName, commatrixNodeBuilderName(nb)))
+
 			return false
 		}
 	}
+
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+		"%s: pool %q storage-only -> true (%d node(s))",
+		commatrixLogMsgPrefix, poolName, len(nodeBuilders)))
 
 	return true
 }
@@ -682,21 +898,43 @@ func commatrixPoolIsStorageOnly(poolName string) bool {
 // commatrixPoolHasWorkerNodes reports whether the MCP contains at least one worker or non-control-plane node.
 func commatrixPoolHasWorkerNodes(poolName string) bool {
 	nodeBuilders, err := commatrixPoolNodeBuilders(poolName)
-	if err != nil || len(nodeBuilders) == 0 {
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Commatrix: pool %q worker check skipped: %v", poolName, err)
+	if err != nil {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+			"%s: pool %q has-worker-nodes -> false (list nodes failed: %v)",
+			commatrixLogMsgPrefix, poolName, err))
+
+		return false
+	}
+
+	if len(nodeBuilders) == 0 {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+			"%s: pool %q has-worker-nodes -> false (no nodes)",
+			commatrixLogMsgPrefix, poolName))
 
 		return false
 	}
 
 	for _, nb := range nodeBuilders {
-		if commatrixNodeHasWorkerRole(nb) {
+		if commatrixNodeHasRoleLabel(nb, commatrixNodeRoleLabelWorker) {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+				"%s: pool %q has-worker-nodes -> true (node %q has worker role)",
+				commatrixLogMsgPrefix, poolName, commatrixNodeBuilderName(nb)))
+
 			return true
 		}
 
-		if !commatrixNodeHasControlPlaneRole(nb) {
+		if !commatrixNodeHasRoleLabel(nb, commatrixNodeRoleLabelMaster, commatrixNodeRoleLabelControlPlane) {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+				"%s: pool %q has-worker-nodes -> true (node %q has no control-plane role)",
+				commatrixLogMsgPrefix, poolName, commatrixNodeBuilderName(nb)))
+
 			return true
 		}
 	}
+
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+		"%s: pool %q has-worker-nodes -> false (all %d node(s) are control-plane only)",
+		commatrixLogMsgPrefix, poolName, len(nodeBuilders)))
 
 	return false
 }
@@ -705,11 +943,11 @@ func commatrixPoolHasWorkerNodes(poolName string) bool {
 func commatrixInferMasterMCPoolNameFromPools(pools []string) string {
 	onCluster := commatrixFilterPoolsOnCluster(pools)
 
-	klog.Infof("Commatrix: infer master MCP from on-cluster pools: %v", onCluster)
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: infer master MachineConfigPool from on-cluster pools: %v", commatrixLogMsgPrefix, onCluster))
 
 	for _, poolName := range onCluster {
 		if strings.EqualFold(poolName, "master") {
-			klog.Infof("Commatrix: selected master MCP %q (standard pool name)", poolName)
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: selected master MachineConfigPool %q (standard pool name)", commatrixLogMsgPrefix, poolName))
 
 			return poolName
 		}
@@ -717,7 +955,7 @@ func commatrixInferMasterMCPoolNameFromPools(pools []string) string {
 
 	for _, poolName := range onCluster {
 		if commatrixPoolIsControlPlaneOnly(poolName) {
-			klog.Infof("Commatrix: selected master MCP %q (control-plane nodes only)", poolName)
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: selected master MachineConfigPool %q (control-plane nodes only)", commatrixLogMsgPrefix, poolName))
 
 			return poolName
 		}
@@ -726,13 +964,13 @@ func commatrixInferMasterMCPoolNameFromPools(pools []string) string {
 	for _, poolName := range onCluster {
 		lower := strings.ToLower(poolName)
 		if strings.Contains(lower, "master") && !strings.Contains(lower, "storage") {
-			klog.Infof("Commatrix: selected master MCP %q (name contains master)", poolName)
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: selected master MachineConfigPool %q (name contains master)", commatrixLogMsgPrefix, poolName))
 
 			return poolName
 		}
 	}
 
-	klog.Infof("Commatrix: could not infer master MCP from pools %v", onCluster)
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: could not infer master MachineConfigPool from pools %v", commatrixLogMsgPrefix, onCluster))
 
 	return ""
 }
@@ -742,7 +980,8 @@ func commatrixInferSecureMCPoolNameFromPools(pools []string) string {
 	onCluster := commatrixFilterPoolsOnCluster(pools)
 	masterPool := commatrixInferMasterMCPoolNameFromPools(onCluster)
 
-	klog.Infof("Commatrix: infer secure MCP from on-cluster pools=%v masterPool=%q", onCluster, masterPool)
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: infer secure worker MachineConfigPool from on-cluster pools=%v masterPool=%q",
+		commatrixLogMsgPrefix, onCluster, masterPool))
 
 	candidates := make([]string, 0, len(onCluster))
 
@@ -752,19 +991,22 @@ func commatrixInferSecureMCPoolNameFromPools(pools []string) string {
 		}
 
 		if commatrixPoolIsControlPlaneOnly(poolName) {
-			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Commatrix: skip pool %q for secure MCP (control-plane only)", poolName)
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+				"%s: skip pool %q for secure worker MCP (control-plane only)", commatrixLogMsgPrefix, poolName))
 
 			continue
 		}
 
 		if commatrixPoolIsStorageOnly(poolName) {
-			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Commatrix: skip pool %q for secure MCP (storage-only nodes)", poolName)
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+				"%s: skip pool %q for secure worker MCP (storage-only nodes)", commatrixLogMsgPrefix, poolName))
 
 			continue
 		}
 
 		if !commatrixPoolHasWorkerNodes(poolName) {
-			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Commatrix: skip pool %q for secure MCP (no worker nodes)", poolName)
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+				"%s: skip pool %q for secure worker MCP (no worker nodes)", commatrixLogMsgPrefix, poolName))
 
 			continue
 		}
@@ -779,11 +1021,12 @@ func commatrixInferSecureMCPoolNameFromPools(pools []string) string {
 			}
 		}
 
-		klog.Infof("Commatrix: no worker MCP matched heuristics; fallback non-master candidates: %v", candidates)
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: no worker MachineConfigPool matched heuristics; fallback non-master candidates: %v",
+			commatrixLogMsgPrefix, candidates))
 	}
 
 	if len(candidates) == 0 {
-		klog.Infof("Commatrix: could not infer secure MCP from pools %v", onCluster)
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: could not infer secure worker MachineConfigPool from pools %v", commatrixLogMsgPrefix, onCluster))
 
 		return ""
 	}
@@ -791,9 +1034,10 @@ func commatrixInferSecureMCPoolNameFromPools(pools []string) string {
 	sort.Strings(candidates)
 
 	if len(candidates) > 1 {
-		klog.Infof("Commatrix: multiple secure MCP candidates %v; using %q", candidates, candidates[0])
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: multiple secure worker MachineConfigPool candidates %v; using %q",
+			commatrixLogMsgPrefix, candidates, candidates[0]))
 	} else {
-		klog.Infof("Commatrix: selected secure MCP %q", candidates[0])
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: selected secure worker MachineConfigPool %q", commatrixLogMsgPrefix, candidates[0]))
 	}
 
 	return candidates[0]
@@ -803,16 +1047,23 @@ func commatrixInferSecureMCPoolNameFromPools(pools []string) string {
 func commatrixSetWorkerFromNodeName(nodeName string) error {
 	nb, errPull := nodes.Pull(APIClient, nodeName)
 	if errPull != nil {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: pull secure worker node %q failed: %v", commatrixLogMsgPrefix, nodeName, errPull))
+
 		return fmt.Errorf("pull node %q: %w", nodeName, errPull)
 	}
 
 	ips, errIPs := commatrixNodeProbeIPs(nb)
 	if errIPs != nil {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: resolve probe IPs for secure worker node %q failed: %v",
+			commatrixLogMsgPrefix, nodeName, errIPs))
+
 		return errIPs
 	}
 
 	commatrixWorkflow.run.SecureWorkerName = nodeName
 	commatrixWorkflow.run.SecureWorkerIPs = ips
+
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: recorded secure worker node %q probe IPs %v", commatrixLogMsgPrefix, nodeName, ips))
 
 	return nil
 }
@@ -827,17 +1078,35 @@ func commatrixResolveConnectivityTopology() error {
 
 	masters, err := nodes.List(APIClient, metav1.ListOptions{LabelSelector: commatrixMasterLabelSelector()})
 	if err != nil {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: list control-plane nodes (selector %q) failed: %v",
+			commatrixLogMsgPrefix, commatrixMasterLabelSelector(), err))
+
 		return fmt.Errorf("list master nodes: %w", err)
 	}
 
 	if len(masters) == 0 {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: no nodes matched control-plane label selector %q",
+			commatrixLogMsgPrefix, commatrixMasterLabelSelector()))
+
 		return fmt.Errorf("no nodes matched master label %q", commatrixMasterLabelSelector())
 	}
 
-	klog.Infof("Commatrix: resolving connectivity topology from master node %q", masters[0].Definition.Name)
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: resolving connectivity topology (master label selector %q, %d control-plane node(s))",
+		commatrixLogMsgPrefix, commatrixMasterLabelSelector(), len(masters)))
+
+	for i, master := range masters {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: control-plane candidate[%d]=%q",
+			commatrixLogMsgPrefix, i, master.Definition.Name))
+	}
+
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: using control-plane node %q for master API probe IPs",
+		commatrixLogMsgPrefix, masters[0].Definition.Name))
 
 	masterIPs, err := commatrixNodeProbeIPs(masters[0])
 	if err != nil {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: resolve probe IPs for control-plane node %q failed: %v",
+			commatrixLogMsgPrefix, masters[0].Definition.Name, err))
+
 		return err
 	}
 
@@ -845,24 +1114,35 @@ func commatrixResolveConnectivityTopology() error {
 
 	nftNode := strings.TrimSpace(commatrixWorkflow.nftProbeNodeName)
 	if nftNode == "" {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: nft probe node not set (call commatrixPrimeWorkflowForVerification first)",
+			commatrixLogMsgPrefix))
+
 		return fmt.Errorf("secure worker: nft probe node not recorded (prime verification workflow first)")
 	}
 
 	if err := commatrixSetWorkerFromNodeName(nftNode); err != nil {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: record secure worker from nft probe node %q failed: %v",
+			commatrixLogMsgPrefix, nftNode, err))
+
 		return fmt.Errorf("secure worker %q: %w", nftNode, err)
 	}
 
 	if err := commatrixResolveSecureProbePorts(nftNode); err != nil {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: resolve secure worker probe ports on %q failed: %v",
+			commatrixLogMsgPrefix, nftNode, err))
+
 		return fmt.Errorf("resolve secure worker probe ports on %q: %w", nftNode, err)
 	}
 
-	klog.Infof(
-		"Commatrix: connectivity topology masterIPs=%v secureWorker=%q secureWorkerIPs=%v openPort=%d blockedPort=%d",
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+		"%s: connectivity topology masterIPs=%v secureWorker=%q secureWorkerIPs=%v openPort=%d blockedPort=%d nftProbeNode=%q",
+		commatrixLogMsgPrefix,
 		commatrixWorkflow.run.MasterIPs,
 		commatrixWorkflow.run.SecureWorkerName,
 		commatrixWorkflow.run.SecureWorkerIPs,
 		commatrixWorkflow.run.SecureOpenPort,
-		commatrixWorkflow.run.SecureBlockedPort)
+		commatrixWorkflow.run.SecureBlockedPort,
+		nftNode))
 
 	return nil
 }
@@ -908,8 +1188,18 @@ func commatrixNodeProbeIPs(nb *nodes.Builder) ([]string, error) {
 	}
 
 	if len(ips) == 0 {
-		return nil, fmt.Errorf("no external IPv4/IPv6 address on node %q", nb.Definition.Name)
+		nodeName := ""
+		if nb != nil {
+			nodeName = nb.Definition.Name
+		}
+
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: node %q has no external IPv4/IPv6 address for TCP probes",
+			commatrixLogMsgPrefix, nodeName))
+
+		return nil, fmt.Errorf("no external IPv4/IPv6 address on node %q", nodeName)
 	}
+
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: node %q probe IPs: %v", commatrixLogMsgPrefix, nb.Definition.Name, ips))
 
 	return ips, nil
 }
@@ -924,24 +1214,30 @@ func commatrixNodesFromMachineConfigPools(poolNames []string) ([]string, error) 
 	for _, poolName := range poolNames {
 		mcpB, errPull := mco.Pull(APIClient, poolName)
 		if errPull != nil {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: pull MachineConfigPool %q failed: %v", commatrixLogMsgPrefix, poolName, errPull))
+
 			return nil, fmt.Errorf("MachineConfigPool %q: %w", poolName, errPull)
 		}
 
 		mcpObj, errGet := mcpB.Get()
 		if errGet != nil {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: get MachineConfigPool %q failed: %v", commatrixLogMsgPrefix, poolName, errGet))
+
 			return nil, fmt.Errorf("get MachineConfigPool %q: %w", poolName, errGet)
 		}
 
 		sel := mcpObj.Spec.NodeSelector
 		if sel == nil {
-			klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
-				"MachineConfigPool %q has nil nodeSelector; skipping node enumeration for this pool", poolName)
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+				"MachineConfigPool %q has nil nodeSelector; skipping node enumeration for this pool", poolName))
 
 			continue
 		}
 
 		nodeLabelSel, errLS := metav1.LabelSelectorAsSelector(sel)
 		if errLS != nil {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: MachineConfigPool %q nodeSelector invalid: %v", commatrixLogMsgPrefix, poolName, errLS))
+
 			return nil, fmt.Errorf("MachineConfigPool %q nodeSelector: %w", poolName, errLS)
 		}
 
@@ -952,6 +1248,9 @@ func commatrixNodesFromMachineConfigPools(poolNames []string) ([]string, error) 
 
 		nodeList, errList := nodes.List(APIClient, metav1.ListOptions{LabelSelector: labelStr})
 		if errList != nil {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: list nodes for pool %q (selector %q) failed: %v",
+				commatrixLogMsgPrefix, poolName, labelStr, errList))
+
 			return nil, fmt.Errorf("list nodes for pool %q (%s): %w", poolName, labelStr, errList)
 		}
 
@@ -970,15 +1269,22 @@ func commatrixNodesFromMachineConfigPools(poolNames []string) ([]string, error) 
 
 	sort.Strings(out)
 
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: pools %v -> node name(s) %v", commatrixLogMsgPrefix, poolNames, out))
+
 	return out, nil
 }
 
 // commatrixRunOnNodeHostShell runs shellCmd on the node host via the MCO daemon pod (chroot /rootfs).
-func commatrixRunOnNodeHostShell(nodeName, shellCmd string) (string, error) {
+func commatrixRunOnNodeHostShell(nodeName, purpose, shellCmd string) (string, error) {
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+		"%s: on node %q (%s), shell: %s", commatrixLogMsgPrefix, nodeName, purpose, shellCmd))
+
 	return commatrixRunOnNodeHostDebug(nodeName, []string{"chroot", "/rootfs", "sh", "-c", shellCmd})
 }
 
 // commatrixVerifyHostFirewallConnectivity probes TCP reachability from the test runner using ports from openshift_filter rules.
+//
+//nolint:funlen // connectivity: topology summary plus master/secure/peer probe cases with logging.
 func commatrixVerifyHostFirewallConnectivity(_ SpecContext) {
 	By("Resolving cluster topology for connectivity probes")
 
@@ -993,15 +1299,24 @@ func commatrixVerifyHostFirewallConnectivity(_ SpecContext) {
 	blockedPortStr := strconv.Itoa(blockedPort)
 	apiPortStr := strconv.Itoa(commatrixAPIPort)
 
-	klog.Infof(
-		"Commatrix connectivity probes: masterIPs=%v secure=%s/%v openPort=%s blockedPort=%s",
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+		"%s: starting connectivity probes from test runner masterIPs=%v secureWorker=%q secureWorkerIPs=%v apiPort=%s openPort=%s blockedPort=%s",
+		commatrixLogMsgPrefix,
 		commatrixWorkflow.run.MasterIPs,
 		commatrixWorkflow.run.SecureWorkerName,
 		commatrixWorkflow.run.SecureWorkerIPs,
+		apiPortStr,
 		openPortStr,
-		blockedPortStr)
+		blockedPortStr))
 
 	tryProbe := func(desc string, addrs []string, port string, expectConnect bool) {
+		expectLabel := "connect"
+		if !expectConnect {
+			expectLabel = "blocked"
+		}
+
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: connectivity probe %q -> addrs=%v port=%s expect=%s",
+			commatrixLogMsgPrefix, desc, addrs, port, expectLabel))
 		By(desc)
 
 		Expect(commatrixTryTCPProbesFromRunner(desc, addrs, port, expectConnect)).NotTo(HaveOccurred(), "%s", desc)
@@ -1050,12 +1365,15 @@ func commatrixVerifyHostFirewallConnectivity(_ SpecContext) {
 		peerIPs, errIP := commatrixNodeProbeIPs(peerNB)
 		Expect(errIP).NotTo(HaveOccurred())
 
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: peer secure-pool worker probe on node %q addrs=%v port=%s expect=blocked",
+			commatrixLogMsgPrefix, peerName, peerIPs, blockedPortStr))
+
 		tryProbe(
 			fmt.Sprintf("Peer secure-pool worker blocked tcp/%s from test runner", blockedPortStr),
 			peerIPs, blockedPortStr, false)
 	} else {
-		klog.Infof("Commatrix: skipping peer secure-pool worker probe (securePool=%q nodes=%d)",
-			securePool, len(securePoolPeerNames))
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: skipping peer secure-pool worker probe (securePool=%q nodeCount=%d need >=2)",
+			commatrixLogMsgPrefix, securePool, len(securePoolPeerNames)))
 	}
 }
 
@@ -1068,7 +1386,12 @@ func commatrixRunJournalKernelGrep(nodeName, since, until, grepFilter string) (s
 
 	shellCmd += fmt.Sprintf(` 2>/dev/null | grep -F %q || true`, grepFilter)
 
-	return commatrixRunOnNodeHostShell(nodeName, shellCmd)
+	purpose := fmt.Sprintf("kernel journal grep %q since %q", grepFilter, since)
+	if strings.TrimSpace(until) != "" {
+		purpose = fmt.Sprintf("kernel journal grep %q since %q until %q", grepFilter, since, until)
+	}
+
+	return commatrixRunOnNodeHostShell(nodeName, purpose, shellCmd)
 }
 
 // commatrixWaitForJournalKernelGrep runs journalctl -k --since on a node (via MCO daemon pod), greps for filter,
@@ -1088,6 +1411,10 @@ func commatrixWaitForJournalKernelGrep(
 			}
 
 			lines = commatrixParseJournalKernelLines(raw)
+
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+				"%s: waiting for kernel journal lines on node %q filter=%q since=%q (have %d, need %d)",
+				commatrixLogMsgPrefix, nodeName, grepFilter, since, len(lines), minLines))
 
 			return len(lines) >= minLines, nil
 		})
@@ -1135,7 +1462,9 @@ func commatrixExpectFirewallLogRateLimitsInWindow(lines []string, windowLabel st
 
 	for _, prefix := range []string{commatrixFirewallLogPrefixNoSpace, commatrixFirewallLogPrefixWithSpace} {
 		n := counts[prefix]
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("firewall journal %s: bucket %q: %d line(s)", windowLabel, prefix, n)
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+			"%s: firewall journal window %q bucket %q: %d line(s) (max %d/min)",
+			commatrixLogMsgPrefix, windowLabel, prefix, n, commatrixFirewallRateLimitPerMinute))
 
 		Expect(n).To(BeNumerically("<=", commatrixFirewallRateLimitPerMinute),
 			"firewall journal %s: bucket %q: %d lines (max %d per minute)", windowLabel, prefix, n, commatrixFirewallRateLimitPerMinute)
@@ -1145,6 +1474,10 @@ func commatrixExpectFirewallLogRateLimitsInWindow(lines []string, windowLabel st
 // commatrixFirewallLogBucket classifies a journal line into a firewall log-prefix bucket for rate-limit checks.
 func commatrixFirewallLogBucket(line string) (string, bool) {
 	if strings.Contains(line, "TCP_TEST") {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+			"%s: firewall journal line -> false (TCP_TEST probe line)",
+			commatrixLogMsgPrefix))
+
 		return "", false
 	}
 
@@ -1152,15 +1485,31 @@ func commatrixFirewallLogBucket(line string) (string, bool) {
 
 	i := strings.Index(line, tag)
 	if i < 0 {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+			"%s: firewall journal line -> false (no %q prefix): %q",
+			commatrixLogMsgPrefix, tag, commatrixLogOutputSnippet(line, 200)))
+
 		return "", false
 	}
 
 	switch msg := line[i+len(tag):]; {
 	case strings.HasPrefix(msg, "firewall IN="):
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+			"%s: firewall journal line -> true (bucket %q)",
+			commatrixLogMsgPrefix, commatrixFirewallLogPrefixWithSpace))
+
 		return commatrixFirewallLogPrefixWithSpace, true
 	case strings.HasPrefix(msg, "firewallIN="):
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+			"%s: firewall journal line -> true (bucket %q)",
+			commatrixLogMsgPrefix, commatrixFirewallLogPrefixNoSpace))
+
 		return commatrixFirewallLogPrefixNoSpace, true
 	default:
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+			"%s: firewall journal line -> false (kernel message not firewall log): %q",
+			commatrixLogMsgPrefix, commatrixLogOutputSnippet(msg, 200)))
+
 		return "", false
 	}
 }
@@ -1181,15 +1530,25 @@ func commatrixVerifyFirewallJournal(_ SpecContext) {
 
 	keyword := commatrixNFTablesLogKeyword
 
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: starting firewall journal checks on node %q probeIPs=%v keyword=%q",
+		commatrixLogMsgPrefix, journalNode, journalProbeIPs, keyword))
+
 	By(fmt.Sprintf("Verifying firewall log rate limits on node %s (two 1-minute windows)", journalNode))
+
+	window1Label := fmt.Sprintf("%s to %s", commatrixJournalSinceTwoMinutes, commatrixJournalSinceOneMinute)
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: reading firewall journal window %q on node %q", commatrixLogMsgPrefix, window1Label, journalNode))
 
 	window1Raw, errWin1 := commatrixRunJournalKernelGrep(
 		journalNode, commatrixJournalSinceTwoMinutes, commatrixJournalSinceOneMinute, keyword)
 	Expect(errWin1).NotTo(HaveOccurred(), "firewall journal window 1 on %s: %s", journalNode, window1Raw)
 
 	window1Lines := commatrixParseJournalKernelLines(window1Raw)
-	commatrixExpectFirewallLogRateLimitsInWindow(window1Lines,
-		fmt.Sprintf("%s to %s", commatrixJournalSinceTwoMinutes, commatrixJournalSinceOneMinute))
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: firewall journal window %q on node %q: %d kernel line(s) matching %q",
+		commatrixLogMsgPrefix, window1Label, journalNode, len(window1Lines), keyword))
+	commatrixExpectFirewallLogRateLimitsInWindow(window1Lines, window1Label)
+
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: reading firewall journal window %q on node %q",
+		commatrixLogMsgPrefix, commatrixJournalSinceOneMinute, journalNode))
 
 	window2Raw, errWin2 := commatrixRunJournalKernelGrep(journalNode, commatrixJournalSinceOneMinute, "", keyword)
 	Expect(errWin2).NotTo(HaveOccurred(), "firewall journal window 2 on %s: %s", journalNode, window2Raw)
@@ -1197,14 +1556,15 @@ func commatrixVerifyFirewallJournal(_ SpecContext) {
 	window2Lines := commatrixParseJournalKernelLines(window2Raw)
 	if len(window2Lines) == 0 {
 		warnMsg := fmt.Sprintf(
-			"firewall journal: no kernel log lines matching %q in the last minute on %s; "+
-				"skipping window-2 rate-limit checks (traffic may be quiet). Last output:\n%s",
-			keyword, journalNode, window2Raw)
+			"%s: firewall journal window %q on node %q: no kernel lines matching %q; "+
+				"skipping window-2 rate-limit checks (traffic may be quiet). Last output: %q",
+			commatrixLogMsgPrefix, commatrixJournalSinceOneMinute, journalNode, keyword,
+			commatrixLogOutputSnippet(window2Raw, 500))
 		klog.Warning(warnMsg)
 		_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: %s\n", warnMsg)
 	} else {
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("firewall journal: %d line(s) matching %q on %s in the last minute",
-			len(window2Lines), keyword, journalNode)
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: firewall journal window %q on node %q: %d kernel line(s) matching %q",
+			commatrixLogMsgPrefix, commatrixJournalSinceOneMinute, journalNode, len(window2Lines), keyword))
 
 		commatrixExpectFirewallLogRateLimitsInWindow(window2Lines, commatrixJournalSinceOneMinute)
 	}
@@ -1219,7 +1579,8 @@ func commatrixVerifyFirewallJournal(_ SpecContext) {
 
 	Expect(testPort).To(BeNumerically(">", 0), "journal TCP_TEST probe port must be resolved from nft rules")
 
-	klog.Infof("Commatrix journal: node=%q probeIPs=%v TCP_TEST port=%d", journalNode, journalProbeIPs, testPort)
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: journal TCP_TEST setup on node %q probeIPs=%v blockedPort=%d chain=%s",
+		commatrixLogMsgPrefix, journalNode, journalProbeIPs, testPort, commatrixNFTablesOpenshiftChain))
 
 	By(fmt.Sprintf("Injecting TCP_TEST log rule on node %s for tcp/%d", journalNode, testPort))
 
@@ -1227,17 +1588,22 @@ func commatrixVerifyFirewallJournal(_ SpecContext) {
 		`set -e; nft insert rule inet openshift_filter %s tcp dport %d log prefix \"TCP_TEST \" drop`,
 		commatrixNFTablesOpenshiftChain, testPort)
 
-	nftInsertCmdOut, nftInsertCmdErr := commatrixRunOnNodeHostShell(journalNode, nftInsertHostShellCmd)
+	nftInsertCmdOut, nftInsertCmdErr := commatrixRunOnNodeHostShell(
+		journalNode, fmt.Sprintf("insert TCP_TEST nft drop rule for tcp/%d", testPort), nftInsertHostShellCmd)
 	Expect(nftInsertCmdErr).NotTo(HaveOccurred(), "nft insert TCP_TEST rule on %s: %s", journalNode, nftInsertCmdOut)
 
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: inserted TCP_TEST rule on node %q: %q",
+		commatrixLogMsgPrefix, journalNode, commatrixLogOutputSnippet(nftInsertCmdOut, 200)))
+
 	defer func() {
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("removing TCP_TEST rule on %s (best-effort)", journalNode)
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: removing TCP_TEST rule on node %q (best-effort)",
+			commatrixLogMsgPrefix, journalNode))
 
 		nftDeleteLogRuleShellCmd := fmt.Sprintf(
 			`HANDLE=$(nft -a list chain inet openshift_filter %s 2>/dev/null | grep TCP_TEST | tail -1 | sed -E "s/.*handle ([0-9]+).*/\\1/"); [ -n "$HANDLE" ] && nft delete rule inet openshift_filter %s handle "$HANDLE" || true`,
 			commatrixNFTablesOpenshiftChain, commatrixNFTablesOpenshiftChain)
 
-		_, _ = commatrixRunOnNodeHostShell(journalNode, nftDeleteLogRuleShellCmd)
+		_, _ = commatrixRunOnNodeHostShell(journalNode, "remove TCP_TEST nft rule", nftDeleteLogRuleShellCmd)
 	}()
 
 	portStr := strconv.Itoa(testPort)
@@ -1245,12 +1611,21 @@ func commatrixVerifyFirewallJournal(_ SpecContext) {
 	By(fmt.Sprintf("Probing %v:%d from test runner (TCP_TEST drop expected)", journalProbeIPs, testPort))
 
 	for _, probeTargetIP := range journalProbeIPs {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+			"%s: journal TCP_TEST probe from test runner -> %s:%d (expect drop)",
+			commatrixLogMsgPrefix, probeTargetIP, testPort))
+
 		if err := commatrixRunTCPProbeFromRunner(false, probeTargetIP, portStr); err != nil {
-			klog.Infof("Commatrix journal: probe %s:%d (drop expected): %v", probeTargetIP, testPort, err)
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+				"%s: journal TCP_TEST probe %s:%d failed as expected: %v",
+				commatrixLogMsgPrefix, probeTargetIP, testPort, err))
 		}
 	}
 
 	By("Verifying TCP_TEST in kernel journal")
+
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: waiting for TCP_TEST kernel journal lines on node %q (min 1, timeout 90s)",
+		commatrixLogMsgPrefix, journalNode))
 
 	tcpTestLines, tcpTestRaw, err := commatrixWaitForJournalKernelGrep(
 		journalNode, commatrixJournalSinceOneMinute, "TCP_TEST", 1, 3*time.Second, 90*time.Second)
@@ -1259,6 +1634,9 @@ func commatrixVerifyFirewallJournal(_ SpecContext) {
 		journalProbeIPs, testPort, journalNode, len(tcpTestLines), tcpTestRaw)
 
 	Expect(tcpTestLines).NotTo(BeEmpty(), "TCP_TEST journal: expected ≥1 TCP_TEST log line on %s", journalNode)
+
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: found %d TCP_TEST kernel journal line(s) on node %q: %v",
+		commatrixLogMsgPrefix, len(tcpTestLines), journalNode, tcpTestLines))
 
 	dptNeedle := fmt.Sprintf("DPT=%d", testPort)
 

--- a/tests/system-tests/rdscore/internal/rdscorecommon/commatrix.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/commatrix.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -23,16 +24,21 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	mcv1 "github.com/openshift/api/machineconfiguration/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/mco"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nodes"
-	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	apimachinerytypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
+	goclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/inittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/system-tests/internal/remote"
 
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/system-tests/rdscore/internal/rdscoreinittools"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/system-tests/rdscore/internal/rdscoreparams"
@@ -52,11 +58,11 @@ const (
 	commatrixFirewallLogPrefixWithSpace = "firewall " // kernel: firewall IN=...
 	commatrixFirewallRateLimitPerMinute = 5
 	// Fixed probe targets and waits (not configurable; same across OCP host-firewall test plans).
-	commatrixAPIPort            = 6443
-	commatrixKubeletPort        = 10250
-	commatrixClosedTCPPort      = 9999
-	commatrixNFTablesLogKeyword              = "firewall"
-	commatrixHostFirewallMCNameSubstring   = "nftables-commatrix"
+	commatrixAPIPort                     = 6443
+	commatrixKubeletPort                 = 10250
+	commatrixClosedTCPPort               = 9999
+	commatrixNFTablesLogKeyword          = "firewall"
+	commatrixHostFirewallMCNameSubstring = "nftables-commatrix"
 )
 
 // commatrixMCPStableWait is how long apply/revert waits for all MachineConfigPools to stabilize.
@@ -65,7 +71,7 @@ const commatrixMCPStableWait = 15 * time.Minute
 // journalShortTimePrefixRe parses journalctl short-iso timestamps for firewall log rate-limit checks.
 var journalShortTimePrefixRe = regexp.MustCompile(`^([A-Z][a-z]{2}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2})`)
 
-// commatrixJSONPatchOp is one RFC 6902 operation for oc patch --type=json.
+// commatrixJSONPatchOp is one RFC 6902 operation for MachineConfiguration cluster JSON patches.
 type commatrixJSONPatchOp struct {
 	Op   string `json:"op"`
 	Path string `json:"path"`
@@ -142,11 +148,11 @@ func commatrixBuildJSONPatchRemoveNDPNFT(clusterJSON string) ([]byte, error) {
 	return patchBytes, nil
 }
 
-// commatrixRunTopology holds node names and InternalIPs resolved for connectivity checks.
+// commatrixRunTopology holds node names and probe IPs resolved for connectivity checks.
 type commatrixRunTopology struct {
 	SecureWorkerName string
-	MasterIP         string
-	SecureWorkerIP   string
+	MasterIPs        []string
+	SecureWorkerIPs  []string
 }
 
 // commatrixWorkflowState carries shared state for the ordered Commatrix spec.
@@ -167,39 +173,32 @@ func commatrixResetWorkflow() {
 	commatrixWorkflow = commatrixWorkflowState{}
 }
 
-// commatrixPrimeWorkflowForVerification discovers applied host-firewall pools from format-mc artifacts
-// or commatrix MachineConfigs already on the cluster (rules must be applied before 95003/95004).
+// commatrixPrimeWorkflowForVerification discovers host-firewall pools from commatrix MachineConfigs
+// already on the cluster (95003/95004 assume platform prep or 95002 apply completed there).
 func commatrixPrimeWorkflowForVerification() error {
 	if commatrixWorkflow.mcApplied {
 		return nil
 	}
 
-	var poolNames []string
-
-	if mcDir, err := commatrixFormatMCDir(); err == nil {
-		rels, listErr := commatrixListMachineConfigYAMLRels(mcDir)
-		if listErr == nil && len(rels) > 0 {
-			poolNames = commatrixMachineConfigPoolNamesFromMCRels(rels)
-			commatrixWorkflow.generatedMCPoolNames = append([]string(nil), poolNames...)
-		}
+	poolNames, err := commatrixHostFirewallPoolNamesFromCluster()
+	if err != nil {
+		return fmt.Errorf("discover host-firewall MachineConfig pools: %w", err)
 	}
 
 	if len(poolNames) == 0 {
-		pools, err := commatrixHostFirewallPoolNamesFromCluster()
-		if err != nil {
-			return fmt.Errorf("discover host-firewall MachineConfig pools: %w", err)
-		}
+		detail := commatrixHostFirewallMCDiscoveryDetail()
+		klog.Warningf("Commatrix: host-firewall MC discovery failed: %s", detail)
 
-		if len(pools) == 0 {
-			return fmt.Errorf(
-				"no commatrix host-firewall MachineConfigs found on cluster or under %s/%s; "+
-					"apply rules before connectivity/journal tests (run 95001/95002 or platform prep)",
-				strings.TrimSpace(RDSCoreConfig.CommatrixOutputDir), commatrixFormatMCSubdir)
-		}
-
-		poolNames = pools
-		commatrixWorkflow.generatedMCPoolNames = append([]string(nil), pools...)
+		return fmt.Errorf(
+			"no commatrix host-firewall MachineConfigs on cluster (look for %q in mc names); %s; "+
+				"apply rules before connectivity/journal tests (run 95001/95002 or platform prep)",
+			commatrixHostFirewallMCNameSubstring, detail)
 	}
+
+	klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+		"Commatrix: discovered host-firewall MC pools on cluster: %v", poolNames)
+
+	commatrixWorkflow.generatedMCPoolNames = append([]string(nil), poolNames...)
 
 	securePool := commatrixInferSecureMCPoolNameFromPools(poolNames)
 	if securePool == "" {
@@ -234,34 +233,40 @@ func commatrixPrimeWorkflowForVerification() error {
 	return nil
 }
 
+func commatrixMachineConfigPoolRole(mcObj *mcv1.MachineConfig) string {
+	if role := strings.TrimSpace(mcObj.Labels[mcv1.MachineConfigRoleLabelKey]); role != "" {
+		return role
+	}
+
+	// Commatrix MC names encode the pool (e.g. 98-nftables-commatrix-appworker-mcp-a) even when the role label is absent.
+	markerIdx := strings.Index(mcObj.Name, commatrixHostFirewallMCNameSubstring)
+	if markerIdx < 0 {
+		return ""
+	}
+
+	return strings.TrimSpace(strings.TrimPrefix(mcObj.Name[markerIdx+len(commatrixHostFirewallMCNameSubstring):], "-"))
+}
+
 func commatrixHostFirewallPoolNamesFromCluster() ([]string, error) {
-	ocGetMcJSONCmdOut, ocGetMcJSONCmdErr := commatrixRunOC("get", "mc", "-o", "json")
-	if ocGetMcJSONCmdErr != nil {
-		return nil, ocGetMcJSONCmdErr
-	}
-
-	var mcList struct {
-		Items []struct {
-			Metadata struct {
-				Name   string            `json:"name"`
-				Labels map[string]string `json:"labels"`
-			} `json:"metadata"`
-		} `json:"items"`
-	}
-
-	if err := json.Unmarshal([]byte(ocGetMcJSONCmdOut), &mcList); err != nil {
-		return nil, fmt.Errorf("parse MachineConfig list: %w", err)
+	mcList, err := mco.ListMC(APIClient)
+	if err != nil {
+		return nil, err
 	}
 
 	seen := make(map[string]struct{})
 	pools := make([]string, 0)
 
-	for _, item := range mcList.Items {
-		if !strings.Contains(item.Metadata.Name, commatrixHostFirewallMCNameSubstring) {
+	for _, mcBuilder := range mcList {
+		if mcBuilder == nil || mcBuilder.Object == nil {
 			continue
 		}
 
-		role := strings.TrimSpace(item.Metadata.Labels["machineconfiguration.openshift.io/role"])
+		mcObj := mcBuilder.Object
+		if !strings.Contains(mcObj.Name, commatrixHostFirewallMCNameSubstring) {
+			continue
+		}
+
+		role := commatrixMachineConfigPoolRole(mcObj)
 		if role == "" {
 			continue
 		}
@@ -280,10 +285,56 @@ func commatrixHostFirewallPoolNamesFromCluster() ([]string, error) {
 	return pools, nil
 }
 
+// commatrixHostFirewallMCDiscoveryDetail summarizes ListMC results to explain empty pool discovery.
+func commatrixHostFirewallMCDiscoveryDetail() string {
+	mcList, err := mco.ListMC(APIClient)
+	if err != nil {
+		return fmt.Sprintf("list MachineConfigs failed: %v", err)
+	}
+
+	var commatrixNames []string
+
+	for _, mcBuilder := range mcList {
+		if mcBuilder == nil || mcBuilder.Object == nil {
+			continue
+		}
+
+		if strings.Contains(mcBuilder.Object.Name, commatrixHostFirewallMCNameSubstring) {
+			commatrixNames = append(commatrixNames, mcBuilder.Object.Name)
+		}
+	}
+
+	sort.Strings(commatrixNames)
+
+	var b strings.Builder
+
+	_, _ = fmt.Fprintf(&b, "listed %d MachineConfig(s)", len(mcList))
+
+	if len(commatrixNames) == 0 {
+		_, _ = fmt.Fprintf(&b, ", none matching %q in metadata.name", commatrixHostFirewallMCNameSubstring)
+	} else {
+		_, _ = fmt.Fprintf(&b, ", %d matching %q but no pool role resolved: %v",
+			len(commatrixNames), commatrixHostFirewallMCNameSubstring, commatrixNames)
+	}
+
+	if APIClient != nil && APIClient.Config != nil {
+		_, _ = fmt.Fprintf(&b, "; API server %s", APIClient.Config.Host)
+	}
+
+	if kubeconfig := strings.TrimSpace(os.Getenv("KUBECONFIG")); kubeconfig != "" {
+		_, _ = fmt.Fprintf(&b, "; KUBECONFIG=%s", kubeconfig)
+	} else {
+		b.WriteString("; KUBECONFIG unset (using default kubeconfig or in-cluster config)")
+	}
+
+	return b.String()
+}
+
 func commatrixMasterLabelSelector() string {
 	return labels.Set(inittools.GeneralConfig.ControlPlaneLabelMap).String()
 }
 
+// commatrixRunOC runs the oc CLI (required for the commatrix plugin subcommand only).
 func commatrixRunOC(ocCmdArgs ...string) (string, error) {
 	ocCmd := exec.Command("oc", ocCmdArgs...)
 	ocCmd.Env = os.Environ()
@@ -291,6 +342,150 @@ func commatrixRunOC(ocCmdArgs ...string) (string, error) {
 	ocCmdOut, ocCmdErr := ocCmd.CombinedOutput()
 
 	return string(ocCmdOut), ocCmdErr
+}
+
+func commatrixLoadMachineConfigYAML(path string) (*mcv1.MachineConfig, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var mc mcv1.MachineConfig
+
+	if err := yaml.Unmarshal(raw, &mc); err != nil {
+		return nil, fmt.Errorf("parse MachineConfig %s: %w", path, err)
+	}
+
+	if strings.TrimSpace(mc.Name) == "" {
+		return nil, fmt.Errorf("MachineConfig %s has no metadata.name", path)
+	}
+
+	return &mc, nil
+}
+
+func commatrixApplyMachineConfigYAML(path string) error {
+	mc, err := commatrixLoadMachineConfigYAML(path)
+	if err != nil {
+		return err
+	}
+
+	if err := APIClient.AttachScheme(mcv1.Install); err != nil {
+		return err
+	}
+
+	existing := &mcv1.MachineConfig{}
+
+	getErr := APIClient.Get(context.TODO(), goclient.ObjectKey{Name: mc.Name}, existing)
+	if getErr != nil {
+		if !k8serrors.IsNotFound(getErr) {
+			return fmt.Errorf("get MachineConfig %q: %w", mc.Name, getErr)
+		}
+
+		return APIClient.Create(context.TODO(), mc)
+	}
+
+	mc.ResourceVersion = existing.ResourceVersion
+
+	return APIClient.Update(context.TODO(), mc)
+}
+
+func commatrixDeleteMachineConfigYAML(path string) error {
+	mc, err := commatrixLoadMachineConfigYAML(path)
+	if err != nil {
+		return err
+	}
+
+	mcBuilder := mco.NewMCBuilder(APIClient, mc.Name)
+	if mcBuilder == nil {
+		return fmt.Errorf("create MachineConfig builder for %q", mc.Name)
+	}
+
+	if !mcBuilder.Exists() {
+		return nil
+	}
+
+	return mcBuilder.Delete()
+}
+
+func commatrixPatchMachineConfigurationClusterMerge(patchPath string) error {
+	patchBytes, err := os.ReadFile(patchPath)
+	if err != nil {
+		return err
+	}
+
+	patchBytes = bytes.TrimSpace(patchBytes)
+	if len(patchBytes) == 0 {
+		return fmt.Errorf("NDP patch file %s is empty", patchPath)
+	}
+
+	mcCluster := &operatorv1.MachineConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+	}
+
+	return APIClient.Patch(
+		context.TODO(),
+		mcCluster,
+		goclient.RawPatch(apimachinerytypes.MergePatchType, patchBytes),
+	)
+}
+
+func commatrixGetMachineConfigurationClusterJSON() ([]byte, error) {
+	mcCluster := &operatorv1.MachineConfiguration{}
+
+	err := APIClient.Get(context.TODO(), goclient.ObjectKey{Name: "cluster"}, mcCluster)
+	if err != nil {
+		return nil, fmt.Errorf("get machineconfiguration/cluster: %w", err)
+	}
+
+	clusterJSON, err := json.Marshal(mcCluster)
+	if err != nil {
+		return nil, fmt.Errorf("marshal machineconfiguration/cluster: %w", err)
+	}
+
+	return clusterJSON, nil
+}
+
+func commatrixPatchMachineConfigurationClusterJSON(patch []byte) error {
+	if len(patch) == 0 || string(patch) == "[]" {
+		return nil
+	}
+
+	mcCluster := &operatorv1.MachineConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+	}
+
+	return APIClient.Patch(
+		context.TODO(),
+		mcCluster,
+		goclient.RawPatch(apimachinerytypes.JSONPatchType, patch),
+	)
+}
+
+func commatrixFormatMCPStatusSnapshot() (string, error) {
+	mcpList, err := mco.ListMCP(APIClient)
+	if err != nil {
+		return "", err
+	}
+
+	var b strings.Builder
+
+	for _, mcpBuilder := range mcpList {
+		if mcpBuilder == nil || mcpBuilder.Object == nil {
+			continue
+		}
+
+		mcpObj := mcpBuilder.Object
+
+		_, _ = fmt.Fprintf(&b, "%s  updated=%d ready=%d machine=%d degraded=%d\n",
+			mcpObj.Name,
+			mcpObj.Status.UpdatedMachineCount,
+			mcpObj.Status.ReadyMachineCount,
+			mcpObj.Status.MachineCount,
+			mcpObj.Status.DegradedMachineCount,
+		)
+	}
+
+	return strings.TrimRight(b.String(), "\n"), nil
 }
 
 // commatrixRunLocalShell runs shellCmd on the machine executing the test (not via oc debug).
@@ -311,44 +506,103 @@ func commatrixRunLocalShell(shellCmd string) error {
 
 // commatrixRunTCPProbeFromRunner runs nc -z from the test runner to host:port.
 func commatrixRunTCPProbeFromRunner(expectConnect bool, host, port string) error {
-	ncCmd := exec.Command("nc", "-z", "-v", "-w3", host, port)
+	args := []string{"-z", "-v", "-w3"}
+
+	if ip := net.ParseIP(host); ip != nil {
+		if ip.To4() != nil {
+			args = append([]string{"-4"}, args...)
+		} else {
+			args = append([]string{"-6"}, args...)
+		}
+	}
+
+	args = append(args, host, port)
+
+	ncCmd := exec.Command("nc", args...)
 	ncCmd.Env = os.Environ()
 
 	ncCmdOut, ncCmdErr := ncCmd.CombinedOutput()
+	ncCmdLine := strings.Join(args, " ")
 
 	if expectConnect {
 		if ncCmdErr != nil {
-			klog.Infof("local: nc -z -v -w3 %s %s failed: %v\n%s", host, port, ncCmdErr, string(ncCmdOut))
+			klog.Infof("local: nc %s failed: %v\n%s", ncCmdLine, ncCmdErr, string(ncCmdOut))
 		} else {
-			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("local: nc -z -v -w3 %s %s\n%s", host, port, string(ncCmdOut))
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("local: nc %s\n%s", ncCmdLine, string(ncCmdOut))
 		}
 
 		return ncCmdErr
 	}
 
 	if ncCmdErr == nil {
-		klog.Infof("local: nc unexpectedly connected to %s:%s\n%s", host, port, string(ncCmdOut))
+		klog.Infof("local: nc unexpectedly connected (%s)\n%s", ncCmdLine, string(ncCmdOut))
 
 		return fmt.Errorf("expected connection to %s:%s to fail, but nc succeeded", host, port)
 	}
 
-	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("local: nc to %s:%s failed as expected: %v\n%s", host, port, ncCmdErr, string(ncCmdOut))
+	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("local: nc to %s failed as expected (%s): %v\n%s",
+		host, ncCmdLine, ncCmdErr, string(ncCmdOut))
 
 	return nil
 }
 
-// commatrixRunOnNodeHostDebug runs `oc debug node/<name> -- <hostDebugCmdArgs...>` so `chroot /host` is the node root.
-func commatrixRunOnNodeHostDebug(nodeName string, hostDebugCmdArgs ...string) (string, error) {
-	ocDebugCmdArgs := append([]string{"debug", "node/" + nodeName, "--"}, hostDebugCmdArgs...)
+func commatrixProbeLabel(addr string) string {
+	if ip := net.ParseIP(addr); ip != nil && ip.To4() == nil {
+		return "IPv6 " + addr
+	}
 
-	hostDebugCmdOut, hostDebugCmdErr := commatrixRunOC(ocDebugCmdArgs...)
+	return "IPv4 " + addr
+}
+
+// commatrixTryTCPProbesFromRunner probes host:port on each address. When expectConnect is true, at least one
+// address must succeed; when false, every address must fail to connect.
+func commatrixTryTCPProbesFromRunner(desc string, addrs []string, port string, expectConnect bool) error {
+	if len(addrs) == 0 {
+		return fmt.Errorf("%s: no internal IP addresses to probe", desc)
+	}
+
+	if expectConnect {
+		var failures []string
+
+		for _, addr := range addrs {
+			label := commatrixProbeLabel(addr)
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("TCP probe %s via %s -> %s:%s (expect connect)",
+				desc, label, addr, port)
+
+			if err := commatrixRunTCPProbeFromRunner(true, addr, port); err == nil {
+				klog.V(rdscoreparams.RDSCoreLogLevel).Infof("TCP probe %s succeeded via %s", desc, label)
+
+				return nil
+			} else {
+				failures = append(failures, fmt.Sprintf("%s: %v", label, err))
+			}
+		}
+
+		return fmt.Errorf("%s: none of %v reachable from test runner (%s)",
+			desc, addrs, strings.Join(failures, "; "))
+	}
+
+	for _, addr := range addrs {
+		label := commatrixProbeLabel(addr)
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("TCP probe %s via %s -> %s:%s (expect blocked)",
+			desc, label, addr, port)
+
+		if err := commatrixRunTCPProbeFromRunner(false, addr, port); err != nil {
+			return fmt.Errorf("%s via %s: %w", desc, label, err)
+		}
+	}
+
+	return nil
+}
+
+// commatrixRunOnNodeHostDebug runs cmd on the node host via the MCO daemon pod (chroot /rootfs).
+func commatrixRunOnNodeHostDebug(nodeName string, cmd []string) (string, error) {
+	hostDebugCmdOut, hostDebugCmdErr := remote.ExecuteOnNodeWithDebugPod(cmd, nodeName)
 
 	if hostDebugCmdErr != nil {
-		klog.Infof("oc debug node/%s -- %s failed: %v\n%s",
-			nodeName, strings.Join(hostDebugCmdArgs, " "), hostDebugCmdErr, hostDebugCmdOut)
+		klog.Infof("node %s exec %v failed: %v\n%s", nodeName, cmd, hostDebugCmdErr, hostDebugCmdOut)
 	} else {
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("oc debug node/%s -- %s\n%s",
-			nodeName, strings.Join(hostDebugCmdArgs, " "), hostDebugCmdOut)
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("node %s exec %v\n%s", nodeName, cmd, hostDebugCmdOut)
 	}
 
 	return hostDebugCmdOut, hostDebugCmdErr
@@ -500,7 +754,7 @@ func commatrixListMachineConfigYAMLRels(root string) ([]string, error) {
 }
 
 // commatrixFindNodeDisruptionPolicyPatch returns the absolute path to a single node-disruption-policy.yaml
-// under root (e.g. format-mc). MachineConfig apply skips that file; merged via oc patch on MachineConfiguration cluster instead.
+// under root (e.g. format-mc). MachineConfig apply skips that file; merged via API patch on MachineConfiguration cluster instead.
 // If none are present, returns ("", nil). More than one match is an error.
 func commatrixFindNodeDisruptionPolicyPatch(root string) (string, error) {
 	var matches []string
@@ -904,22 +1158,22 @@ func commatrixSetWorkerFromNodeName(nodeName string) error {
 		return fmt.Errorf("pull node %q: %w", nodeName, errPull)
 	}
 
-	ip, errIP := commatrixNodeInternalIP(nb)
-	if errIP != nil {
-		return errIP
+	ips, errIPs := commatrixNodeProbeIPs(nb)
+	if errIPs != nil {
+		return errIPs
 	}
 
 	commatrixWorkflow.run.SecureWorkerName = nodeName
-	commatrixWorkflow.run.SecureWorkerIP = ip
+	commatrixWorkflow.run.SecureWorkerIPs = ips
 
 	return nil
 }
 
-// commatrixResolveConnectivityTopology fills master and secure-worker names and InternalIPs for connectivity and journal specs.
+// commatrixResolveConnectivityTopology fills master and secure-worker names and probe IPs for connectivity and journal specs.
 func commatrixResolveConnectivityTopology() error {
-	commatrixWorkflow.run.MasterIP = ""
+	commatrixWorkflow.run.MasterIPs = nil
 	commatrixWorkflow.run.SecureWorkerName = ""
-	commatrixWorkflow.run.SecureWorkerIP = ""
+	commatrixWorkflow.run.SecureWorkerIPs = nil
 
 	masters, err := nodes.List(APIClient, metav1.ListOptions{LabelSelector: commatrixMasterLabelSelector()})
 	if err != nil {
@@ -930,12 +1184,12 @@ func commatrixResolveConnectivityTopology() error {
 		return fmt.Errorf("no nodes matched master label %q", commatrixMasterLabelSelector())
 	}
 
-	masterIP, err := commatrixNodeInternalIP(masters[0])
+	masterIPs, err := commatrixNodeProbeIPs(masters[0])
 	if err != nil {
 		return err
 	}
 
-	commatrixWorkflow.run.MasterIP = masterIP
+	commatrixWorkflow.run.MasterIPs = masterIPs
 
 	nftNode := strings.TrimSpace(commatrixWorkflow.nftProbeNodeName)
 	if nftNode == "" {
@@ -949,18 +1203,27 @@ func commatrixResolveConnectivityTopology() error {
 	return nil
 }
 
-func commatrixNodeInternalIP(nb *nodes.Builder) (string, error) {
-	if nb.Object == nil {
-		return "", fmt.Errorf("node %q has nil Object", nb.Definition.Name)
-	}
+// commatrixNodeProbeIPs returns IPv4 then IPv6 node addresses for nc probes via eco-goinfra nodes helpers.
+func commatrixNodeProbeIPs(nb *nodes.Builder) ([]string, error) {
+	var ips []string
 
-	for _, a := range nb.Object.Status.Addresses {
-		if a.Type == corev1.NodeInternalIP {
-			return a.Address, nil
+	if ipv4, err := nb.ExternalIPv4Network(); err == nil {
+		if addr := strings.TrimSpace(ipv4); addr != "" {
+			ips = append(ips, addr)
 		}
 	}
 
-	return "", fmt.Errorf("no internal IP on node %q", nb.Object.Name)
+	if ipv6, err := nb.ExternalIPv6Network(); err == nil {
+		if addr := strings.TrimSpace(ipv6); addr != "" {
+			ips = append(ips, addr)
+		}
+	}
+
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("no external IPv4/IPv6 address on node %q", nb.Definition.Name)
+	}
+
+	return ips, nil
 }
 
 // commatrixFormatMCDir returns the direct oc commatrix mc output directory (<output_dir>/format-mc).
@@ -979,10 +1242,10 @@ func commatrixWaitAllMachineConfigPoolsStable(stepLabel string) {
 	err := mco.ListMCPWaitToBeStableFor(APIClient, 90*time.Second, commatrixMCPStableWait)
 	Expect(err).NotTo(HaveOccurred(), "%s: all MCPs did not stabilize within timeout", stepLabel)
 
-	ocGetMcpCmdOut, ocGetMcpCmdErr := commatrixRunOC("get", "mcp", "-o", "wide")
-	Expect(ocGetMcpCmdErr).NotTo(HaveOccurred(), "%s: oc get mcp", stepLabel)
+	mcpSnapshot, mcpSnapshotErr := commatrixFormatMCPStatusSnapshot()
+	Expect(mcpSnapshotErr).NotTo(HaveOccurred(), "%s: list MachineConfigPools", stepLabel)
 
-	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("%s: MCP snapshot after stable wait:\n%s", stepLabel, strings.TrimSpace(ocGetMcpCmdOut))
+	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("%s: MCP snapshot after stable wait:\n%s", stepLabel, mcpSnapshot)
 }
 
 // commatrixMachineConfigPoolNameFromMCRel extracts the MachineConfigPool name from a commatrix MachineConfig path.
@@ -1113,7 +1376,8 @@ func commatrixNodesFromMachineConfigPools(poolNames []string) ([]string, error) 
 
 // commatrixStopNFTOnNode stops nftables on one node (best-effort during suite cleanup).
 func commatrixStopNFTOnNode(nodeName string) {
-	stopNftablesCmdOut, stopNftablesCmdErr := commatrixRunOnNodeHostDebug(nodeName, "chroot", "/host", "sh", "-c", "systemctl stop nftables || true")
+	stopNftablesCmdOut, stopNftablesCmdErr := commatrixRunOnNodeHostDebug(nodeName,
+		[]string{"chroot", "/rootfs", "sh", "-c", "systemctl stop nftables || true"})
 	if stopNftablesCmdErr != nil {
 		klog.Errorf("stop nftables on %s: %v\n%s", nodeName, stopNftablesCmdErr, stopNftablesCmdOut)
 
@@ -1123,9 +1387,9 @@ func commatrixStopNFTOnNode(nodeName string) {
 	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("stop nftables on %s: %s", nodeName, strings.TrimSpace(stopNftablesCmdOut))
 }
 
-// commatrixRunOnNodeHostShell runs shellCmd on the node host via oc debug (chroot /host).
+// commatrixRunOnNodeHostShell runs shellCmd on the node host via the MCO daemon pod (chroot /rootfs).
 func commatrixRunOnNodeHostShell(nodeName, shellCmd string) (string, error) {
-	return commatrixRunOnNodeHostDebug(nodeName, "chroot", "/host", "sh", "-c", shellCmd)
+	return commatrixRunOnNodeHostDebug(nodeName, []string{"chroot", "/rootfs", "sh", "-c", shellCmd})
 }
 
 // commatrixGenerateArtifacts runs oc commatrix generate for mc and butane, runs the butane CLI in the same
@@ -1214,11 +1478,9 @@ func commatrixApplyHostFirewallMC(_ SpecContext) {
 
 	By("Patching MachineConfiguration cluster node disruption policy")
 
-	ocPatchNdpCmdOut, ocPatchNdpCmdErr := commatrixRunOC("patch", "machineconfiguration", "cluster",
-		"--type=merge", "--patch-file="+ndp)
-	Expect(ocPatchNdpCmdErr).NotTo(HaveOccurred(), "cluster NDP patch failed: %s", ocPatchNdpCmdOut)
+	Expect(commatrixPatchMachineConfigurationClusterMerge(ndp)).NotTo(HaveOccurred(), "cluster NDP patch failed")
 
-	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("patched NDP from %s: %s", ndp, strings.TrimSpace(ocPatchNdpCmdOut))
+	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("patched NDP from %s", ndp)
 	commatrixWorkflow.ndpApplied = true
 
 	commatrixWorkflow.generatedMCPoolNames = commatrixMachineConfigPoolNamesFromMCRels(mcRels)
@@ -1259,10 +1521,9 @@ func commatrixApplyHostFirewallMC(_ SpecContext) {
 	for _, rel := range applyRels {
 		abs := filepath.Join(mcDir, filepath.FromSlash(rel))
 
-		ocApplyMcCmdOut, ocApplyMcCmdErr := commatrixRunOC("apply", "-f", abs)
-		Expect(ocApplyMcCmdErr).NotTo(HaveOccurred(), "oc apply %q failed: %s", rel, ocApplyMcCmdOut)
+		Expect(commatrixApplyMachineConfigYAML(abs)).NotTo(HaveOccurred(), "apply MachineConfig %q", rel)
 
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("apply: applied %q: %s", rel, strings.TrimSpace(ocApplyMcCmdOut))
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("apply: applied %q", rel)
 	}
 
 	commatrixWaitAllMachineConfigPoolsStable("apply host firewall MCs")
@@ -1300,7 +1561,8 @@ func commatrixApplyHostFirewallMC(_ SpecContext) {
 		func(context.Context) (bool, error) {
 			var hostDebugCmdErr error
 
-			nftOpenshiftChainCmdOut, hostDebugCmdErr = commatrixRunOnNodeHostDebug(nftNode, "chroot", "/host", "sh", "-c", nftOpenshiftChainShellCmd)
+			nftOpenshiftChainCmdOut, hostDebugCmdErr = commatrixRunOnNodeHostDebug(nftNode,
+				[]string{"chroot", "/rootfs", "sh", "-c", nftOpenshiftChainShellCmd})
 			if hostDebugCmdErr != nil {
 				klog.V(rdscoreparams.RDSCoreLogLevel).Infof("nft list (retry) on %s: %v", nftNode, hostDebugCmdErr)
 
@@ -1320,24 +1582,22 @@ func commatrixVerifyHostFirewallConnectivity(_ SpecContext) {
 
 	Expect(commatrixResolveConnectivityTopology()).NotTo(HaveOccurred())
 
-	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Commatrix connectivity probes: masterIP=%s secure=%s/%s",
-		commatrixWorkflow.run.MasterIP, commatrixWorkflow.run.SecureWorkerName, commatrixWorkflow.run.SecureWorkerIP)
+	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Commatrix connectivity probes: masterIPs=%v secure=%s/%v",
+		commatrixWorkflow.run.MasterIPs, commatrixWorkflow.run.SecureWorkerName, commatrixWorkflow.run.SecureWorkerIPs)
 
 	apiPort := strconv.Itoa(commatrixAPIPort)
 	kubeletPort := strconv.Itoa(commatrixKubeletPort)
 	closedPort := strconv.Itoa(commatrixClosedTCPPort)
 
-	tryProbe := func(desc, dstHost, port string, expectConnect bool) {
+	tryProbe := func(desc string, addrs []string, port string, expectConnect bool) {
 		By(desc)
 
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("TCP probe %s -> %s:%s (expect connect=%v)", desc, dstHost, port, expectConnect)
-
-		Expect(commatrixRunTCPProbeFromRunner(expectConnect, dstHost, port)).NotTo(HaveOccurred(), "%s", desc)
+		Expect(commatrixTryTCPProbesFromRunner(desc, addrs, port, expectConnect)).NotTo(HaveOccurred(), "%s", desc)
 	}
 
-	tryProbe("Master API reachable from test runner", commatrixWorkflow.run.MasterIP, apiPort, true)
+	tryProbe("Master API reachable from test runner", commatrixWorkflow.run.MasterIPs, apiPort, true)
 
-	tryProbe("Secure-pool worker API blocked from test runner", commatrixWorkflow.run.SecureWorkerIP, apiPort, false)
+	tryProbe("Secure-pool worker API blocked from test runner", commatrixWorkflow.run.SecureWorkerIPs, apiPort, false)
 
 	var securePoolPeerNames []string
 
@@ -1364,17 +1624,17 @@ func commatrixVerifyHostFirewallConnectivity(_ SpecContext) {
 		peerNB, errPull := nodes.Pull(APIClient, peerName)
 		Expect(errPull).NotTo(HaveOccurred())
 
-		peerIP, errIP := commatrixNodeInternalIP(peerNB)
+		peerIPs, errIP := commatrixNodeProbeIPs(peerNB)
 		Expect(errIP).NotTo(HaveOccurred())
 
-		tryProbe("Peer secure-pool worker API blocked from test runner", peerIP, apiPort, false)
+		tryProbe("Peer secure-pool worker API blocked from test runner", peerIPs, apiPort, false)
 	} else {
 		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Skipping peer secure-pool worker API probe: fewer than two secure-pool nodes")
 	}
 
-	tryProbe("Secure-pool worker kubelet reachable from test runner", commatrixWorkflow.run.SecureWorkerIP, kubeletPort, true)
+	tryProbe("Secure-pool worker kubelet reachable from test runner", commatrixWorkflow.run.SecureWorkerIPs, kubeletPort, true)
 
-	tryProbe("Closed test port blocked on secure-pool worker", commatrixWorkflow.run.SecureWorkerIP, closedPort, false)
+	tryProbe("Closed test port blocked on secure-pool worker", commatrixWorkflow.run.SecureWorkerIPs, closedPort, false)
 }
 
 func commatrixRunJournalKernelGrep(nodeName, since, until, grepFilter string) (string, error) {
@@ -1385,10 +1645,10 @@ func commatrixRunJournalKernelGrep(nodeName, since, until, grepFilter string) (s
 
 	shellCmd += fmt.Sprintf(` 2>/dev/null | grep -F %q || true`, grepFilter)
 
-	return commatrixRunOnNodeHostDebug(nodeName, "chroot", "/host", "sh", "-c", shellCmd)
+	return commatrixRunOnNodeHostShell(nodeName, shellCmd)
 }
 
-// commatrixWaitForJournalKernelGrep runs journalctl -k --since on a node (via oc debug), greps for filter,
+// commatrixWaitForJournalKernelGrep runs journalctl -k --since on a node (via MCO daemon pod), greps for filter,
 // and polls until at least minLines kernel lines are present.
 func commatrixWaitForJournalKernelGrep(
 	nodeName, since, grepFilter string,
@@ -1495,8 +1755,8 @@ func commatrixVerifyFirewallJournal(_ SpecContext) {
 	journalNB, errPull := nodes.Pull(APIClient, journalNode)
 	Expect(errPull).NotTo(HaveOccurred(), "pull journal node %q", journalNode)
 
-	journalInternalIP, errIP := commatrixNodeInternalIP(journalNB)
-	Expect(errIP).NotTo(HaveOccurred(), "internal IP for journal node for %s", journalNode)
+	journalProbeIPs, errIP := commatrixNodeProbeIPs(journalNB)
+	Expect(errIP).NotTo(HaveOccurred(), "probe IP(s) for journal node %s", journalNode)
 
 	keyword := commatrixNFTablesLogKeyword
 
@@ -1529,7 +1789,6 @@ func commatrixVerifyFirewallJournal(_ SpecContext) {
 	}
 
 	apiPort := commatrixAPIPort
-	probeTargetIP := journalInternalIP
 
 	By(fmt.Sprintf("Injecting TCP_TEST log rule on node %s", journalNode))
 
@@ -1550,10 +1809,14 @@ func commatrixVerifyFirewallJournal(_ SpecContext) {
 		_, _ = commatrixRunOnNodeHostShell(journalNode, nftDeleteLogRuleShellCmd)
 	}()
 
-	By(fmt.Sprintf("Probing %s:%d from test runner", probeTargetIP, apiPort))
+	portStr := strconv.Itoa(apiPort)
 
-	if err := commatrixRunTCPProbeFromRunner(false, probeTargetIP, strconv.Itoa(apiPort)); err != nil {
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("local nc to %s:%d (drop expected): %v", probeTargetIP, apiPort, err)
+	By(fmt.Sprintf("Probing %v:%d from test runner (TCP_TEST drop expected)", journalProbeIPs, apiPort))
+
+	for _, probeTargetIP := range journalProbeIPs {
+		if err := commatrixRunTCPProbeFromRunner(false, probeTargetIP, portStr); err != nil {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("local nc to %s:%d (drop expected): %v", probeTargetIP, apiPort, err)
+		}
 	}
 
 	By("Verifying TCP_TEST in kernel journal")
@@ -1561,8 +1824,8 @@ func commatrixVerifyFirewallJournal(_ SpecContext) {
 	tcpTestLines, tcpTestRaw, err := commatrixWaitForJournalKernelGrep(
 		journalNode, commatrixJournalSinceOneMinute, "TCP_TEST", 1, 3*time.Second, 90*time.Second)
 	Expect(err).NotTo(HaveOccurred(),
-		"TCP_TEST journal: expected at least one TCP_TEST kernel log line after nc to %s:%d on %s (got %d); last output:\n%s",
-		probeTargetIP, apiPort, journalNode, len(tcpTestLines), tcpTestRaw)
+		"TCP_TEST journal: expected at least one TCP_TEST kernel log line after nc to %v:%d on %s (got %d); last output:\n%s",
+		journalProbeIPs, apiPort, journalNode, len(tcpTestLines), tcpTestRaw)
 
 	Expect(tcpTestLines).NotTo(BeEmpty(), "TCP_TEST journal: expected ≥1 TCP_TEST log line on %s", journalNode)
 
@@ -1577,14 +1840,14 @@ func commatrixVerifyFirewallJournal(_ SpecContext) {
 }
 
 func commatrixRevertNDP() {
-	ocGetMcClusterCmdOut, ocGetMcClusterCmdErr := commatrixRunOC("get", "machineconfiguration", "cluster", "-o", "json")
-	if ocGetMcClusterCmdErr != nil {
-		klog.Errorf("revert NDP: get machineconfiguration/cluster: %v\n%s", ocGetMcClusterCmdErr, ocGetMcClusterCmdOut)
+	clusterJSON, errGet := commatrixGetMachineConfigurationClusterJSON()
+	if errGet != nil {
+		klog.Errorf("revert NDP: %v", errGet)
 
 		return
 	}
 
-	patch, errBuild := commatrixBuildJSONPatchRemoveNDPNFT(ocGetMcClusterCmdOut)
+	patch, errBuild := commatrixBuildJSONPatchRemoveNDPNFT(string(clusterJSON))
 	if errBuild != nil {
 		klog.Errorf("revert NDP: build JSON patch: %v", errBuild)
 
@@ -1597,15 +1860,13 @@ func commatrixRevertNDP() {
 		return
 	}
 
-	ocJSONPatchMcClusterCmdOut, ocJSONPatchMcClusterCmdErr := commatrixRunOC(
-		"patch", "machineconfiguration", "cluster", "--type=json", "-p", string(patch))
-	if ocJSONPatchMcClusterCmdErr != nil {
-		klog.Errorf("revert NDP: json patch failed: %v\n%s", ocJSONPatchMcClusterCmdErr, ocJSONPatchMcClusterCmdOut)
+	if errPatch := commatrixPatchMachineConfigurationClusterJSON(patch); errPatch != nil {
+		klog.Errorf("revert NDP: json patch failed: %v", errPatch)
 
 		return
 	}
 
-	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("revert NDP: %s", strings.TrimSpace(ocJSONPatchMcClusterCmdOut))
+	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("revert NDP: patched machineconfiguration/cluster")
 	commatrixWorkflow.ndpApplied = false
 }
 
@@ -1630,14 +1891,13 @@ func commatrixRevertHostFirewall() {
 	for _, rel := range commatrixWorkflow.appliedMCRels {
 		abs := filepath.Join(mcDir, filepath.FromSlash(rel))
 
-		ocDeleteMcCmdOut, ocDeleteMcCmdErr := commatrixRunOC("delete", "-f", abs, "--ignore-not-found=true")
-		if ocDeleteMcCmdErr != nil {
-			klog.Errorf("revert: oc delete %q: %v\n%s", rel, ocDeleteMcCmdErr, ocDeleteMcCmdOut)
+		if errDelete := commatrixDeleteMachineConfigYAML(abs); errDelete != nil {
+			klog.Errorf("revert: delete MachineConfig %q: %v", rel, errDelete)
 
 			continue
 		}
 
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("revert: deleted %q: %s", rel, strings.TrimSpace(ocDeleteMcCmdOut))
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("revert: deleted %q", rel)
 	}
 
 	if errWait := mco.ListMCPWaitToBeStableFor(APIClient, 90*time.Second, commatrixMCPStableWait); errWait != nil {
@@ -1667,13 +1927,13 @@ func CommatrixRevertAfterSpec() {
 	commatrixRevertHostFirewall()
 }
 
-// VerifyCommatrixHostFirewallArtifacts generates commatrix artifacts and validates embedded openshift_filter nftables.
+// VerifyCommatrixHostFirewallArtifacts (reportxml 95001) generates commatrix artifacts and validates embedded openshift_filter nftables.
 func VerifyCommatrixHostFirewallArtifacts(ctx SpecContext) {
 	commatrixResetWorkflow()
 	commatrixGenerateArtifacts(ctx)
 }
 
-// VerifyCommatrixHostFirewallApply applies host-firewall MachineConfigs and verifies nftables on a node.
+// VerifyCommatrixHostFirewallApply (reportxml 95002) applies host-firewall MachineConfigs and verifies nftables on a node.
 func VerifyCommatrixHostFirewallApply(ctx SpecContext) {
 	commatrixApplyHostFirewallMC(ctx)
 }

--- a/tests/system-tests/rdscore/internal/rdscorecommon/commatrix.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/commatrix.go
@@ -316,13 +316,14 @@ func commatrixTryTCPProbesFromRunner(desc string, addrs []string, port string, e
 			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("TCP probe %s via %s -> %s:%s (expect connect)",
 				desc, label, addr, port)
 
-			if err := commatrixRunTCPProbeFromRunner(true, addr, port); err == nil {
+			err := commatrixRunTCPProbeFromRunner(true, addr, port)
+			if err == nil {
 				klog.V(rdscoreparams.RDSCoreLogLevel).Infof("TCP probe %s succeeded via %s", desc, label)
 
 				return nil
-			} else {
-				failures = append(failures, fmt.Sprintf("%s: %v", label, err))
 			}
+
+			failures = append(failures, fmt.Sprintf("%s: %v", label, err))
 		}
 
 		return fmt.Errorf("%s: none of %v reachable from test runner (%s)",

--- a/tests/system-tests/rdscore/internal/rdscorecommon/commatrix.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/commatrix.go
@@ -117,7 +117,8 @@ func commatrixPrimeWorkflowForVerification() error {
 
 	if len(poolNames) == 0 {
 		detail := commatrixHostFirewallMCDiscoveryDetail()
-		klog.Warningf("%s: host-firewall MachineConfig discovery failed: %s", commatrixLogMsgPrefix, detail)
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: host-firewall MachineConfig discovery failed: %s",
+			commatrixLogMsgPrefix, detail))
 
 		return fmt.Errorf(
 			"no commatrix host-firewall MachineConfigs on cluster (look for %q in mc names); %s; "+
@@ -228,6 +229,10 @@ func commatrixHostFirewallPoolNamesFromCluster() ([]string, error) {
 
 	for _, mcBuilder := range mcList {
 		if mcBuilder == nil || mcBuilder.Object == nil {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+				"%s: skip nil MachineConfig builder while discovering host-firewall pools",
+				commatrixLogMsgPrefix))
+
 			continue
 		}
 
@@ -240,6 +245,10 @@ func commatrixHostFirewallPoolNamesFromCluster() ([]string, error) {
 
 		role := commatrixMachineConfigPoolRole(mcObj)
 		if role == "" {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+				"%s: skip MachineConfig %q (commatrix name match but pool role not resolved)",
+				commatrixLogMsgPrefix, mcObj.Name))
+
 			continue
 		}
 
@@ -470,13 +479,28 @@ func commatrixExtractOpenshiftFilterRuleLines(nftText string) []string {
 
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
-		if line == "" || strings.HasPrefix(line, "#") {
+		if line == "" {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+				"%s: skip openshift_filter nft line (empty)", commatrixLogMsgPrefix))
+
+			continue
+		}
+
+		if strings.HasPrefix(line, "#") {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+				"%s: skip openshift_filter nft line (comment): %q",
+				commatrixLogMsgPrefix, commatrixLogOutputSnippet(line, 200)))
+
 			continue
 		}
 
 		lower := strings.ToLower(line)
 		if strings.HasPrefix(lower, "table ") || strings.HasPrefix(lower, "chain ") ||
 			strings.HasPrefix(lower, "type ") || strings.HasPrefix(lower, "delete ") {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+				"%s: skip openshift_filter nft line (table/chain metadata): %q",
+				commatrixLogMsgPrefix, commatrixLogOutputSnippet(line, 200)))
+
 			continue
 		}
 
@@ -486,7 +510,13 @@ func commatrixExtractOpenshiftFilterRuleLines(nftText string) []string {
 			strings.HasPrefix(lower, "tcp ") || strings.HasPrefix(lower, "udp ") ||
 			strings.HasPrefix(lower, "ip ") || strings.HasPrefix(lower, "meta ") {
 			rules = append(rules, line)
+
+			continue
 		}
+
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+			"%s: skip openshift_filter nft line (no rule heuristics matched): %q",
+			commatrixLogMsgPrefix, commatrixLogOutputSnippet(line, 200)))
 	}
 
 	if len(rules) == 0 {
@@ -566,12 +596,18 @@ func commatrixParseAcceptedTCPDPortsFromNFTables(nftText string) map[int]struct{
 		lower := strings.ToLower(ruleLine)
 		if !strings.Contains(lower, "tcp") || !strings.Contains(lower, " dport ") {
 			skippedNotTCPDport++
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+				"%s: skip accept-port parse (not tcp dport rule): %q",
+				commatrixLogMsgPrefix, commatrixLogOutputSnippet(ruleLine, 200)))
 
 			continue
 		}
 
 		if !strings.Contains(lower, "accept") {
 			skippedNoAccept++
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+				"%s: skip accept-port parse (no accept action): %q",
+				commatrixLogMsgPrefix, commatrixLogOutputSnippet(ruleLine, 200)))
 
 			continue
 		}
@@ -579,6 +615,9 @@ func commatrixParseAcceptedTCPDPortsFromNFTables(nftText string) map[int]struct{
 		ports := commatrixExtractPortNumbersAfterDport(ruleLine)
 		if len(ports) == 0 {
 			skippedNoPorts++
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+				"%s: skip accept-port parse (no dport numbers parsed): %q",
+				commatrixLogMsgPrefix, commatrixLogOutputSnippet(ruleLine, 200)))
 
 			continue
 		}
@@ -629,9 +668,9 @@ func commatrixPickBlockedTCPPort(allowed map[int]struct{}) int {
 		}
 	}
 
-	klog.Warningf(
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
 		"%s: all blocked-port candidates %v are in nft accept rules %v; falling back to default closed port %d",
-		commatrixLogMsgPrefix, candidates, commatrixFormatPortSet(allowed), commatrixClosedTCPPort)
+		commatrixLogMsgPrefix, candidates, commatrixFormatPortSet(allowed), commatrixClosedTCPPort))
 
 	return commatrixClosedTCPPort
 }
@@ -685,8 +724,9 @@ func commatrixAllowedTCPDPortsFromNode(nodeName string) (map[int]struct{}, error
 
 	allowed := commatrixParseAcceptedTCPDPortsFromNFTables(nftOutput)
 	if len(allowed) == 0 {
-		klog.Warningf("%s: node %q has no accepted tcp dport rules in openshift_filter; nft output: %q",
-			commatrixLogMsgPrefix, nodeName, commatrixLogOutputSnippet(nftOutput, 1000))
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+			"%s: node %q has no accepted tcp dport rules in openshift_filter; nft output: %q",
+			commatrixLogMsgPrefix, nodeName, commatrixLogOutputSnippet(nftOutput, 1000)))
 
 		return nil, fmt.Errorf(
 			"no accepted tcp dport rules in openshift_filter on %q; nft output:\n%s",
@@ -1018,6 +1058,10 @@ func commatrixInferSecureMCPoolNameFromPools(pools []string) string {
 
 	for _, poolName := range onCluster {
 		if poolName == masterPool {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+				"%s: skip pool %q for secure worker MCP (same as master pool %q)",
+				commatrixLogMsgPrefix, poolName, masterPool))
+
 			continue
 		}
 
@@ -1312,6 +1356,10 @@ func commatrixNodesFromMachineConfigPools(poolNames []string) ([]string, error) 
 
 		for _, nb := range nodeList {
 			if nb == nil || nb.Object == nil {
+				klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+					"%s: skip nil node builder while listing nodes for pool %q",
+					commatrixLogMsgPrefix, poolName))
+
 				continue
 			}
 
@@ -1520,6 +1568,9 @@ func commatrixParseJournalKernelLines(raw string) []string {
 			strings.HasPrefix(line, "Removing debug pod") ||
 			strings.HasPrefix(line, "error: non-zero exit code") {
 			skippedDebugPod++
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+				"%s: skip journal line (debug-pod noise): %q",
+				commatrixLogMsgPrefix, commatrixLogOutputSnippet(line, 200)))
 
 			continue
 		}
@@ -1531,6 +1582,9 @@ func commatrixParseJournalKernelLines(raw string) []string {
 		}
 
 		skippedNonKernel++
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+			"%s: skip journal line (not kernel firewall output): %q",
+			commatrixLogMsgPrefix, commatrixLogOutputSnippet(line, 200)))
 	}
 
 	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
@@ -1550,6 +1604,10 @@ func commatrixExpectFirewallLogRateLimitsInWindow(lines []string, windowLabel st
 	for _, line := range lines {
 		prefix, ok := commatrixFirewallLogBucket(line)
 		if !ok {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+				"%s: skip firewall journal line for rate-limit bucket in window %q (no bucket match)",
+				commatrixLogMsgPrefix, windowLabel))
+
 			continue
 		}
 
@@ -1651,13 +1709,11 @@ func commatrixVerifyFirewallJournal(_ SpecContext) {
 
 	window2Lines := commatrixParseJournalKernelLines(window2Raw)
 	if len(window2Lines) == 0 {
-		warnMsg := fmt.Sprintf(
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
 			"%s: firewall journal window %q on node %q: no kernel lines matching %q; "+
 				"skipping window-2 rate-limit checks (traffic may be quiet). Last output: %q",
 			commatrixLogMsgPrefix, commatrixJournalSinceOneMinute, journalNode, keyword,
-			commatrixLogOutputSnippet(window2Raw, 500))
-		klog.Warning(warnMsg)
-		_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: %s\n", warnMsg)
+			commatrixLogOutputSnippet(window2Raw, 500)))
 	} else {
 		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf("%s: firewall journal window %q on node %q: %d kernel line(s) matching %q",
 			commatrixLogMsgPrefix, commatrixJournalSinceOneMinute, journalNode, len(window2Lines), keyword))
@@ -1699,7 +1755,17 @@ func commatrixVerifyFirewallJournal(_ SpecContext) {
 			`HANDLE=$(nft -a list chain inet openshift_filter %s 2>/dev/null | grep TCP_TEST | tail -1 | sed -E "s/.*handle ([0-9]+).*/\\1/"); [ -n "$HANDLE" ] && nft delete rule inet openshift_filter %s handle "$HANDLE" || true`,
 			commatrixNFTablesOpenshiftChain, commatrixNFTablesOpenshiftChain)
 
-		_, _ = commatrixRunOnNodeHostShell(journalNode, "remove TCP_TEST nft rule", nftDeleteLogRuleShellCmd)
+		nftDeleteOut, cleanupErr := commatrixRunOnNodeHostShell(
+			journalNode, "remove TCP_TEST nft rule", nftDeleteLogRuleShellCmd)
+		if cleanupErr != nil {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+				"%s: error cleaning up TCP_TEST nft rule on node %q: %v output=%q",
+				commatrixLogMsgPrefix, journalNode, cleanupErr, commatrixLogOutputSnippet(nftDeleteOut, 500)))
+		} else {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+				"%s: cleaned up TCP_TEST nft rule on node %q: %q",
+				commatrixLogMsgPrefix, journalNode, commatrixLogOutputSnippet(nftDeleteOut, 500)))
+		}
 	}()
 
 	portStr := strconv.Itoa(testPort)

--- a/tests/system-tests/rdscore/internal/rdscorecommon/commatrix.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/commatrix.go
@@ -244,6 +244,10 @@ func commatrixHostFirewallPoolNamesFromCluster() ([]string, error) {
 		}
 
 		if _, ok := seen[role]; ok {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+				"%s: skip MachineConfig %q (pool %q already discovered from earlier commatrix MC)",
+				commatrixLogMsgPrefix, mcObj.Name, role))
+
 			continue
 		}
 
@@ -431,6 +435,10 @@ func commatrixTryTCPProbesFromRunner(desc string, addrs []string, port string, e
 		}
 	}
 
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+		"%s: TCP probe %q blocked on all %d address(es) %v port %s as expected",
+		commatrixLogMsgPrefix, desc, len(addrs), addrs, port))
+
 	return nil
 }
 
@@ -550,21 +558,40 @@ func commatrixExtractPortNumbersAfterDport(ruleLine string) []int {
 // commatrixParseAcceptedTCPDPortsFromNFTables builds the set of TCP dports with accept rules in openshift_filter text.
 func commatrixParseAcceptedTCPDPortsFromNFTables(nftText string) map[int]struct{} {
 	allowed := make(map[int]struct{})
+	ruleLines := commatrixExtractOpenshiftFilterRuleLines(nftText)
 
-	for _, ruleLine := range commatrixExtractOpenshiftFilterRuleLines(nftText) {
+	var skippedNotTCPDport, skippedNoAccept, skippedNoPorts int
+
+	for _, ruleLine := range ruleLines {
 		lower := strings.ToLower(ruleLine)
 		if !strings.Contains(lower, "tcp") || !strings.Contains(lower, " dport ") {
+			skippedNotTCPDport++
+
 			continue
 		}
 
 		if !strings.Contains(lower, "accept") {
+			skippedNoAccept++
+
 			continue
 		}
 
-		for _, portNum := range commatrixExtractPortNumbersAfterDport(ruleLine) {
+		ports := commatrixExtractPortNumbersAfterDport(ruleLine)
+		if len(ports) == 0 {
+			skippedNoPorts++
+
+			continue
+		}
+
+		for _, portNum := range ports {
 			allowed[portNum] = struct{}{}
 		}
 	}
+
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+		"%s: parsed openshift_filter accept tcp dports from %d rule line(s): skippedNotTCPOrDport=%d skippedNoAccept=%d skippedNoPorts=%d -> %v",
+		commatrixLogMsgPrefix, len(ruleLines), skippedNotTCPDport, skippedNoAccept, skippedNoPorts,
+		commatrixFormatPortSet(allowed)))
 
 	return allowed
 }
@@ -722,6 +749,10 @@ func commatrixFilterPoolsOnCluster(pools []string) []string {
 	}
 
 	sort.Strings(filtered)
+
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+		"%s: filter pools on cluster: input=%v -> on-cluster=%v",
+		commatrixLogMsgPrefix, pools, filtered))
 
 	return filtered
 }
@@ -1151,12 +1182,18 @@ func commatrixResolveConnectivityTopology() error {
 func commatrixProbeHostAddr(raw string) (string, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+			"%s: probe host address %q -> error (empty address)", commatrixLogMsgPrefix, raw))
+
 		return "", fmt.Errorf("empty address")
 	}
 
 	if strings.Contains(raw, "/") {
 		ip, _, err := net.ParseCIDR(raw)
 		if err != nil {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+				"%s: probe host address %q -> error (parse CIDR: %v)", commatrixLogMsgPrefix, raw, err))
+
 			return "", fmt.Errorf("parse address %q: %w", raw, err)
 		}
 
@@ -1165,6 +1202,9 @@ func commatrixProbeHostAddr(raw string) (string, error) {
 
 	ip := net.ParseIP(raw)
 	if ip == nil {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+			"%s: probe host address %q -> error (invalid IP)", commatrixLogMsgPrefix, raw))
+
 		return "", fmt.Errorf("invalid address %q", raw)
 	}
 
@@ -1173,18 +1213,27 @@ func commatrixProbeHostAddr(raw string) (string, error) {
 
 // commatrixNodeProbeIPs returns IPv4 then IPv6 node addresses for TCP probes via eco-goinfra nodes helpers.
 func commatrixNodeProbeIPs(nb *nodes.Builder) ([]string, error) {
+	nodeName := commatrixNodeBuilderName(nb)
 	var ips []string
 
-	if ipv4, err := nb.ExternalIPv4Network(); err == nil {
-		if addr, errHost := commatrixProbeHostAddr(ipv4); errHost == nil {
-			ips = append(ips, addr)
-		}
+	if ipv4, err := nb.ExternalIPv4Network(); err != nil {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+			"%s: node %q IPv4 external network lookup failed: %v", commatrixLogMsgPrefix, nodeName, err))
+	} else if addr, errHost := commatrixProbeHostAddr(ipv4); errHost != nil {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+			"%s: node %q IPv4 address %q unusable for probes: %v", commatrixLogMsgPrefix, nodeName, ipv4, errHost))
+	} else {
+		ips = append(ips, addr)
 	}
 
-	if ipv6, err := nb.ExternalIPv6Network(); err == nil {
-		if addr, errHost := commatrixProbeHostAddr(ipv6); errHost == nil {
-			ips = append(ips, addr)
-		}
+	if ipv6, err := nb.ExternalIPv6Network(); err != nil {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+			"%s: node %q IPv6 external network lookup failed: %v", commatrixLogMsgPrefix, nodeName, err))
+	} else if addr, errHost := commatrixProbeHostAddr(ipv6); errHost != nil {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+			"%s: node %q IPv6 address %q unusable for probes: %v", commatrixLogMsgPrefix, nodeName, ipv6, errHost))
+	} else {
+		ips = append(ips, addr)
 	}
 
 	if len(ips) == 0 {
@@ -1229,7 +1278,8 @@ func commatrixNodesFromMachineConfigPools(poolNames []string) ([]string, error) 
 		sel := mcpObj.Spec.NodeSelector
 		if sel == nil {
 			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
-				"MachineConfigPool %q has nil nodeSelector; skipping node enumeration for this pool", poolName))
+				"%s: MachineConfigPool %q has nil nodeSelector; skipping node enumeration for this pool",
+				commatrixLogMsgPrefix, poolName))
 
 			continue
 		}
@@ -1243,6 +1293,10 @@ func commatrixNodesFromMachineConfigPools(poolNames []string) ([]string, error) 
 
 		labelStr := nodeLabelSel.String()
 		if labelStr == "" {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+				"%s: MachineConfigPool %q has empty nodeSelector; skipping node enumeration for this pool",
+				commatrixLogMsgPrefix, poolName))
+
 			continue
 		}
 
@@ -1254,6 +1308,8 @@ func commatrixNodesFromMachineConfigPools(poolNames []string) ([]string, error) 
 			return nil, fmt.Errorf("list nodes for pool %q (%s): %w", poolName, labelStr, errList)
 		}
 
+		poolNodeCount := 0
+
 		for _, nb := range nodeList {
 			if nb == nil || nb.Object == nil {
 				continue
@@ -1263,7 +1319,18 @@ func commatrixNodesFromMachineConfigPools(poolNames []string) ([]string, error) 
 			if _, ok := seen[name]; !ok {
 				seen[name] = struct{}{}
 				out = append(out, name)
+				poolNodeCount++
 			}
+		}
+
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+			"%s: MachineConfigPool %q nodeSelector %q -> %d node(s) listed, %d new unique (total unique so far %d)",
+			commatrixLogMsgPrefix, poolName, labelStr, len(nodeList), poolNodeCount, len(out)))
+
+		if len(nodeList) == 0 {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+				"%s: MachineConfigPool %q nodeSelector %q matched 0 nodes on cluster",
+				commatrixLogMsgPrefix, poolName, labelStr))
 		}
 	}
 
@@ -1407,6 +1474,10 @@ func commatrixWaitForJournalKernelGrep(
 
 			raw, pollErr = commatrixRunJournalKernelGrep(nodeName, since, "", grepFilter)
 			if pollErr != nil {
+				klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+					"%s: kernel journal grep on node %q filter=%q since=%q failed: %v",
+					commatrixLogMsgPrefix, nodeName, grepFilter, since, pollErr))
+
 				return false, pollErr
 			}
 
@@ -1419,6 +1490,13 @@ func commatrixWaitForJournalKernelGrep(
 			return len(lines) >= minLines, nil
 		})
 
+	if err != nil {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+			"%s: timed out waiting for kernel journal lines on node %q filter=%q since=%q (have %d, need %d, timeout %s): %v; last output: %q",
+			commatrixLogMsgPrefix, nodeName, grepFilter, since, len(lines), minLines, timeout, err,
+			commatrixLogOutputSnippet(raw, 1000)))
+	}
+
 	return lines, raw, err
 }
 
@@ -1426,20 +1504,38 @@ func commatrixWaitForJournalKernelGrep(
 func commatrixParseJournalKernelLines(raw string) []string {
 	var out []string
 
-	for _, line := range strings.Split(raw, "\n") {
+	rawLines := strings.Split(raw, "\n")
+	var skippedEmpty, skippedDebugPod, skippedNonKernel int
+
+	for _, line := range rawLines {
 		line = strings.TrimSpace(line)
-		if line == "" ||
-			strings.HasPrefix(line, "Starting pod/") ||
+		if line == "" {
+			skippedEmpty++
+
+			continue
+		}
+
+		if strings.HasPrefix(line, "Starting pod/") ||
 			strings.HasPrefix(line, "To use host binaries") ||
 			strings.HasPrefix(line, "Removing debug pod") ||
 			strings.HasPrefix(line, "error: non-zero exit code") {
+			skippedDebugPod++
+
 			continue
 		}
 
 		if strings.Contains(line, "kernel:") || journalShortTimePrefixRe.MatchString(line) {
 			out = append(out, line)
+
+			continue
 		}
+
+		skippedNonKernel++
 	}
+
+	klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+		"%s: parsed kernel journal lines from %d raw line(s): kept=%d skippedEmpty=%d skippedDebugPod=%d skippedNonKernel=%d",
+		commatrixLogMsgPrefix, len(rawLines), len(out), skippedEmpty, skippedDebugPod, skippedNonKernel))
 
 	return out
 }
@@ -1662,6 +1758,10 @@ func VerifyCommatrixHostFirewallJournal(ctx SpecContext) {
 		"host-firewall rules must be applied on the cluster before journal checks")
 
 	if strings.TrimSpace(commatrixWorkflow.run.SecureWorkerName) == "" {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Info(fmt.Sprintf(
+			"%s: journal spec running without prior connectivity spec; resolving connectivity topology for secure worker",
+			commatrixLogMsgPrefix))
+
 		Expect(commatrixResolveConnectivityTopology()).NotTo(HaveOccurred(),
 			"resolve connectivity topology before journal checks")
 	}

--- a/tests/system-tests/rdscore/internal/rdscorecommon/commatrix.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/commatrix.go
@@ -1,0 +1,1670 @@
+// Commatrix host-firewall workflow (ginkgo reportxml 95001–95004): generate artifacts, apply MCs,
+// verify TCP connectivity from the test runner, verify firewall journal logging; cleanup runs after apply.
+//
+//nolint:varnamelen,lll,wsl_v5 // test helpers follow oc/k8s naming; long oc/shell/klog lines are intentional.
+package rdscorecommon
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/mco"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nodes"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/yaml"
+
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/inittools"
+
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/system-tests/rdscore/internal/rdscoreinittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/system-tests/rdscore/internal/rdscoreparams"
+)
+
+const (
+	commatrixFormatMCSubdir             = "format-mc"
+	commatrixFormatButaneSubdir         = "format-butane"
+	commatrixFileExtYAML                = ".yaml"
+	commatrixFileExtYML                 = ".yml"
+	commatrixNDPNFTFilePath             = "/etc/sysconfig/nftables.conf"
+	commatrixNDPNFTUnitName             = "nftables.service"
+	commatrixNFTablesOpenshiftChain     = "OPENSHIFT"
+	commatrixJournalSinceOneMinute      = "1 minute ago"
+	commatrixJournalSinceTwoMinutes     = "2 minutes ago"
+	commatrixFirewallLogPrefixNoSpace   = "firewall"  // kernel: firewallIN=...
+	commatrixFirewallLogPrefixWithSpace = "firewall " // kernel: firewall IN=...
+	commatrixFirewallRateLimitPerMinute = 5
+	// Fixed probe targets and waits (not configurable; same across OCP host-firewall test plans).
+	commatrixAPIPort            = 6443
+	commatrixKubeletPort        = 10250
+	commatrixClosedTCPPort      = 9999
+	commatrixNFTablesLogKeyword = "firewall"
+)
+
+// commatrixMCPStableWait is how long apply/revert waits for all MachineConfigPools to stabilize.
+const commatrixMCPStableWait = 15 * time.Minute
+
+// journalShortTimePrefixRe parses journalctl short-iso timestamps for firewall log rate-limit checks.
+var journalShortTimePrefixRe = regexp.MustCompile(`^([A-Z][a-z]{2}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2})`)
+
+// commatrixJSONPatchOp is one RFC 6902 operation for oc patch --type=json.
+type commatrixJSONPatchOp struct {
+	Op   string `json:"op"`
+	Path string `json:"path"`
+}
+
+// commatrixBuildJSONPatchRemoveNDPNFT builds a JSON Patch that removes the nftables file and unit from
+// spec.nodeDisruptionPolicy by list index (operator.openshift.io MachineConfiguration does not support strategic patch).
+func commatrixBuildJSONPatchRemoveNDPNFT(clusterJSON string) ([]byte, error) {
+	var root map[string]interface{}
+
+	if err := json.Unmarshal([]byte(clusterJSON), &root); err != nil {
+		return nil, fmt.Errorf("parse MachineConfiguration cluster JSON: %w", err)
+	}
+
+	spec, hasSpec := root["spec"].(map[string]interface{})
+	if !hasSpec {
+		return nil, fmt.Errorf("cluster JSON missing spec")
+	}
+
+	ndp, hasNDP := spec["nodeDisruptionPolicy"].(map[string]interface{})
+	if !hasNDP {
+		return []byte("[]"), nil
+	}
+
+	var ops []commatrixJSONPatchOp
+
+	if files, hasFiles := ndp["files"].([]interface{}); hasFiles {
+		for fileIdx, item := range files {
+			fm, isFileMap := item.(map[string]interface{})
+			if !isFileMap {
+				continue
+			}
+
+			path, _ := fm["path"].(string)
+			if filepath.Clean(path) == filepath.Clean(commatrixNDPNFTFilePath) {
+				ops = append(ops, commatrixJSONPatchOp{
+					Op:   "remove",
+					Path: fmt.Sprintf("/spec/nodeDisruptionPolicy/files/%d", fileIdx),
+				})
+
+				break
+			}
+		}
+	}
+
+	if units, hasUnits := ndp["units"].([]interface{}); hasUnits {
+		for unitIdx, item := range units {
+			um, isUnitMap := item.(map[string]interface{})
+			if !isUnitMap {
+				continue
+			}
+
+			name, _ := um["name"].(string)
+			if name == commatrixNDPNFTUnitName {
+				ops = append(ops, commatrixJSONPatchOp{
+					Op:   "remove",
+					Path: fmt.Sprintf("/spec/nodeDisruptionPolicy/units/%d", unitIdx),
+				})
+
+				break
+			}
+		}
+	}
+
+	if len(ops) == 0 {
+		return []byte("[]"), nil
+	}
+
+	patchBytes, err := json.Marshal(ops)
+	if err != nil {
+		return nil, err
+	}
+
+	return patchBytes, nil
+}
+
+// commatrixRunTopology holds node names and InternalIPs resolved for connectivity checks.
+type commatrixRunTopology struct {
+	MCName           string
+	SecureWorkerName string
+	OpenWorkerName   string
+	MasterIP         string
+	SecureWorkerIP   string
+	OpenWorkerIP     string
+}
+
+// commatrixWorkflowState carries shared state for the ordered Commatrix spec.
+type commatrixWorkflowState struct {
+	run                  commatrixRunTopology
+	mcApplied            bool
+	ndpApplied           bool
+	revertNodeNames      []string
+	generatedMCPoolNames []string
+	appliedMCPoolNames   []string
+	appliedMCRels        []string
+	nftProbeNodeName     string
+}
+
+var commatrixWorkflow commatrixWorkflowState
+
+func commatrixResetWorkflow() {
+	commatrixWorkflow = commatrixWorkflowState{}
+}
+
+func commatrixMasterLabelSelector() string {
+	return labels.Set(inittools.GeneralConfig.ControlPlaneLabelMap).String()
+}
+
+func commatrixRunOC(ocCmdArgs ...string) (string, error) {
+	ocCmd := exec.Command("oc", ocCmdArgs...)
+	ocCmd.Env = os.Environ()
+
+	ocCmdOut, ocCmdErr := ocCmd.CombinedOutput()
+
+	return string(ocCmdOut), ocCmdErr
+}
+
+// commatrixRunLocalShell runs shellCmd on the machine executing the test (not via oc debug).
+func commatrixRunLocalShell(shellCmd string) error {
+	localCmd := exec.Command("bash", "-c", shellCmd)
+	localCmd.Env = os.Environ()
+
+	localCmdOut, localCmdErr := localCmd.CombinedOutput()
+
+	if localCmdErr != nil {
+		klog.Infof("local: bash -c %q failed: %v\n%s", shellCmd, localCmdErr, string(localCmdOut))
+	} else {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("local: bash -c %q\n%s", shellCmd, string(localCmdOut))
+	}
+
+	return localCmdErr
+}
+
+// commatrixRunTCPProbeFromRunner runs nc -z from the test runner to host:port.
+func commatrixRunTCPProbeFromRunner(expectConnect bool, host, port string) error {
+	var shellCmd string
+
+	if expectConnect {
+		shellCmd = fmt.Sprintf(`nc -z -v -w3 %s %s`, host, port)
+	} else {
+		shellCmd = fmt.Sprintf(`! nc -z -v -w3 %s %s`, host, port)
+	}
+
+	return commatrixRunLocalShell(shellCmd)
+}
+
+// commatrixRunOnNodeHostDebug runs `oc debug node/<name> -- <hostDebugCmdArgs...>` so `chroot /host` is the node root.
+func commatrixRunOnNodeHostDebug(nodeName string, hostDebugCmdArgs ...string) (string, error) {
+	ocDebugCmdArgs := append([]string{"debug", "node/" + nodeName, "--"}, hostDebugCmdArgs...)
+
+	hostDebugCmdOut, hostDebugCmdErr := commatrixRunOC(ocDebugCmdArgs...)
+
+	if hostDebugCmdErr != nil {
+		klog.Infof("oc debug node/%s -- %s failed: %v\n%s",
+			nodeName, strings.Join(hostDebugCmdArgs, " "), hostDebugCmdErr, hostDebugCmdOut)
+	} else {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("oc debug node/%s -- %s\n%s",
+			nodeName, strings.Join(hostDebugCmdArgs, " "), hostDebugCmdOut)
+	}
+
+	return hostDebugCmdOut, hostDebugCmdErr
+}
+
+// commatrixButaneBasenameToMC replaces the first case-insensitive "butane" substring in a filename with "mc".
+func commatrixButaneBasenameToMC(name string) (string, bool) {
+	lower := strings.ToLower(name)
+	i := strings.Index(lower, "butane")
+	if i < 0 {
+		return "", false
+	}
+
+	return name[:i] + "mc" + name[i+len("butane"):], true
+}
+
+type commatrixButaneRenderJob struct {
+	srcRel string
+	outRel string
+}
+
+func commatrixDiscoverButaneRenderJobs(buRawRoot string) ([]commatrixButaneRenderJob, error) {
+	seenOut := make(map[string]string)
+
+	var jobs []commatrixButaneRenderJob
+
+	err := filepath.WalkDir(buRawRoot, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		rel, err := filepath.Rel(buRawRoot, path)
+		if err != nil {
+			return err
+		}
+
+		base := filepath.Base(rel)
+		ext := strings.ToLower(filepath.Ext(base))
+
+		var outRel string
+
+		switch {
+		case strings.Contains(strings.ToLower(base), "butane") && (ext == commatrixFileExtYAML || ext == commatrixFileExtYML):
+			newBase, ok := commatrixButaneBasenameToMC(base)
+			if !ok {
+				return nil
+			}
+
+			outRel = filepath.Join(filepath.Dir(rel), newBase)
+		case ext == ".bu":
+			outRel = filepath.Join(filepath.Dir(rel), strings.TrimSuffix(base, filepath.Ext(base))+commatrixFileExtYAML)
+		default:
+			return nil
+		}
+
+		outRel = filepath.Clean(outRel)
+
+		if prev, ok := seenOut[outRel]; ok {
+			return fmt.Errorf("duplicate rendered MC path %q from sources %q and %q", outRel, prev, rel)
+		}
+
+		seenOut[outRel] = rel
+		jobs = append(jobs, commatrixButaneRenderJob{srcRel: rel, outRel: outRel})
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(jobs, func(i, j int) bool {
+		return jobs[i].srcRel < jobs[j].srcRel
+	})
+
+	return jobs, nil
+}
+
+func commatrixYAMLEquivalent(leftYAML, rightYAML []byte) error {
+	leftJSON, err := yaml.YAMLToJSON(bytes.TrimSpace(leftYAML))
+	if err != nil {
+		return fmt.Errorf("left yaml-to-json: %w", err)
+	}
+
+	rightJSON, err := yaml.YAMLToJSON(bytes.TrimSpace(rightYAML))
+	if err != nil {
+		return fmt.Errorf("right yaml-to-json: %w", err)
+	}
+
+	if !bytes.Equal(leftJSON, rightJSON) {
+		return fmt.Errorf(
+			"MachineConfig YAML differs after YAML→JSON normalization (left %d B, right %d B)",
+			len(leftJSON), len(rightJSON))
+	}
+
+	return nil
+}
+
+func commatrixListMachineConfigYAMLRels(root string) ([]string, error) {
+	var rels []string
+
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		ext := strings.ToLower(filepath.Ext(path))
+		if ext != commatrixFileExtYAML && ext != commatrixFileExtYML {
+			return nil
+		}
+
+		baseName := strings.ToLower(filepath.Base(path))
+		if baseName == "node-disruption-policy.yaml" || baseName == "node-disruption-policy.yml" {
+			return nil
+		}
+
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		if !bytes.Contains(raw, []byte("kind: MachineConfig")) && !bytes.Contains(raw, []byte("kind: \"MachineConfig\"")) {
+			return nil
+		}
+
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+
+		rels = append(rels, filepath.ToSlash(rel))
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Strings(rels)
+
+	return rels, nil
+}
+
+// commatrixFindNodeDisruptionPolicyPatch returns the absolute path to a single node-disruption-policy.yaml
+// under root (e.g. format-mc). MachineConfig apply skips that file; merged via oc patch on MachineConfiguration cluster instead.
+// If none are present, returns ("", nil). More than one match is an error.
+func commatrixFindNodeDisruptionPolicyPatch(root string) (string, error) {
+	var matches []string
+
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		if strings.ToLower(filepath.Base(path)) == "node-disruption-policy.yaml" {
+			rel, errRel := filepath.Rel(root, path)
+			if errRel != nil {
+				return errRel
+			}
+
+			matches = append(matches, filepath.ToSlash(rel))
+		}
+
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+
+	sort.Strings(matches)
+
+	switch len(matches) {
+	case 0:
+		return "", nil
+	case 1:
+		abs := filepath.Join(root, filepath.FromSlash(matches[0]))
+
+		return filepath.Clean(abs), nil
+	default:
+		return "", fmt.Errorf("multiple node-disruption-policy.yaml files under %s: %v", root, matches)
+	}
+}
+
+func commatrixCompareMCDirectVsRendered(mcRoot, renderRoot string) {
+	mcRels, err := commatrixListMachineConfigYAMLRels(mcRoot)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(mcRels).NotTo(BeEmpty(), "no MachineConfig YAML under direct mc output %s", mcRoot)
+
+	renderedRels, err := commatrixListMachineConfigYAMLRels(renderRoot)
+	Expect(err).NotTo(HaveOccurred())
+
+	Expect(renderedRels).To(Equal(mcRels),
+		"MachineConfig relative paths under %s and %s should match exactly", mcRoot, renderRoot)
+
+	for _, rel := range mcRels {
+		relOS := filepath.FromSlash(rel)
+
+		left, err := os.ReadFile(filepath.Join(mcRoot, relOS))
+		Expect(err).NotTo(HaveOccurred(), "read direct mc %s", rel)
+
+		right, err := os.ReadFile(filepath.Join(renderRoot, relOS))
+		Expect(err).NotTo(HaveOccurred(), "read butane-rendered mc %s", rel)
+
+		errEq := commatrixYAMLEquivalent(left, right)
+		Expect(errEq).NotTo(HaveOccurred(), "MachineConfig %q: direct mc vs butane-rendered differ: %v", rel, errEq)
+	}
+}
+
+// commatrixDecodeDataURLLinePayload decodes ignition data: URL payloads from generated MCs:
+// awk -F ',' '/source: data:/ {print $NF}' ... | base64 -d | gunzip
+// Ignition often uses a single line `source: data:...;base64,<payload>`.
+func commatrixDecodeDataURLLinePayload(line string) ([]byte, bool) {
+	lineLower := strings.ToLower(line)
+	if !strings.Contains(lineLower, "source:") || !strings.Contains(lineLower, "data:") {
+		return nil, false
+	}
+
+	idx := strings.Index(lineLower, "base64,")
+	if idx < 0 {
+		return nil, false
+	}
+
+	b64 := strings.TrimSpace(line[idx+len("base64,"):])
+	b64 = strings.Trim(b64, `"'`)
+
+	raw, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		return nil, false
+	}
+
+	if len(raw) >= 2 && raw[0] == 0x1f && raw[1] == 0x8b {
+		zr, errZ := gzip.NewReader(bytes.NewReader(raw))
+		if errZ != nil {
+			return nil, false
+		}
+
+		out, errR := io.ReadAll(zr)
+		_ = zr.Close()
+		if errR != nil {
+			return nil, false
+		}
+
+		return out, true
+	}
+
+	return raw, true
+}
+
+func commatrixCollectDecodedDataURLPayloads(mcYAML []byte) [][]byte {
+	var out [][]byte
+
+	for _, line := range strings.Split(string(mcYAML), "\n") {
+		if p, ok := commatrixDecodeDataURLLinePayload(line); ok {
+			out = append(out, p)
+		}
+	}
+
+	return out
+}
+
+func commatrixExpectDecodedHostFirewallNFTables(decoded []byte, mcRel string) {
+	s := strings.ToLower(string(decoded))
+
+	Expect(s).To(ContainSubstring("table inet openshift_filter"),
+		"mc %s: decoded payload should define table inet openshift_filter", mcRel)
+	Expect(s).To(ContainSubstring("delete table inet openshift_filter"),
+		"mc %s: decoded payload should delete table inet openshift_filter before recreate", mcRel)
+	Expect(s).To(ContainSubstring("type filter hook input"),
+		"mc %s: decoded payload should use an input filter hook (host firewall)", mcRel)
+	Expect(s).To(ContainSubstring("tcp dport"),
+		"mc %s: decoded payload should open tcp destination ports", mcRel)
+	Expect(s).To(ContainSubstring("udp dport"),
+		"mc %s: decoded payload should open udp destination ports", mcRel)
+	Expect(s).To(ContainSubstring("accept"),
+		"mc %s: decoded payload should contain accept rules", mcRel)
+	Expect(s).To(ContainSubstring("log"),
+		"mc %s: decoded payload should contain log rules (rate-limited firewall logging)", mcRel)
+	Expect(s).To(ContainSubstring("chain openshift"),
+		"mc %s: decoded payload should define openshift chain (e.g. OPENSHIFT)", mcRel)
+}
+
+// commatrixVerifyHostFirewallNFTablesInMCRoot walks MachineConfig YAML under root, decodes any
+// ignition `source: data:...;base64,...` lines, and asserts at least one payload is the openshift_filter ruleset.
+func commatrixVerifyHostFirewallNFTablesInMCRoot(mcRoot string) {
+	rels, err := commatrixListMachineConfigYAMLRels(mcRoot)
+	Expect(err).NotTo(HaveOccurred(), "list MachineConfigs under %s", mcRoot)
+
+	var verifiedRel string
+
+	for _, rel := range rels {
+		raw, errRead := os.ReadFile(filepath.Join(mcRoot, filepath.FromSlash(rel)))
+		Expect(errRead).NotTo(HaveOccurred(), "read MachineConfig %s", rel)
+
+		for _, payload := range commatrixCollectDecodedDataURLPayloads(raw) {
+			if !strings.Contains(strings.ToLower(string(payload)), "table inet openshift_filter") {
+				continue
+			}
+
+			commatrixExpectDecodedHostFirewallNFTables(payload, rel)
+			verifiedRel = rel
+
+			break
+		}
+
+		if verifiedRel != "" {
+			break
+		}
+	}
+
+	Expect(verifiedRel).NotTo(BeEmpty(),
+		"no MachineConfig under %s contained a data: URL payload decoding to openshift_filter nftables", mcRoot)
+
+	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("validated host-firewall nftables in %s under %s", verifiedRel, mcRoot)
+}
+
+// commatrixExtractOpenshiftFilterRuleLines returns non-empty nft rule lines from a decoded openshift_filter payload.
+func commatrixExtractOpenshiftFilterRuleLines(nftText string) []string {
+	var rules []string
+
+	for _, line := range strings.Split(nftText, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		lower := strings.ToLower(line)
+		if strings.HasPrefix(lower, "table ") || strings.HasPrefix(lower, "chain ") ||
+			strings.HasPrefix(lower, "type ") || strings.HasPrefix(lower, "delete ") {
+			continue
+		}
+
+		if strings.Contains(lower, " dport ") || strings.Contains(lower, " sport ") ||
+			strings.Contains(lower, " accept") || strings.Contains(lower, " drop") ||
+			strings.Contains(lower, " reject") || strings.Contains(lower, " log") ||
+			strings.HasPrefix(lower, "tcp ") || strings.HasPrefix(lower, "udp ") ||
+			strings.HasPrefix(lower, "ip ") || strings.HasPrefix(lower, "meta ") {
+			rules = append(rules, line)
+		}
+	}
+
+	return rules
+}
+
+// commatrixLogOpenshiftFilterRulesByPool logs openshift_filter rules from each mc-<pool>.yaml
+// and, when the cluster API is available, the node names that match each pool's MachineConfigPool nodeSelector.
+func commatrixLogOpenshiftFilterRulesByPool(mcRoot string) {
+	rels, err := commatrixListMachineConfigYAMLRels(mcRoot)
+	if err != nil {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Commatrix artifacts: openshift_filter rule dump skipped: list MachineConfigs under %s: %v", mcRoot, err)
+
+		return
+	}
+
+	sort.Strings(rels)
+
+	for _, rel := range rels {
+		raw, errRead := os.ReadFile(filepath.Join(mcRoot, filepath.FromSlash(rel)))
+		if errRead != nil {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Commatrix artifacts: read MachineConfig %s: %v", rel, errRead)
+
+			continue
+		}
+
+		pool, hasPool := commatrixMachineConfigPoolNameFromMCRel(rel)
+		if !hasPool {
+			pool = "(unknown pool — expected mc-<pool>.yaml)"
+		}
+
+		var logged bool
+
+		for _, payload := range commatrixCollectDecodedDataURLPayloads(raw) {
+			if !strings.Contains(strings.ToLower(string(payload)), "table inet openshift_filter") {
+				continue
+			}
+
+			logged = true
+
+			targetNodes := "(cluster API unavailable)"
+			if APIClient != nil && hasPool {
+				if nodeNames, errNodes := commatrixNodesFromMachineConfigPools([]string{pool}); errNodes != nil {
+					targetNodes = fmt.Sprintf("(list nodes for pool %q: %v)", pool, errNodes)
+				} else if len(nodeNames) == 0 {
+					targetNodes = "(no nodes matched pool nodeSelector yet)"
+				} else {
+					targetNodes = strings.Join(nodeNames, ", ")
+				}
+			}
+
+			ruleLines := commatrixExtractOpenshiftFilterRuleLines(string(payload))
+			if len(ruleLines) == 0 {
+				klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Commatrix artifacts: MachineConfig %s pool=%q target node(s): %s\nopenshift_filter payload (no discrete rule lines parsed):\n%s",
+					rel, pool, targetNodes, strings.TrimSpace(string(payload)))
+
+				continue
+			}
+
+			var b strings.Builder
+			_, _ = fmt.Fprintf(&b, "Commatrix artifacts: MachineConfig %s pool=%q target node(s): %s\nopenshift_filter rules (%d):",
+				rel, pool, targetNodes, len(ruleLines))
+
+			for i, rule := range ruleLines {
+				_, _ = fmt.Fprintf(&b, "\n  [%d] %s", i+1, rule)
+			}
+
+			klog.Info(b.String())
+		}
+
+		if !logged {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Commatrix artifacts: MachineConfig %s pool=%q: no openshift_filter data: URL payload", rel, pool)
+		}
+	}
+}
+
+func commatrixRenderButaneRawToRenderedMC(buRawRoot, renderRoot string) {
+	jobs, err := commatrixDiscoverButaneRenderJobs(buRawRoot)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(jobs).NotTo(BeEmpty(), "no butane inputs (*butane*.yaml/.yml or *.bu) found under %s", buRawRoot)
+
+	for _, j := range jobs {
+		absIn := filepath.Join(buRawRoot, j.srcRel)
+		absOut := filepath.Join(renderRoot, j.outRel)
+
+		errMk := os.MkdirAll(filepath.Dir(absOut), 0o750)
+		Expect(errMk).NotTo(HaveOccurred(), "mkdir for butane output %s", absOut)
+
+		filesDir := filepath.Join(buRawRoot, filepath.Dir(j.srcRel))
+
+		butaneCmd := exec.Command("butane", "--strict", "--files-dir", filesDir, absIn, "-o", absOut)
+		butaneCmd.Env = os.Environ()
+
+		butaneCmdOut, butaneCmdErr := butaneCmd.CombinedOutput()
+		Expect(butaneCmdErr).NotTo(HaveOccurred(), "butane %q -> %q: %s", absIn, absOut, strings.TrimSpace(string(butaneCmdOut)))
+	}
+}
+
+// commatrixVerifyDestDirAfterGenerate asserts destDir contains at least one file (recursive) and prints every file (path, mode, size).
+func commatrixVerifyDestDirAfterGenerate(destDir string) {
+	var lines []string
+
+	n := 0
+
+	err := filepath.WalkDir(destDir, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		n++
+
+		rel, relErr := filepath.Rel(destDir, path)
+		if relErr != nil {
+			rel = path
+		}
+
+		fi, errFI := d.Info()
+		if errFI != nil {
+			lines = append(lines, fmt.Sprintf("%s\t?\t?", filepath.ToSlash(rel)))
+
+			return nil
+		}
+
+		lines = append(lines, fmt.Sprintf("%s\t%s\t%d", filepath.ToSlash(rel), fi.Mode().String(), fi.Size()))
+
+		return nil
+	})
+	Expect(err).NotTo(HaveOccurred(), "walk commatrix destDir %q", destDir)
+	Expect(n).To(BeNumerically(">", 0), "expected at least one file under %s", destDir)
+
+	sort.Strings(lines)
+
+	listing := strings.Join(lines, "\n")
+
+	_, _ = fmt.Fprintf(GinkgoWriter, "\n=== commatrix destDir %q (%d files) ===\n%s\n\n", destDir, n, listing)
+
+	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("commatrix destDir %q: %d files\n%s", destDir, n, listing)
+
+	By(fmt.Sprintf("Verifying commatrix output directory (%d files)", n))
+}
+
+func commatrixPickMCPoolName(candidates []string, match func(string) bool) string {
+	for _, p := range candidates {
+		if match(p) {
+			return p
+		}
+	}
+
+	return ""
+}
+
+func commatrixInferSecureMCPoolNameFromPools(pools []string) string {
+	if p := commatrixPickMCPoolName(pools, func(name string) bool {
+		lower := strings.ToLower(name)
+
+		return strings.Contains(lower, "appworker") && strings.Contains(lower, "mcp-a")
+	}); p != "" {
+		return p
+	}
+
+	if p := commatrixPickMCPoolName(pools, func(name string) bool {
+		return strings.Contains(strings.ToLower(name), "appworker")
+	}); p != "" {
+		return p
+	}
+
+	return commatrixPickMCPoolName(pools, func(name string) bool {
+		lower := strings.ToLower(name)
+
+		return !strings.Contains(lower, "master") && !strings.Contains(lower, "storage")
+	})
+}
+
+func commatrixInferSecureMCPoolName() string {
+	pools := commatrixWorkflow.appliedMCPoolNames
+	if len(pools) == 0 {
+		pools = commatrixWorkflow.generatedMCPoolNames
+	}
+
+	return commatrixInferSecureMCPoolNameFromPools(pools)
+}
+
+func commatrixInferMasterMCPoolNameFromPools(pools []string) string {
+	for _, p := range pools {
+		if strings.EqualFold(p, "master") {
+			return p
+		}
+	}
+
+	return commatrixPickMCPoolName(pools, func(name string) bool {
+		lower := strings.ToLower(name)
+
+		return strings.Contains(lower, "master") && !strings.Contains(lower, "storage") &&
+			!strings.Contains(lower, "appworker") && !strings.Contains(lower, "gateway")
+	})
+}
+
+func commatrixInferOpenMCPoolName(securePool string) string {
+	pools := commatrixWorkflow.generatedMCPoolNames
+	if len(pools) == 0 {
+		pools = commatrixWorkflow.appliedMCPoolNames
+	}
+	if p := commatrixPickMCPoolName(pools, func(name string) bool {
+		lower := strings.ToLower(name)
+
+		return strings.Contains(lower, "appworker") && strings.Contains(lower, "mcp-b")
+	}); p != "" {
+		return p
+	}
+
+	for _, p := range pools {
+		if p == securePool {
+			continue
+		}
+
+		if strings.Contains(strings.ToLower(p), "appworker") {
+			return p
+		}
+	}
+
+	return ""
+}
+
+func commatrixFirstNodeNameInMCPool(poolName string) (string, error) {
+	names, err := commatrixNodesFromMachineConfigPools([]string{poolName})
+	if err != nil {
+		return "", err
+	}
+
+	if len(names) == 0 {
+		return "", fmt.Errorf("no nodes in MachineConfigPool %q", poolName)
+	}
+
+	return names[0], nil
+}
+
+func commatrixSetWorkerFromNodeName(nodeName string) error {
+	nb, errPull := nodes.Pull(APIClient, nodeName)
+	if errPull != nil {
+		return fmt.Errorf("pull node %q: %w", nodeName, errPull)
+	}
+
+	ip, errIP := commatrixNodeInternalIP(nb)
+	if errIP != nil {
+		return errIP
+	}
+
+	commatrixWorkflow.run.SecureWorkerName = nodeName
+	commatrixWorkflow.run.SecureWorkerIP = ip
+
+	return nil
+}
+
+func commatrixSetOpenWorkerFromNodeName(nodeName string) error {
+	nb, errPull := nodes.Pull(APIClient, nodeName)
+	if errPull != nil {
+		return fmt.Errorf("pull open-pool node %q: %w", nodeName, errPull)
+	}
+
+	openIP, errIP := commatrixNodeInternalIP(nb)
+	if errIP != nil {
+		return errIP
+	}
+
+	commatrixWorkflow.run.OpenWorkerName = nodeName
+	commatrixWorkflow.run.OpenWorkerIP = openIP
+
+	return nil
+}
+
+// commatrixResolveConnectivityTopology fills master/secure/open node names and InternalIPs once for connectivity and journal specs.
+//
+//nolint:funlen // master + secure (nft probe node) + open pool resolution.
+func commatrixResolveConnectivityTopology() error {
+	commatrixWorkflow.run.MasterIP = ""
+	commatrixWorkflow.run.SecureWorkerName = ""
+	commatrixWorkflow.run.SecureWorkerIP = ""
+	commatrixWorkflow.run.OpenWorkerName = ""
+	commatrixWorkflow.run.OpenWorkerIP = ""
+
+	masters, err := nodes.List(APIClient, metav1.ListOptions{LabelSelector: commatrixMasterLabelSelector()})
+	if err != nil {
+		return fmt.Errorf("list master nodes: %w", err)
+	}
+
+	if len(masters) == 0 {
+		return fmt.Errorf("no nodes matched master label %q", commatrixMasterLabelSelector())
+	}
+
+	masterIP, err := commatrixNodeInternalIP(masters[0])
+	if err != nil {
+		return err
+	}
+
+	commatrixWorkflow.run.MasterIP = masterIP
+
+	nftNode := strings.TrimSpace(commatrixWorkflow.nftProbeNodeName)
+	if nftNode == "" {
+		return fmt.Errorf("secure worker: run apply spec first (nft probe node not recorded)")
+	}
+
+	if err := commatrixSetWorkerFromNodeName(nftNode); err != nil {
+		return fmt.Errorf("secure worker %q: %w", nftNode, err)
+	}
+
+	openLabel := strings.TrimSpace(RDSCoreConfig.CommatrixOpenPoolNodeLabel)
+	switch {
+	case openLabel != "":
+		openNodes, errList := nodes.List(APIClient, metav1.ListOptions{LabelSelector: openLabel})
+		if errList != nil {
+			return fmt.Errorf("list open-pool nodes: %w", errList)
+		}
+
+		if len(openNodes) == 0 {
+			return fmt.Errorf("no nodes matched open pool label %q", openLabel)
+		}
+
+		if err := commatrixSetOpenWorkerFromNodeName(openNodes[0].Object.Name); err != nil {
+			return err
+		}
+	default:
+		securePool := commatrixInferSecureMCPoolName()
+		openPool := commatrixInferOpenMCPoolName(securePool)
+		if openPool == "" {
+			return fmt.Errorf(
+				"open worker: set rdscore_commatrix_open_pool_node_label or apply host-firewall MCs to one worker pool only")
+		}
+
+		openNode, errOpen := commatrixFirstNodeNameInMCPool(openPool)
+		if errOpen != nil {
+			return fmt.Errorf("open pool %q: %w", openPool, errOpen)
+		}
+
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Commatrix: using node %q from MachineConfigPool %q (open / no-firewall pool)", openNode, openPool)
+
+		if err := commatrixSetOpenWorkerFromNodeName(openNode); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func commatrixNodeInternalIP(nb *nodes.Builder) (string, error) {
+	if nb.Object == nil {
+		return "", fmt.Errorf("node %q has nil Object", nb.Definition.Name)
+	}
+
+	for _, a := range nb.Object.Status.Addresses {
+		if a.Type == corev1.NodeInternalIP {
+			return a.Address, nil
+		}
+	}
+
+	return "", fmt.Errorf("no internal IP on node %q", nb.Object.Name)
+}
+
+// commatrixFormatMCDir returns the direct oc commatrix mc output directory (<output_dir>/format-mc).
+func commatrixFormatMCDir() (string, error) {
+	dest := strings.TrimSpace(RDSCoreConfig.CommatrixOutputDir)
+	if dest == "" {
+		return "", fmt.Errorf("CommatrixOutputDir is empty")
+	}
+
+	return filepath.Join(filepath.Clean(dest), commatrixFormatMCSubdir), nil
+}
+
+func commatrixWaitAllMachineConfigPoolsStable(stepLabel string) {
+	By(fmt.Sprintf("%s — wait for all MachineConfigPools to stabilize (ready == updated == machine count; no degraded)", stepLabel))
+
+	err := mco.ListMCPWaitToBeStableFor(APIClient, 90*time.Second, commatrixMCPStableWait)
+	Expect(err).NotTo(HaveOccurred(), "%s: all MCPs did not stabilize within timeout", stepLabel)
+
+	ocGetMcpCmdOut, ocGetMcpCmdErr := commatrixRunOC("get", "mcp", "-o", "wide")
+	Expect(ocGetMcpCmdErr).NotTo(HaveOccurred(), "%s: oc get mcp", stepLabel)
+
+	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("%s: MCP snapshot after stable wait:\n%s", stepLabel, strings.TrimSpace(ocGetMcpCmdOut))
+}
+
+// commatrixMachineConfigPoolNameFromMCRel extracts the MachineConfigPool name from a commatrix MachineConfig path.
+// This workflow requires basenames mc-<pool>.yaml or mc-<pool>.yml (e.g. mc-appworker-mcp-a.yaml → appworker-mcp-a).
+func commatrixMachineConfigPoolNameFromMCRel(rel string) (string, bool) {
+	base := filepath.Base(rel)
+	ext := strings.ToLower(filepath.Ext(base))
+	if ext != ".yaml" && ext != ".yml" {
+		return "", false
+	}
+
+	stem := strings.TrimSuffix(base, filepath.Ext(base))
+	if len(stem) < 4 || !strings.HasPrefix(strings.ToLower(stem), "mc-") {
+		return "", false
+	}
+
+	pool := strings.TrimSpace(stem[3:])
+	if pool == "" {
+		return "", false
+	}
+
+	return pool, true
+}
+
+// commatrixMachineConfigPoolNamesFromMCRels returns sorted unique pool names from mc-<pool>.yaml paths (each rel must already match that layout).
+func commatrixMachineConfigPoolNamesFromMCRels(mcRels []string) []string {
+	seen := make(map[string]struct{})
+
+	var pools []string
+
+	for _, rel := range mcRels {
+		if p, ok := commatrixMachineConfigPoolNameFromMCRel(rel); ok {
+			if _, dup := seen[p]; !dup {
+				seen[p] = struct{}{}
+				pools = append(pools, p)
+			}
+		}
+	}
+
+	sort.Strings(pools)
+
+	return pools
+}
+
+// commatrixMCRelsForPools returns mc-<pool>.yaml paths whose pool name is in poolNames.
+func commatrixMCRelsForPools(mcRels []string, poolNames []string) []string {
+	want := make(map[string]struct{}, len(poolNames))
+	for _, p := range poolNames {
+		want[p] = struct{}{}
+	}
+
+	var out []string
+
+	for _, rel := range mcRels {
+		pool, ok := commatrixMachineConfigPoolNameFromMCRel(rel)
+		if !ok {
+			continue
+		}
+
+		if _, match := want[pool]; match {
+			out = append(out, rel)
+		}
+	}
+
+	sort.Strings(out)
+
+	return out
+}
+
+// commatrixNodesFromMachineConfigPools returns sorted unique node names matching each pool's
+// MachineConfigPool.spec.nodeSelector on the live cluster.
+func commatrixNodesFromMachineConfigPools(poolNames []string) ([]string, error) {
+	seen := make(map[string]struct{})
+
+	var out []string
+
+	for _, poolName := range poolNames {
+		mcpB, errPull := mco.Pull(APIClient, poolName)
+		if errPull != nil {
+			return nil, fmt.Errorf("MachineConfigPool %q: %w", poolName, errPull)
+		}
+
+		mcpObj, errGet := mcpB.Get()
+		if errGet != nil {
+			return nil, fmt.Errorf("get MachineConfigPool %q: %w", poolName, errGet)
+		}
+
+		sel := mcpObj.Spec.NodeSelector
+		if sel == nil {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+				"MachineConfigPool %q has nil nodeSelector; skipping node enumeration for this pool", poolName)
+
+			continue
+		}
+
+		nodeLabelSel, errLS := metav1.LabelSelectorAsSelector(sel)
+		if errLS != nil {
+			return nil, fmt.Errorf("MachineConfigPool %q nodeSelector: %w", poolName, errLS)
+		}
+
+		labelStr := nodeLabelSel.String()
+		if labelStr == "" {
+			continue
+		}
+
+		nodeList, errList := nodes.List(APIClient, metav1.ListOptions{LabelSelector: labelStr})
+		if errList != nil {
+			return nil, fmt.Errorf("list nodes for pool %q (%s): %w", poolName, labelStr, errList)
+		}
+
+		for _, nb := range nodeList {
+			if nb == nil || nb.Object == nil {
+				continue
+			}
+
+			name := nb.Object.Name
+			if _, ok := seen[name]; !ok {
+				seen[name] = struct{}{}
+				out = append(out, name)
+			}
+		}
+	}
+
+	sort.Strings(out)
+
+	return out, nil
+}
+
+// commatrixStopNFTOnNode stops nftables on one node (best-effort during suite cleanup).
+func commatrixStopNFTOnNode(nodeName string) {
+	stopNftablesCmdOut, stopNftablesCmdErr := commatrixRunOnNodeHostDebug(nodeName, "chroot", "/host", "sh", "-c", "systemctl stop nftables || true")
+	if stopNftablesCmdErr != nil {
+		klog.Errorf("stop nftables on %s: %v\n%s", nodeName, stopNftablesCmdErr, stopNftablesCmdOut)
+
+		return
+	}
+
+	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("stop nftables on %s: %s", nodeName, strings.TrimSpace(stopNftablesCmdOut))
+}
+
+// commatrixRunOnNodeHostShell runs shellCmd on the node host via oc debug (chroot /host).
+func commatrixRunOnNodeHostShell(nodeName, shellCmd string) (string, error) {
+	return commatrixRunOnNodeHostDebug(nodeName, "chroot", "/host", "sh", "-c", shellCmd)
+}
+
+// commatrixGenerateArtifacts runs oc commatrix generate for mc and butane, runs the butane CLI in the same
+// directory as the generated butane YAML (mc-*.yaml next to butane-*.yaml), then asserts parity with direct mc output.
+func commatrixGenerateArtifacts(_ SpecContext) {
+	By("Generating commatrix MachineConfig artifacts")
+
+	Expect(strings.TrimSpace(RDSCoreConfig.CommatrixOutputDir)).NotTo(BeEmpty(),
+		"rdscore_commatrix_output_dir is required for oc commatrix generate")
+
+	destDir := filepath.Clean(strings.TrimSpace(RDSCoreConfig.CommatrixOutputDir))
+	mcDir := filepath.Join(destDir, commatrixFormatMCSubdir)
+	buDir := filepath.Join(destDir, commatrixFormatButaneSubdir)
+
+	for _, d := range []string{mcDir, buDir} {
+		_ = os.RemoveAll(d)
+	}
+
+	for _, d := range []string{destDir, mcDir, buDir} {
+		err := os.MkdirAll(d, 0o750)
+		Expect(err).NotTo(HaveOccurred(), "mkdir %s", d)
+	}
+
+	ocCommatrixMcGenCmdOut, ocCommatrixMcGenCmdErr := commatrixRunOC("commatrix", "generate", "--format", "mc", "--host-open-ports", "--destDir", mcDir)
+	Expect(ocCommatrixMcGenCmdErr).NotTo(HaveOccurred(), "oc commatrix generate (mc): %s", ocCommatrixMcGenCmdOut)
+	commatrixVerifyDestDirAfterGenerate(mcDir)
+
+	ocCommatrixButaneGenCmdOut, ocCommatrixButaneGenCmdErr := commatrixRunOC("commatrix", "generate", "--format", "butane", "--host-open-ports", "--destDir", buDir)
+	Expect(ocCommatrixButaneGenCmdErr).NotTo(HaveOccurred(), "oc commatrix generate (butane): %s", ocCommatrixButaneGenCmdOut)
+
+	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("oc commatrix generate (butane): %s", strings.TrimSpace(ocCommatrixButaneGenCmdOut))
+
+	commatrixVerifyDestDirAfterGenerate(buDir)
+
+	By("Rendering butane to MachineConfig")
+	commatrixRenderButaneRawToRenderedMC(buDir, buDir)
+
+	commatrixVerifyDestDirAfterGenerate(buDir)
+
+	By("Comparing direct mc vs butane-rendered MachineConfigs")
+	commatrixCompareMCDirectVsRendered(mcDir, buDir)
+
+	By("Validating host-firewall nftables in generated MachineConfigs")
+	commatrixVerifyHostFirewallNFTablesInMCRoot(mcDir)
+	commatrixVerifyHostFirewallNFTablesInMCRoot(buDir)
+
+	commatrixLogOpenshiftFilterRulesByPool(mcDir)
+}
+
+// commatrixApplyHostFirewallMC patches NDP, applies host-firewall MachineConfigs, waits for MCP stable, verifies nft chain.
+//
+//nolint:funlen
+func commatrixApplyHostFirewallMC(_ SpecContext) {
+	mcDir, err := commatrixFormatMCDir()
+	if err != nil {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Apply skipped: %v", err)
+
+		return
+	}
+
+	if _, statErr := os.Stat(mcDir); statErr != nil {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Apply skipped: format-mc missing (%s): %v", mcDir, statErr)
+
+		return
+	}
+
+	mcRels, err := commatrixListMachineConfigYAMLRels(mcDir)
+	Expect(err).NotTo(HaveOccurred(), "list MachineConfigs under %s", mcDir)
+
+	if len(mcRels) == 0 {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Apply skipped: no MachineConfig YAML under %s", mcDir)
+
+		return
+	}
+
+	for _, rel := range mcRels {
+		_, ok := commatrixMachineConfigPoolNameFromMCRel(rel)
+		Expect(ok).To(BeTrue(),
+			"format-mc MachineConfigs must be named mc-<pool>.yaml (pool = MachineConfigPool name); invalid path %q", rel)
+	}
+
+	ndp, errNdp := commatrixFindNodeDisruptionPolicyPatch(mcDir)
+	Expect(errNdp).NotTo(HaveOccurred(), "find node-disruption-policy.yaml under format-mc")
+	Expect(ndp).NotTo(BeEmpty(),
+		"node-disruption-policy.yaml required under format-mc (oc commatrix generate output)")
+
+	By("Patching MachineConfiguration cluster node disruption policy")
+
+	ocPatchNdpCmdOut, ocPatchNdpCmdErr := commatrixRunOC("patch", "machineconfiguration", "cluster",
+		"--type=merge", "--patch-file="+ndp)
+	Expect(ocPatchNdpCmdErr).NotTo(HaveOccurred(), "cluster NDP patch failed: %s", ocPatchNdpCmdOut)
+
+	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("patched NDP from %s: %s", ndp, strings.TrimSpace(ocPatchNdpCmdOut))
+	commatrixWorkflow.ndpApplied = true
+
+	commatrixWorkflow.generatedMCPoolNames = commatrixMachineConfigPoolNamesFromMCRels(mcRels)
+	Expect(commatrixWorkflow.generatedMCPoolNames).NotTo(BeEmpty(), "internal: expected pool name(s) from mc-<pool>.yaml paths")
+
+	securePool := commatrixInferSecureMCPoolNameFromPools(commatrixWorkflow.generatedMCPoolNames)
+	Expect(securePool).NotTo(BeEmpty(),
+		"could not infer secure/firewall MCP from generated MCs; set rdscore_commatrix_secure_mcp_name (e.g. appworker-mcp-a)")
+
+	masterPool := commatrixInferMasterMCPoolNameFromPools(commatrixWorkflow.generatedMCPoolNames)
+	Expect(masterPool).NotTo(BeEmpty(),
+		"could not infer master MCP from generated MCs (expected mc-master.yaml)")
+
+	applyPools := []string{securePool, masterPool}
+	applyRels := commatrixMCRelsForPools(mcRels, applyPools)
+	Expect(applyRels).NotTo(BeEmpty(),
+		"no mc-%s.yaml / mc-%s.yaml under %s", securePool, masterPool, mcDir)
+	Expect(commatrixMCRelsForPools(mcRels, []string{masterPool})).NotTo(BeEmpty(),
+		"no mc-%s.yaml under %s; commatrix generate must emit mc-master.yaml", masterPool, mcDir)
+
+	applyRelSet := make(map[string]struct{}, len(applyRels))
+	for _, rel := range applyRels {
+		applyRelSet[rel] = struct{}{}
+	}
+
+	var skippedRels []string
+
+	for _, rel := range mcRels {
+		if _, applied := applyRelSet[rel]; !applied {
+			skippedRels = append(skippedRels, rel)
+		}
+	}
+
+	By("Applying secure-pool and master MachineConfigs")
+
+	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("apply: pools=%v files=%v skipped=%v", applyPools, applyRels, skippedRels)
+
+	for _, rel := range applyRels {
+		abs := filepath.Join(mcDir, filepath.FromSlash(rel))
+
+		ocApplyMcCmdOut, ocApplyMcCmdErr := commatrixRunOC("apply", "-f", abs)
+		Expect(ocApplyMcCmdErr).NotTo(HaveOccurred(), "oc apply %q failed: %s", rel, ocApplyMcCmdOut)
+
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("apply: applied %q: %s", rel, strings.TrimSpace(ocApplyMcCmdOut))
+	}
+
+	commatrixWaitAllMachineConfigPoolsStable("apply host firewall MCs")
+
+	var errRec error
+
+	commatrixWorkflow.revertNodeNames, errRec = commatrixNodesFromMachineConfigPools(applyPools)
+	Expect(errRec).NotTo(HaveOccurred(), "resolve nodes for applied pool(s) %v", applyPools)
+	Expect(commatrixWorkflow.revertNodeNames).NotTo(BeEmpty(),
+		"no nodes matched MachineConfigPool nodeSelector(s) for applied pools %v (check pool membership on the cluster)", applyPools)
+
+	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("apply: revert nodes (pools %v): %v",
+		applyPools, commatrixWorkflow.revertNodeNames)
+
+	commatrixWorkflow.appliedMCPoolNames = append([]string(nil), applyPools...)
+	commatrixWorkflow.appliedMCRels = append([]string(nil), applyRels...)
+
+	commatrixWorkflow.mcApplied = true
+
+	securePoolNodes, errSecureNodes := commatrixNodesFromMachineConfigPools([]string{securePool})
+	Expect(errSecureNodes).NotTo(HaveOccurred(), "list nodes in secure pool %q", securePool)
+	Expect(securePoolNodes).NotTo(BeEmpty(), "no nodes in secure pool %q for nft probe", securePool)
+
+	nftNode := securePoolNodes[0]
+	commatrixWorkflow.nftProbeNodeName = nftNode
+
+	By(fmt.Sprintf("Verifying openshift_filter chain on node %s", nftNode))
+
+	nftOpenshiftChainShellCmd := "nft list chain inet openshift_filter OPENSHIFT 2>/dev/null || " +
+		"nft list chain inet openshift_filter OPENCHAIN 2>/dev/null || true"
+
+	var nftOpenshiftChainCmdOut string
+
+	err = wait.PollUntilContextTimeout(context.TODO(), 10*time.Second, 3*time.Minute, true,
+		func(context.Context) (bool, error) {
+			var hostDebugCmdErr error
+
+			nftOpenshiftChainCmdOut, hostDebugCmdErr = commatrixRunOnNodeHostDebug(nftNode, "chroot", "/host", "sh", "-c", nftOpenshiftChainShellCmd)
+			if hostDebugCmdErr != nil {
+				klog.V(rdscoreparams.RDSCoreLogLevel).Infof("nft list (retry) on %s: %v", nftNode, hostDebugCmdErr)
+
+				return false, nil
+			}
+
+			return strings.TrimSpace(nftOpenshiftChainCmdOut) != "", nil
+		})
+	Expect(err).NotTo(HaveOccurred(), "nft openshift_filter/OPENSHIFT chain not visible on %s", nftNode)
+
+	Expect(strings.ToLower(nftOpenshiftChainCmdOut)).To(ContainSubstring("openshift_filter"))
+}
+
+// commatrixVerifyHostFirewallConnectivity probes API/kubelet TCP reachability from the test runner.
+func commatrixVerifyHostFirewallConnectivity(_ SpecContext) {
+	if !commatrixWorkflow.mcApplied {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Connectivity skipped: host-firewall MachineConfigs were not applied")
+
+		return
+	}
+
+	By("Resolving cluster topology for connectivity probes")
+
+	Expect(commatrixResolveConnectivityTopology()).NotTo(HaveOccurred())
+
+	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Commatrix connectivity probes: masterIP=%s secure=%s/%s open=%s/%s",
+		commatrixWorkflow.run.MasterIP, commatrixWorkflow.run.SecureWorkerName, commatrixWorkflow.run.SecureWorkerIP,
+		commatrixWorkflow.run.OpenWorkerName, commatrixWorkflow.run.OpenWorkerIP)
+
+	apiPort := strconv.Itoa(commatrixAPIPort)
+	kubeletPort := strconv.Itoa(commatrixKubeletPort)
+	closedPort := strconv.Itoa(commatrixClosedTCPPort)
+
+	tryProbe := func(desc, dstHost, port string, expectConnect bool) {
+		By(desc)
+
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("TCP probe %s -> %s:%s (expect connect=%v)", desc, dstHost, port, expectConnect)
+
+		Expect(commatrixRunTCPProbeFromRunner(expectConnect, dstHost, port)).NotTo(HaveOccurred(), "%s", desc)
+	}
+
+	tryProbe("Master API reachable from test runner", commatrixWorkflow.run.MasterIP, apiPort, true)
+
+	tryProbe("Secure-pool worker API blocked from test runner", commatrixWorkflow.run.SecureWorkerIP, apiPort, false)
+
+	var securePoolPeerNames []string
+
+	if len(commatrixWorkflow.appliedMCPoolNames) > 0 {
+		var errPeers error
+
+		securePoolPeerNames, errPeers = commatrixNodesFromMachineConfigPools(commatrixWorkflow.appliedMCPoolNames)
+		Expect(errPeers).NotTo(HaveOccurred())
+	}
+
+	if len(securePoolPeerNames) >= 2 {
+		var peerName string
+
+		for _, name := range securePoolPeerNames {
+			if name != commatrixWorkflow.run.SecureWorkerName {
+				peerName = name
+
+				break
+			}
+		}
+
+		Expect(peerName).NotTo(BeEmpty(), "need a second node in secure pool besides %s", commatrixWorkflow.run.SecureWorkerName)
+
+		peerNB, errPull := nodes.Pull(APIClient, peerName)
+		Expect(errPull).NotTo(HaveOccurred())
+
+		peerIP, errIP := commatrixNodeInternalIP(peerNB)
+		Expect(errIP).NotTo(HaveOccurred())
+
+		tryProbe("Peer secure-pool worker API blocked from test runner", peerIP, apiPort, false)
+	} else {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Skipping peer secure-pool worker API probe: fewer than two secure-pool nodes")
+	}
+
+	tryProbe("Secure-pool worker kubelet reachable from test runner", commatrixWorkflow.run.SecureWorkerIP, kubeletPort, true)
+
+	tryProbe("Closed test port blocked on secure-pool worker", commatrixWorkflow.run.SecureWorkerIP, closedPort, false)
+
+	tryProbe("Open-pool worker kubelet reachable (pool without host-firewall MC)", commatrixWorkflow.run.OpenWorkerIP, kubeletPort, true)
+}
+
+func commatrixRunJournalKernelGrep(nodeName, since, until, grepFilter string) (string, error) {
+	shellCmd := fmt.Sprintf(`journalctl -k --since %q`, since)
+	if strings.TrimSpace(until) != "" {
+		shellCmd += fmt.Sprintf(` --until %q`, until)
+	}
+
+	shellCmd += fmt.Sprintf(` 2>/dev/null | grep -F %q || true`, grepFilter)
+
+	return commatrixRunOnNodeHostDebug(nodeName, "chroot", "/host", "sh", "-c", shellCmd)
+}
+
+// commatrixWaitForJournalKernelGrep runs journalctl -k --since on a node (via oc debug), greps for filter,
+// and polls until at least minLines kernel lines are present.
+func commatrixWaitForJournalKernelGrep(
+	nodeName, since, grepFilter string,
+	minLines int,
+	interval, timeout time.Duration,
+) (lines []string, raw string, err error) {
+	err = wait.PollUntilContextTimeout(context.TODO(), interval, timeout, true,
+		func(context.Context) (bool, error) {
+			var pollErr error
+
+			raw, pollErr = commatrixRunJournalKernelGrep(nodeName, since, "", grepFilter)
+			if pollErr != nil {
+				klog.V(rdscoreparams.RDSCoreLogLevel).Infof("journal on %s: %v", nodeName, pollErr)
+
+				return false, nil
+			}
+
+			lines = commatrixParseJournalKernelLines(raw)
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("journal on %s since %q filter %q: %d line(s)",
+				nodeName, since, grepFilter, len(lines))
+
+			return len(lines) >= minLines, nil
+		})
+
+	return lines, raw, err
+}
+
+func commatrixParseJournalKernelLines(raw string) []string {
+	var out []string
+
+	for _, line := range strings.Split(raw, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" ||
+			strings.HasPrefix(line, "Starting pod/") ||
+			strings.HasPrefix(line, "To use host binaries") ||
+			strings.HasPrefix(line, "Removing debug pod") ||
+			strings.HasPrefix(line, "error: non-zero exit code") {
+			continue
+		}
+
+		if strings.Contains(line, "kernel:") || journalShortTimePrefixRe.MatchString(line) {
+			out = append(out, line)
+		}
+	}
+
+	return out
+}
+
+// commatrixExpectFirewallLogRateLimitsInWindow counts firewall / firewall-space log lines in one journal window (≤5 per bucket).
+func commatrixExpectFirewallLogRateLimitsInWindow(lines []string, windowLabel string) {
+	counts := map[string]int{
+		commatrixFirewallLogPrefixNoSpace:   0,
+		commatrixFirewallLogPrefixWithSpace: 0,
+	}
+
+	for _, line := range lines {
+		prefix, ok := commatrixFirewallLogBucket(line)
+		if !ok {
+			continue
+		}
+
+		counts[prefix]++
+	}
+
+	for _, prefix := range []string{commatrixFirewallLogPrefixNoSpace, commatrixFirewallLogPrefixWithSpace} {
+		n := counts[prefix]
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("firewall journal %s: bucket %q: %d line(s)", windowLabel, prefix, n)
+
+		Expect(n).To(BeNumerically("<=", commatrixFirewallRateLimitPerMinute),
+			"firewall journal %s: bucket %q: %d lines (max %d per minute)", windowLabel, prefix, n, commatrixFirewallRateLimitPerMinute)
+	}
+}
+
+func commatrixFirewallLogBucket(line string) (string, bool) {
+	if strings.Contains(line, "TCP_TEST") {
+		return "", false
+	}
+
+	const tag = "kernel: "
+
+	i := strings.Index(line, tag)
+	if i < 0 {
+		return "", false
+	}
+
+	switch msg := line[i+len(tag):]; {
+	case strings.HasPrefix(msg, "firewall IN="):
+		return commatrixFirewallLogPrefixWithSpace, true
+	case strings.HasPrefix(msg, "firewallIN="):
+		return commatrixFirewallLogPrefixNoSpace, true
+	default:
+		return "", false
+	}
+}
+
+// commatrixVerifyFirewallJournal checks firewall journal rate limits and TCP_TEST log-drop probe.
+// Uses the same secure worker node as connectivity (nft apply probe, nc probes); run connectivity before this spec.
+//
+//nolint:funlen // journal: two 1-minute windows, TCP_TEST rule inject/probe, and journal assertions.
+func commatrixVerifyFirewallJournal(_ SpecContext) {
+	if !commatrixWorkflow.mcApplied {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Journal checks skipped: host-firewall MachineConfigs were not applied")
+
+		return
+	}
+
+	journalNode := commatrixWorkflow.run.SecureWorkerName
+	Expect(journalNode).NotTo(BeEmpty(), "journal node: run connectivity spec first to resolve secure worker")
+
+	journalNB, errPull := nodes.Pull(APIClient, journalNode)
+	Expect(errPull).NotTo(HaveOccurred(), "pull journal node %q", journalNode)
+
+	journalInternalIP, errIP := commatrixNodeInternalIP(journalNB)
+	Expect(errIP).NotTo(HaveOccurred(), "internal IP for journal node for %s", journalNode)
+
+	keyword := commatrixNFTablesLogKeyword
+
+	By(fmt.Sprintf("Verifying firewall log rate limits on node %s (two 1-minute windows)", journalNode))
+
+	window1Raw, errWin1 := commatrixRunJournalKernelGrep(
+		journalNode, commatrixJournalSinceTwoMinutes, commatrixJournalSinceOneMinute, keyword)
+	Expect(errWin1).NotTo(HaveOccurred(), "firewall journal window 1 on %s: %s", journalNode, window1Raw)
+
+	window1Lines := commatrixParseJournalKernelLines(window1Raw)
+	commatrixExpectFirewallLogRateLimitsInWindow(window1Lines,
+		fmt.Sprintf("%s to %s", commatrixJournalSinceTwoMinutes, commatrixJournalSinceOneMinute))
+
+	window2Raw, errWin2 := commatrixRunJournalKernelGrep(journalNode, commatrixJournalSinceOneMinute, "", keyword)
+	Expect(errWin2).NotTo(HaveOccurred(), "firewall journal window 2 on %s: %s", journalNode, window2Raw)
+
+	window2Lines := commatrixParseJournalKernelLines(window2Raw)
+	Expect(window2Lines).NotTo(BeEmpty(),
+		"firewall journal: expected at least one kernel log line matching %q in the last minute on %s; last output:\n%s",
+		keyword, journalNode, window2Raw)
+
+	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("firewall journal: %d line(s) matching %q on %s in the last minute",
+		len(window2Lines), keyword, journalNode)
+
+	commatrixExpectFirewallLogRateLimitsInWindow(window2Lines, commatrixJournalSinceOneMinute)
+
+	apiPort := commatrixAPIPort
+	probeTargetIP := journalInternalIP
+
+	By(fmt.Sprintf("Injecting TCP_TEST log rule on node %s", journalNode))
+
+	nftInsertHostShellCmd := fmt.Sprintf(
+		`set -e; nft insert rule inet openshift_filter %s tcp dport %d log prefix \"TCP_TEST \" drop`,
+		commatrixNFTablesOpenshiftChain, apiPort)
+
+	nftInsertCmdOut, nftInsertCmdErr := commatrixRunOnNodeHostShell(journalNode, nftInsertHostShellCmd)
+	Expect(nftInsertCmdErr).NotTo(HaveOccurred(), "nft insert TCP_TEST rule on %s: %s", journalNode, nftInsertCmdOut)
+
+	defer func() {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("removing TCP_TEST rule on %s (best-effort)", journalNode)
+
+		nftDeleteLogRuleShellCmd := fmt.Sprintf(
+			`HANDLE=$(nft -a list chain inet openshift_filter %s 2>/dev/null | grep TCP_TEST | tail -1 | sed -E "s/.*handle ([0-9]+).*/\\1/"); [ -n "$HANDLE" ] && nft delete rule inet openshift_filter %s handle "$HANDLE" || true`,
+			commatrixNFTablesOpenshiftChain, commatrixNFTablesOpenshiftChain)
+
+		_, _ = commatrixRunOnNodeHostShell(journalNode, nftDeleteLogRuleShellCmd)
+	}()
+
+	By(fmt.Sprintf("Probing %s:%d from test runner", probeTargetIP, apiPort))
+
+	tcpProbeShellCmd := fmt.Sprintf(`nc -z -v -w1 %s %d`, probeTargetIP, apiPort)
+
+	if err := commatrixRunLocalShell(tcpProbeShellCmd); err != nil {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("local nc to %s:%d (drop expected): %v", probeTargetIP, apiPort, err)
+	}
+
+	By("Verifying TCP_TEST in kernel journal")
+
+	tcpTestLines, tcpTestRaw, err := commatrixWaitForJournalKernelGrep(
+		journalNode, commatrixJournalSinceOneMinute, "TCP_TEST", 1, 3*time.Second, 90*time.Second)
+	Expect(err).NotTo(HaveOccurred(),
+		"TCP_TEST journal: expected at least one TCP_TEST kernel log line after nc to %s:%d on %s (got %d); last output:\n%s",
+		probeTargetIP, apiPort, journalNode, len(tcpTestLines), tcpTestRaw)
+
+	Expect(tcpTestLines).NotTo(BeEmpty(), "TCP_TEST journal: expected ≥1 TCP_TEST log line on %s", journalNode)
+
+	dptNeedle := fmt.Sprintf("DPT=%d", apiPort)
+
+	journalJoined := strings.ToUpper(strings.Join(tcpTestLines, "\n"))
+
+	Expect(journalJoined).To(ContainSubstring("TCP_TEST"),
+		"TCP_TEST journal: journal lines should include TCP_TEST log prefix from injected rule")
+	Expect(journalJoined).To(ContainSubstring(strings.ToUpper(dptNeedle)),
+		"TCP_TEST journal: journal lines should reference probed destination port %s", dptNeedle)
+}
+
+func commatrixRevertNDP() {
+	ocGetMcClusterCmdOut, ocGetMcClusterCmdErr := commatrixRunOC("get", "machineconfiguration", "cluster", "-o", "json")
+	if ocGetMcClusterCmdErr != nil {
+		klog.Errorf("revert NDP: get machineconfiguration/cluster: %v\n%s", ocGetMcClusterCmdErr, ocGetMcClusterCmdOut)
+
+		return
+	}
+
+	patch, errBuild := commatrixBuildJSONPatchRemoveNDPNFT(ocGetMcClusterCmdOut)
+	if errBuild != nil {
+		klog.Errorf("revert NDP: build JSON patch: %v", errBuild)
+
+		return
+	}
+
+	if len(patch) == 0 || string(patch) == "[]" {
+		commatrixWorkflow.ndpApplied = false
+
+		return
+	}
+
+	ocJSONPatchMcClusterCmdOut, ocJSONPatchMcClusterCmdErr := commatrixRunOC(
+		"patch", "machineconfiguration", "cluster", "--type=json", "-p", string(patch))
+	if ocJSONPatchMcClusterCmdErr != nil {
+		klog.Errorf("revert NDP: json patch failed: %v\n%s", ocJSONPatchMcClusterCmdErr, ocJSONPatchMcClusterCmdOut)
+
+		return
+	}
+
+	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("revert NDP: %s", strings.TrimSpace(ocJSONPatchMcClusterCmdOut))
+	commatrixWorkflow.ndpApplied = false
+}
+
+func commatrixRevertHostFirewall() {
+	if !commatrixWorkflow.mcApplied {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("revert skipped: no MachineConfig was applied")
+
+		return
+	}
+
+	mcDir, errMcDir := commatrixFormatMCDir()
+	if errMcDir != nil {
+		klog.Errorf("revert: resolve format-mc dir: %v", errMcDir)
+
+		return
+	}
+
+	for _, nodeName := range commatrixWorkflow.revertNodeNames {
+		commatrixStopNFTOnNode(nodeName)
+	}
+
+	for _, rel := range commatrixWorkflow.appliedMCRels {
+		abs := filepath.Join(mcDir, filepath.FromSlash(rel))
+
+		ocDeleteMcCmdOut, ocDeleteMcCmdErr := commatrixRunOC("delete", "-f", abs, "--ignore-not-found=true")
+		if ocDeleteMcCmdErr != nil {
+			klog.Errorf("revert: oc delete %q: %v\n%s", rel, ocDeleteMcCmdErr, ocDeleteMcCmdOut)
+
+			continue
+		}
+
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("revert: deleted %q: %s", rel, strings.TrimSpace(ocDeleteMcCmdOut))
+	}
+
+	if errWait := mco.ListMCPWaitToBeStableFor(APIClient, 90*time.Second, commatrixMCPStableWait); errWait != nil {
+		klog.Errorf("revert: MCP stable wait: %v", errWait)
+	}
+
+	commatrixWorkflow.mcApplied = false
+
+	if commatrixWorkflow.ndpApplied {
+		commatrixRevertNDP()
+	}
+
+	destDir := filepath.Clean(strings.TrimSpace(RDSCoreConfig.CommatrixOutputDir))
+	if destDir != "" && destDir != "." && destDir != string(filepath.Separator) {
+		if errRm := os.RemoveAll(destDir); errRm != nil {
+			klog.Errorf("revert: remove output dir %s: %v", destDir, errRm)
+		} else {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("revert: removed output directory %s", destDir)
+		}
+	}
+}
+
+// CommatrixRevertAfterSpec undoes apply changes after the ordered commatrix Describe finishes.
+// Errors are logged only so a failed connectivity/journal spec still attempts cleanup.
+func CommatrixRevertAfterSpec() {
+	By("Reverting commatrix cluster changes")
+	commatrixRevertHostFirewall()
+}
+
+// VerifyCommatrixHostFirewallArtifacts generates commatrix artifacts and validates embedded openshift_filter nftables.
+func VerifyCommatrixHostFirewallArtifacts(ctx SpecContext) {
+	commatrixResetWorkflow()
+	commatrixGenerateArtifacts(ctx)
+}
+
+// VerifyCommatrixHostFirewallApply applies host-firewall MachineConfigs and verifies nftables on a node.
+func VerifyCommatrixHostFirewallApply(ctx SpecContext) {
+	commatrixApplyHostFirewallMC(ctx)
+}
+
+// VerifyCommatrixHostFirewallConnectivity verifies TCP connectivity from the test runner.
+func VerifyCommatrixHostFirewallConnectivity(ctx SpecContext) {
+	commatrixVerifyHostFirewallConnectivity(ctx)
+}
+
+// VerifyCommatrixHostFirewallJournal verifies firewall journal rate limits and TCP_TEST logging.
+func VerifyCommatrixHostFirewallJournal(ctx SpecContext) {
+	commatrixVerifyFirewallJournal(ctx)
+}

--- a/tests/system-tests/rdscore/internal/rdscorecommon/commatrix.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/commatrix.go
@@ -1,5 +1,5 @@
-// Commatrix host-firewall workflow (ginkgo reportxml 95001–95004): optional generate/apply helpers,
-// plus connectivity (95003) and journal (95004) verification against a cluster that already has rules applied.
+// Commatrix host-firewall workflow (ginkgo reportxml 95001–95008): optional generate/apply helpers,
+// plus connectivity (95003/95005/95007) and journal (95004/95006/95008) verification against a cluster that already has rules applied.
 //
 //nolint:varnamelen,lll,wsl_v5 // test helpers follow oc/k8s naming; long oc/shell/klog lines are intentional.
 package rdscorecommon
@@ -243,13 +243,9 @@ func commatrixHostFirewallPoolNamesFromCluster() ([]string, error) {
 	var mcList struct {
 		Items []struct {
 			Metadata struct {
-				Name string `json:"name"`
+				Name   string            `json:"name"`
+				Labels map[string]string `json:"labels"`
 			} `json:"metadata"`
-			Spec struct {
-				Config struct {
-					Role string `json:"role"`
-				} `json:"config"`
-			} `json:"spec"`
 		} `json:"items"`
 	}
 
@@ -265,7 +261,7 @@ func commatrixHostFirewallPoolNamesFromCluster() ([]string, error) {
 			continue
 		}
 
-		role := strings.TrimSpace(item.Spec.Config.Role)
+		role := strings.TrimSpace(item.Metadata.Labels["machineconfiguration.openshift.io/role"])
 		if role == "" {
 			continue
 		}
@@ -1519,10 +1515,12 @@ func commatrixVerifyFirewallJournal(_ SpecContext) {
 
 	window2Lines := commatrixParseJournalKernelLines(window2Raw)
 	if len(window2Lines) == 0 {
-		_, _ = fmt.Fprintf(GinkgoWriter,
-			"WARNING: firewall journal: no kernel log lines matching %q in the last minute on %s; "+
-				"skipping window-2 rate-limit checks (traffic may be quiet). Last output:\n%s\n",
+		warnMsg := fmt.Sprintf(
+			"firewall journal: no kernel log lines matching %q in the last minute on %s; "+
+				"skipping window-2 rate-limit checks (traffic may be quiet). Last output:\n%s",
 			keyword, journalNode, window2Raw)
+		klog.Warning(warnMsg)
+		_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: %s\n", warnMsg)
 	} else {
 		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("firewall journal: %d line(s) matching %q on %s in the last minute",
 			len(window2Lines), keyword, journalNode)

--- a/tests/system-tests/rdscore/internal/rdscorecommon/commatrix.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/commatrix.go
@@ -1203,18 +1203,42 @@ func commatrixResolveConnectivityTopology() error {
 	return nil
 }
 
+// commatrixProbeHostAddr returns the host portion of an OVN/node address (strips /prefix when present).
+func commatrixProbeHostAddr(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", fmt.Errorf("empty address")
+	}
+
+	if strings.Contains(raw, "/") {
+		ip, _, err := net.ParseCIDR(raw)
+		if err != nil {
+			return "", fmt.Errorf("parse address %q: %w", raw, err)
+		}
+
+		return ip.String(), nil
+	}
+
+	ip := net.ParseIP(raw)
+	if ip == nil {
+		return "", fmt.Errorf("invalid address %q", raw)
+	}
+
+	return ip.String(), nil
+}
+
 // commatrixNodeProbeIPs returns IPv4 then IPv6 node addresses for nc probes via eco-goinfra nodes helpers.
 func commatrixNodeProbeIPs(nb *nodes.Builder) ([]string, error) {
 	var ips []string
 
 	if ipv4, err := nb.ExternalIPv4Network(); err == nil {
-		if addr := strings.TrimSpace(ipv4); addr != "" {
+		if addr, errHost := commatrixProbeHostAddr(ipv4); errHost == nil {
 			ips = append(ips, addr)
 		}
 	}
 
 	if ipv6, err := nb.ExternalIPv6Network(); err == nil {
-		if addr := strings.TrimSpace(ipv6); addr != "" {
+		if addr, errHost := commatrixProbeHostAddr(ipv6); errHost == nil {
 			ips = append(ips, addr)
 		}
 	}

--- a/tests/system-tests/rdscore/internal/rdscorecommon/commatrix.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/commatrix.go
@@ -1,21 +1,14 @@
-// Commatrix host-firewall workflow (ginkgo reportxml 95001–95008): optional generate/apply helpers,
-// plus connectivity (95003/95005/95007) and journal (95004/95006/95008) verification against a cluster that already has rules applied.
+// Commatrix host-firewall verification (ginkgo reportxml 95003–95008): TCP connectivity and firewall
+// journal checks against a cluster that already has commatrix host-firewall MachineConfigs applied.
 //
-//nolint:varnamelen,lll,wsl_v5 // test helpers follow oc/k8s naming; long oc/shell/klog lines are intentional.
+//nolint:varnamelen,lll,wsl_v5 // test helpers follow oc/k8s naming; long shell/klog lines are intentional.
 package rdscorecommon
 
 import (
-	"bytes"
-	"compress/gzip"
 	"context"
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
-	"io"
 	"net"
 	"os"
-	"os/exec"
-	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
@@ -25,17 +18,12 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	mcv1 "github.com/openshift/api/machineconfiguration/v1"
-	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/mco"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nodes"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	apimachinerytypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
-	goclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/yaml"
 
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/inittools"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/system-tests/internal/remote"
@@ -45,12 +33,6 @@ import (
 )
 
 const (
-	commatrixFormatMCSubdir             = "format-mc"
-	commatrixFormatButaneSubdir         = "format-butane"
-	commatrixFileExtYAML                = ".yaml"
-	commatrixFileExtYML                 = ".yml"
-	commatrixNDPNFTFilePath             = "/etc/sysconfig/nftables.conf"
-	commatrixNDPNFTUnitName             = "nftables.service"
 	commatrixNFTablesOpenshiftChain     = "OPENSHIFT"
 	commatrixJournalSinceOneMinute      = "1 minute ago"
 	commatrixJournalSinceTwoMinutes     = "2 minutes ago"
@@ -67,118 +49,35 @@ const (
 	commatrixTCPProbeTimeout = 3 * time.Second
 )
 
-// commatrixMCPStableWait is how long apply/revert waits for all MachineConfigPools to stabilize.
-const commatrixMCPStableWait = 15 * time.Minute
-
 // journalShortTimePrefixRe parses journalctl short-iso timestamps for firewall log rate-limit checks.
 var journalShortTimePrefixRe = regexp.MustCompile(`^([A-Z][a-z]{2}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2})`)
 
-// commatrixJSONPatchOp is one RFC 6902 operation for MachineConfiguration cluster JSON patches.
-type commatrixJSONPatchOp struct {
-	Op   string `json:"op"`
-	Path string `json:"path"`
-}
-
-// commatrixBuildJSONPatchRemoveNDPNFT builds a JSON Patch that removes the nftables file and unit from
-// spec.nodeDisruptionPolicy by list index (operator.openshift.io MachineConfiguration does not support strategic patch).
-func commatrixBuildJSONPatchRemoveNDPNFT(clusterJSON string) ([]byte, error) {
-	var root map[string]interface{}
-
-	if err := json.Unmarshal([]byte(clusterJSON), &root); err != nil {
-		return nil, fmt.Errorf("parse MachineConfiguration cluster JSON: %w", err)
-	}
-
-	spec, hasSpec := root["spec"].(map[string]interface{})
-	if !hasSpec {
-		return nil, fmt.Errorf("cluster JSON missing spec")
-	}
-
-	ndp, hasNDP := spec["nodeDisruptionPolicy"].(map[string]interface{})
-	if !hasNDP {
-		return []byte("[]"), nil
-	}
-
-	var ops []commatrixJSONPatchOp
-
-	if files, hasFiles := ndp["files"].([]interface{}); hasFiles {
-		for fileIdx, item := range files {
-			fm, isFileMap := item.(map[string]interface{})
-			if !isFileMap {
-				continue
-			}
-
-			path, _ := fm["path"].(string)
-			if filepath.Clean(path) == filepath.Clean(commatrixNDPNFTFilePath) {
-				ops = append(ops, commatrixJSONPatchOp{
-					Op:   "remove",
-					Path: fmt.Sprintf("/spec/nodeDisruptionPolicy/files/%d", fileIdx),
-				})
-
-				break
-			}
-		}
-	}
-
-	if units, hasUnits := ndp["units"].([]interface{}); hasUnits {
-		for unitIdx, item := range units {
-			um, isUnitMap := item.(map[string]interface{})
-			if !isUnitMap {
-				continue
-			}
-
-			name, _ := um["name"].(string)
-			if name == commatrixNDPNFTUnitName {
-				ops = append(ops, commatrixJSONPatchOp{
-					Op:   "remove",
-					Path: fmt.Sprintf("/spec/nodeDisruptionPolicy/units/%d", unitIdx),
-				})
-
-				break
-			}
-		}
-	}
-
-	if len(ops) == 0 {
-		return []byte("[]"), nil
-	}
-
-	patchBytes, err := json.Marshal(ops)
-	if err != nil {
-		return nil, err
-	}
-
-	return patchBytes, nil
-}
+// commatrixNFTablesPortTokenRe extracts numeric ports from nftables dport clauses.
+var commatrixNFTablesPortTokenRe = regexp.MustCompile(`\b(\d{1,5})\b`)
 
 // commatrixRunTopology holds node names and probe IPs resolved for connectivity checks.
 type commatrixRunTopology struct {
-	SecureWorkerName string
-	MasterIPs        []string
-	SecureWorkerIPs  []string
+	SecureWorkerName  string
+	MasterIPs         []string
+	SecureWorkerIPs   []string
+	SecureOpenPort    int
+	SecureBlockedPort int
 }
 
-// commatrixWorkflowState carries shared state for the ordered Commatrix spec.
+// commatrixWorkflowState carries shared state between connectivity and journal specs in one test run.
 type commatrixWorkflowState struct {
-	run                  commatrixRunTopology
-	mcApplied            bool
-	ndpApplied           bool
-	revertNodeNames      []string
-	generatedMCPoolNames []string
-	appliedMCPoolNames   []string
-	appliedMCRels        []string
-	nftProbeNodeName     string
+	run                 commatrixRunTopology
+	primed              bool
+	discoveredPoolNames []string
+	probePoolNames      []string
+	nftProbeNodeName    string
 }
 
 var commatrixWorkflow commatrixWorkflowState
 
-func commatrixResetWorkflow() {
-	commatrixWorkflow = commatrixWorkflowState{}
-}
-
-// commatrixPrimeWorkflowForVerification discovers host-firewall pools from commatrix MachineConfigs
-// already on the cluster (95003/95004 assume platform prep or 95002 apply completed there).
+// commatrixPrimeWorkflowForVerification discovers host-firewall pools from commatrix MachineConfigs on the cluster.
 func commatrixPrimeWorkflowForVerification() error {
-	if commatrixWorkflow.mcApplied {
+	if commatrixWorkflow.primed {
 		return nil
 	}
 
@@ -193,14 +92,14 @@ func commatrixPrimeWorkflowForVerification() error {
 
 		return fmt.Errorf(
 			"no commatrix host-firewall MachineConfigs on cluster (look for %q in mc names); %s; "+
-				"apply rules before connectivity/journal tests (run 95001/95002 or platform prep)",
+				"apply host-firewall rules before connectivity/journal tests",
 			commatrixHostFirewallMCNameSubstring, detail)
 	}
 
 	klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
 		"Commatrix: discovered host-firewall MC pools on cluster: %v", poolNames)
 
-	commatrixWorkflow.generatedMCPoolNames = append([]string(nil), poolNames...)
+	commatrixWorkflow.discoveredPoolNames = append([]string(nil), poolNames...)
 
 	securePool := commatrixInferSecureMCPoolNameFromPools(poolNames)
 	if securePool == "" {
@@ -214,7 +113,7 @@ func commatrixPrimeWorkflowForVerification() error {
 		applyPools = append(applyPools, masterPool)
 	}
 
-	commatrixWorkflow.appliedMCPoolNames = append([]string(nil), applyPools...)
+	commatrixWorkflow.probePoolNames = append([]string(nil), applyPools...)
 
 	secureNodes, err := commatrixNodesFromMachineConfigPools([]string{securePool})
 	if err != nil {
@@ -226,21 +125,22 @@ func commatrixPrimeWorkflowForVerification() error {
 	}
 
 	commatrixWorkflow.nftProbeNodeName = secureNodes[0]
-	commatrixWorkflow.mcApplied = true
+	commatrixWorkflow.primed = true
 
-	klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
-		"Commatrix: primed verification workflow pools=%v secureWorker=%q",
-		applyPools, commatrixWorkflow.nftProbeNodeName)
+	klog.Infof(
+		"Commatrix: primed verification workflow discoveredPools=%v securePool=%q masterPool=%q probePools=%v nftProbeNode=%q securePoolNodes=%v",
+		poolNames, securePool, masterPool, applyPools, commatrixWorkflow.nftProbeNodeName, secureNodes)
 
 	return nil
 }
 
+// commatrixMachineConfigPoolRole returns the MachineConfigPool name for a commatrix MC from its role label or name suffix.
 func commatrixMachineConfigPoolRole(mcObj *mcv1.MachineConfig) string {
 	if role := strings.TrimSpace(mcObj.Labels[mcv1.MachineConfigRoleLabelKey]); role != "" {
 		return role
 	}
 
-	// Commatrix MC names encode the pool (e.g. 98-nftables-commatrix-appworker-mcp-a) even when the role label is absent.
+	// Commatrix MC names encode the pool after the marker even when the role label is absent.
 	markerIdx := strings.Index(mcObj.Name, commatrixHostFirewallMCNameSubstring)
 	if markerIdx < 0 {
 		return ""
@@ -249,6 +149,7 @@ func commatrixMachineConfigPoolRole(mcObj *mcv1.MachineConfig) string {
 	return strings.TrimSpace(strings.TrimPrefix(mcObj.Name[markerIdx+len(commatrixHostFirewallMCNameSubstring):], "-"))
 }
 
+// commatrixHostFirewallPoolNamesFromCluster lists unique MCP names from commatrix host-firewall MachineConfigs on the cluster.
 func commatrixHostFirewallPoolNamesFromCluster() ([]string, error) {
 	mcList, err := mco.ListMC(APIClient)
 	if err != nil {
@@ -332,180 +233,12 @@ func commatrixHostFirewallMCDiscoveryDetail() string {
 	return b.String()
 }
 
+// commatrixMasterLabelSelector returns the label selector string for control-plane nodes from GeneralConfig.
 func commatrixMasterLabelSelector() string {
 	return labels.Set(inittools.GeneralConfig.ControlPlaneLabelMap).String()
 }
 
-// commatrixRunOC runs the oc CLI (required for the commatrix plugin subcommand only).
-func commatrixRunOC(ocCmdArgs ...string) (string, error) {
-	ocCmd := exec.Command("oc", ocCmdArgs...)
-	ocCmd.Env = os.Environ()
-
-	ocCmdOut, ocCmdErr := ocCmd.CombinedOutput()
-
-	return string(ocCmdOut), ocCmdErr
-}
-
-func commatrixLoadMachineConfigYAML(path string) (*mcv1.MachineConfig, error) {
-	raw, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-
-	var mc mcv1.MachineConfig
-
-	if err := yaml.Unmarshal(raw, &mc); err != nil {
-		return nil, fmt.Errorf("parse MachineConfig %s: %w", path, err)
-	}
-
-	if strings.TrimSpace(mc.Name) == "" {
-		return nil, fmt.Errorf("MachineConfig %s has no metadata.name", path)
-	}
-
-	return &mc, nil
-}
-
-func commatrixApplyMachineConfigYAML(path string) error {
-	mc, err := commatrixLoadMachineConfigYAML(path)
-	if err != nil {
-		return err
-	}
-
-	if err := APIClient.AttachScheme(mcv1.Install); err != nil {
-		return err
-	}
-
-	existing := &mcv1.MachineConfig{}
-
-	getErr := APIClient.Get(context.TODO(), goclient.ObjectKey{Name: mc.Name}, existing)
-	if getErr != nil {
-		if !k8serrors.IsNotFound(getErr) {
-			return fmt.Errorf("get MachineConfig %q: %w", mc.Name, getErr)
-		}
-
-		return APIClient.Create(context.TODO(), mc)
-	}
-
-	mc.ResourceVersion = existing.ResourceVersion
-
-	return APIClient.Update(context.TODO(), mc)
-}
-
-func commatrixDeleteMachineConfigYAML(path string) error {
-	mc, err := commatrixLoadMachineConfigYAML(path)
-	if err != nil {
-		return err
-	}
-
-	mcBuilder := mco.NewMCBuilder(APIClient, mc.Name)
-	if mcBuilder == nil {
-		return fmt.Errorf("create MachineConfig builder for %q", mc.Name)
-	}
-
-	if !mcBuilder.Exists() {
-		return nil
-	}
-
-	return mcBuilder.Delete()
-}
-
-func commatrixPatchMachineConfigurationClusterMerge(patchPath string) error {
-	patchBytes, err := os.ReadFile(patchPath)
-	if err != nil {
-		return err
-	}
-
-	patchBytes = bytes.TrimSpace(patchBytes)
-	if len(patchBytes) == 0 {
-		return fmt.Errorf("NDP patch file %s is empty", patchPath)
-	}
-
-	mcCluster := &operatorv1.MachineConfiguration{
-		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
-	}
-
-	return APIClient.Patch(
-		context.TODO(),
-		mcCluster,
-		goclient.RawPatch(apimachinerytypes.MergePatchType, patchBytes),
-	)
-}
-
-func commatrixGetMachineConfigurationClusterJSON() ([]byte, error) {
-	mcCluster := &operatorv1.MachineConfiguration{}
-
-	err := APIClient.Get(context.TODO(), goclient.ObjectKey{Name: "cluster"}, mcCluster)
-	if err != nil {
-		return nil, fmt.Errorf("get machineconfiguration/cluster: %w", err)
-	}
-
-	clusterJSON, err := json.Marshal(mcCluster)
-	if err != nil {
-		return nil, fmt.Errorf("marshal machineconfiguration/cluster: %w", err)
-	}
-
-	return clusterJSON, nil
-}
-
-func commatrixPatchMachineConfigurationClusterJSON(patch []byte) error {
-	if len(patch) == 0 || string(patch) == "[]" {
-		return nil
-	}
-
-	mcCluster := &operatorv1.MachineConfiguration{
-		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
-	}
-
-	return APIClient.Patch(
-		context.TODO(),
-		mcCluster,
-		goclient.RawPatch(apimachinerytypes.JSONPatchType, patch),
-	)
-}
-
-func commatrixFormatMCPStatusSnapshot() (string, error) {
-	mcpList, err := mco.ListMCP(APIClient)
-	if err != nil {
-		return "", err
-	}
-
-	var b strings.Builder
-
-	for _, mcpBuilder := range mcpList {
-		if mcpBuilder == nil || mcpBuilder.Object == nil {
-			continue
-		}
-
-		mcpObj := mcpBuilder.Object
-
-		_, _ = fmt.Fprintf(&b, "%s  updated=%d ready=%d machine=%d degraded=%d\n",
-			mcpObj.Name,
-			mcpObj.Status.UpdatedMachineCount,
-			mcpObj.Status.ReadyMachineCount,
-			mcpObj.Status.MachineCount,
-			mcpObj.Status.DegradedMachineCount,
-		)
-	}
-
-	return strings.TrimRight(b.String(), "\n"), nil
-}
-
-// commatrixRunLocalShell runs shellCmd on the machine executing the test (not via oc debug).
-func commatrixRunLocalShell(shellCmd string) error {
-	localCmd := exec.Command("bash", "-c", shellCmd)
-	localCmd.Env = os.Environ()
-
-	localCmdOut, localCmdErr := localCmd.CombinedOutput()
-
-	if localCmdErr != nil {
-		klog.Infof("local: bash -c %q failed: %v\n%s", shellCmd, localCmdErr, string(localCmdOut))
-	} else {
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("local: bash -c %q\n%s", shellCmd, string(localCmdOut))
-	}
-
-	return localCmdErr
-}
-
+// commatrixTCPProbeNetwork returns the net.Dial network name (tcp4/tcp6/tcp) for a probe target host address.
 func commatrixTCPProbeNetwork(host string) string {
 	ip := net.ParseIP(host)
 	if ip == nil {
@@ -519,6 +252,7 @@ func commatrixTCPProbeNetwork(host string) string {
 	return "tcp6"
 }
 
+// commatrixDialTCP opens a short-lived TCP connection to host:port from the test runner.
 func commatrixDialTCP(host, port string) error {
 	conn, err := net.DialTimeout(commatrixTCPProbeNetwork(host), net.JoinHostPort(host, port), commatrixTCPProbeTimeout)
 	if err != nil {
@@ -534,29 +268,31 @@ func commatrixRunTCPProbeFromRunner(expectConnect bool, host, port string) error
 	addr := net.JoinHostPort(host, port)
 	probeDesc := fmt.Sprintf("dial %s %s", network, addr)
 
-	if expectConnect {
-		if err := commatrixDialTCP(host, port); err != nil {
-			klog.Infof("probe: %s failed: %v", probeDesc, err)
+	dialErr := commatrixDialTCP(host, port)
+	connected := dialErr == nil
 
-			return err
+	if expectConnect == connected {
+		if expectConnect {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("probe: %s succeeded", probeDesc)
+		} else {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("probe: %s failed as expected: %v", probeDesc, dialErr)
 		}
 
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("probe: %s succeeded", probeDesc)
-
 		return nil
 	}
 
-	if err := commatrixDialTCP(host, port); err != nil {
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("probe: %s failed as expected: %v", probeDesc, err)
+	if expectConnect {
+		klog.Infof("probe: %s failed (expected connect): %v", probeDesc, dialErr)
 
-		return nil
+		return dialErr
 	}
 
-	klog.Infof("probe: %s unexpectedly connected", probeDesc)
+	klog.Infof("probe: %s unexpectedly connected (expected blocked)", probeDesc)
 
 	return fmt.Errorf("expected connection to %s to fail, but dial succeeded", addr)
 }
 
+// commatrixProbeLabel returns a short IPv4/IPv6 label for probe log messages.
 func commatrixProbeLabel(addr string) string {
 	if ip := net.ParseIP(addr); ip != nil && ip.To4() == nil {
 		return "IPv6 " + addr
@@ -619,327 +355,6 @@ func commatrixRunOnNodeHostDebug(nodeName string, cmd []string) (string, error) 
 	return hostDebugCmdOut, hostDebugCmdErr
 }
 
-// commatrixButaneBasenameToMC replaces the first case-insensitive "butane" substring in a filename with "mc".
-func commatrixButaneBasenameToMC(name string) (string, bool) {
-	lower := strings.ToLower(name)
-	i := strings.Index(lower, "butane")
-	if i < 0 {
-		return "", false
-	}
-
-	return name[:i] + "mc" + name[i+len("butane"):], true
-}
-
-type commatrixButaneRenderJob struct {
-	srcRel string
-	outRel string
-}
-
-func commatrixDiscoverButaneRenderJobs(buRawRoot string) ([]commatrixButaneRenderJob, error) {
-	seenOut := make(map[string]string)
-
-	var jobs []commatrixButaneRenderJob
-
-	err := filepath.WalkDir(buRawRoot, func(path string, d os.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-
-		if d.IsDir() {
-			return nil
-		}
-
-		rel, err := filepath.Rel(buRawRoot, path)
-		if err != nil {
-			return err
-		}
-
-		base := filepath.Base(rel)
-		ext := strings.ToLower(filepath.Ext(base))
-
-		var outRel string
-
-		switch {
-		case strings.Contains(strings.ToLower(base), "butane") && (ext == commatrixFileExtYAML || ext == commatrixFileExtYML):
-			newBase, ok := commatrixButaneBasenameToMC(base)
-			if !ok {
-				return nil
-			}
-
-			outRel = filepath.Join(filepath.Dir(rel), newBase)
-		case ext == ".bu":
-			outRel = filepath.Join(filepath.Dir(rel), strings.TrimSuffix(base, filepath.Ext(base))+commatrixFileExtYAML)
-		default:
-			return nil
-		}
-
-		outRel = filepath.Clean(outRel)
-
-		if prev, ok := seenOut[outRel]; ok {
-			return fmt.Errorf("duplicate rendered MC path %q from sources %q and %q", outRel, prev, rel)
-		}
-
-		seenOut[outRel] = rel
-		jobs = append(jobs, commatrixButaneRenderJob{srcRel: rel, outRel: outRel})
-
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	sort.Slice(jobs, func(i, j int) bool {
-		return jobs[i].srcRel < jobs[j].srcRel
-	})
-
-	return jobs, nil
-}
-
-func commatrixYAMLEquivalent(leftYAML, rightYAML []byte) error {
-	leftJSON, err := yaml.YAMLToJSON(bytes.TrimSpace(leftYAML))
-	if err != nil {
-		return fmt.Errorf("left yaml-to-json: %w", err)
-	}
-
-	rightJSON, err := yaml.YAMLToJSON(bytes.TrimSpace(rightYAML))
-	if err != nil {
-		return fmt.Errorf("right yaml-to-json: %w", err)
-	}
-
-	if !bytes.Equal(leftJSON, rightJSON) {
-		return fmt.Errorf(
-			"MachineConfig YAML differs after YAML→JSON normalization (left %d B, right %d B)",
-			len(leftJSON), len(rightJSON))
-	}
-
-	return nil
-}
-
-func commatrixListMachineConfigYAMLRels(root string) ([]string, error) {
-	var rels []string
-
-	err := filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-
-		if d.IsDir() {
-			return nil
-		}
-
-		ext := strings.ToLower(filepath.Ext(path))
-		if ext != commatrixFileExtYAML && ext != commatrixFileExtYML {
-			return nil
-		}
-
-		baseName := strings.ToLower(filepath.Base(path))
-		if baseName == "node-disruption-policy.yaml" || baseName == "node-disruption-policy.yml" {
-			return nil
-		}
-
-		raw, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-
-		if !bytes.Contains(raw, []byte("kind: MachineConfig")) && !bytes.Contains(raw, []byte("kind: \"MachineConfig\"")) {
-			return nil
-		}
-
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-
-		rels = append(rels, filepath.ToSlash(rel))
-
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	sort.Strings(rels)
-
-	return rels, nil
-}
-
-// commatrixFindNodeDisruptionPolicyPatch returns the absolute path to a single node-disruption-policy.yaml
-// under root (e.g. format-mc). MachineConfig apply skips that file; merged via API patch on MachineConfiguration cluster instead.
-// If none are present, returns ("", nil). More than one match is an error.
-func commatrixFindNodeDisruptionPolicyPatch(root string) (string, error) {
-	var matches []string
-
-	err := filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-
-		if d.IsDir() {
-			return nil
-		}
-
-		if strings.ToLower(filepath.Base(path)) == "node-disruption-policy.yaml" {
-			rel, errRel := filepath.Rel(root, path)
-			if errRel != nil {
-				return errRel
-			}
-
-			matches = append(matches, filepath.ToSlash(rel))
-		}
-
-		return nil
-	})
-	if err != nil {
-		return "", err
-	}
-
-	sort.Strings(matches)
-
-	switch len(matches) {
-	case 0:
-		return "", nil
-	case 1:
-		abs := filepath.Join(root, filepath.FromSlash(matches[0]))
-
-		return filepath.Clean(abs), nil
-	default:
-		return "", fmt.Errorf("multiple node-disruption-policy.yaml files under %s: %v", root, matches)
-	}
-}
-
-func commatrixCompareMCDirectVsRendered(mcRoot, renderRoot string) {
-	mcRels, err := commatrixListMachineConfigYAMLRels(mcRoot)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(mcRels).NotTo(BeEmpty(), "no MachineConfig YAML under direct mc output %s", mcRoot)
-
-	renderedRels, err := commatrixListMachineConfigYAMLRels(renderRoot)
-	Expect(err).NotTo(HaveOccurred())
-
-	Expect(renderedRels).To(Equal(mcRels),
-		"MachineConfig relative paths under %s and %s should match exactly", mcRoot, renderRoot)
-
-	for _, rel := range mcRels {
-		relOS := filepath.FromSlash(rel)
-
-		left, err := os.ReadFile(filepath.Join(mcRoot, relOS))
-		Expect(err).NotTo(HaveOccurred(), "read direct mc %s", rel)
-
-		right, err := os.ReadFile(filepath.Join(renderRoot, relOS))
-		Expect(err).NotTo(HaveOccurred(), "read butane-rendered mc %s", rel)
-
-		errEq := commatrixYAMLEquivalent(left, right)
-		Expect(errEq).NotTo(HaveOccurred(), "MachineConfig %q: direct mc vs butane-rendered differ: %v", rel, errEq)
-	}
-}
-
-// commatrixDecodeDataURLLinePayload decodes ignition data: URL payloads from generated MCs:
-// awk -F ',' '/source: data:/ {print $NF}' ... | base64 -d | gunzip
-// Ignition often uses a single line `source: data:...;base64,<payload>`.
-func commatrixDecodeDataURLLinePayload(line string) ([]byte, bool) {
-	lineLower := strings.ToLower(line)
-	if !strings.Contains(lineLower, "source:") || !strings.Contains(lineLower, "data:") {
-		return nil, false
-	}
-
-	idx := strings.Index(lineLower, "base64,")
-	if idx < 0 {
-		return nil, false
-	}
-
-	b64 := strings.TrimSpace(line[idx+len("base64,"):])
-	b64 = strings.Trim(b64, `"'`)
-
-	raw, err := base64.StdEncoding.DecodeString(b64)
-	if err != nil {
-		return nil, false
-	}
-
-	if len(raw) >= 2 && raw[0] == 0x1f && raw[1] == 0x8b {
-		zr, errZ := gzip.NewReader(bytes.NewReader(raw))
-		if errZ != nil {
-			return nil, false
-		}
-
-		out, errR := io.ReadAll(zr)
-		_ = zr.Close()
-		if errR != nil {
-			return nil, false
-		}
-
-		return out, true
-	}
-
-	return raw, true
-}
-
-func commatrixCollectDecodedDataURLPayloads(mcYAML []byte) [][]byte {
-	var out [][]byte
-
-	for _, line := range strings.Split(string(mcYAML), "\n") {
-		if p, ok := commatrixDecodeDataURLLinePayload(line); ok {
-			out = append(out, p)
-		}
-	}
-
-	return out
-}
-
-func commatrixExpectDecodedHostFirewallNFTables(decoded []byte, mcRel string) {
-	s := strings.ToLower(string(decoded))
-
-	Expect(s).To(ContainSubstring("table inet openshift_filter"),
-		"mc %s: decoded payload should define table inet openshift_filter", mcRel)
-	Expect(s).To(ContainSubstring("delete table inet openshift_filter"),
-		"mc %s: decoded payload should delete table inet openshift_filter before recreate", mcRel)
-	Expect(s).To(ContainSubstring("type filter hook input"),
-		"mc %s: decoded payload should use an input filter hook (host firewall)", mcRel)
-	Expect(s).To(ContainSubstring("tcp dport"),
-		"mc %s: decoded payload should open tcp destination ports", mcRel)
-	Expect(s).To(ContainSubstring("udp dport"),
-		"mc %s: decoded payload should open udp destination ports", mcRel)
-	Expect(s).To(ContainSubstring("accept"),
-		"mc %s: decoded payload should contain accept rules", mcRel)
-	Expect(s).To(ContainSubstring("log"),
-		"mc %s: decoded payload should contain log rules (rate-limited firewall logging)", mcRel)
-	Expect(s).To(ContainSubstring("chain openshift"),
-		"mc %s: decoded payload should define openshift chain (e.g. OPENSHIFT)", mcRel)
-}
-
-// commatrixVerifyHostFirewallNFTablesInMCRoot walks MachineConfig YAML under root, decodes any
-// ignition `source: data:...;base64,...` lines, and asserts at least one payload is the openshift_filter ruleset.
-func commatrixVerifyHostFirewallNFTablesInMCRoot(mcRoot string) {
-	rels, err := commatrixListMachineConfigYAMLRels(mcRoot)
-	Expect(err).NotTo(HaveOccurred(), "list MachineConfigs under %s", mcRoot)
-
-	var verifiedRel string
-
-	for _, rel := range rels {
-		raw, errRead := os.ReadFile(filepath.Join(mcRoot, filepath.FromSlash(rel)))
-		Expect(errRead).NotTo(HaveOccurred(), "read MachineConfig %s", rel)
-
-		for _, payload := range commatrixCollectDecodedDataURLPayloads(raw) {
-			if !strings.Contains(strings.ToLower(string(payload)), "table inet openshift_filter") {
-				continue
-			}
-
-			commatrixExpectDecodedHostFirewallNFTables(payload, rel)
-			verifiedRel = rel
-
-			break
-		}
-
-		if verifiedRel != "" {
-			break
-		}
-	}
-
-	Expect(verifiedRel).NotTo(BeEmpty(),
-		"no MachineConfig under %s contained a data: URL payload decoding to openshift_filter nftables", mcRoot)
-
-	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("validated host-firewall nftables in %s under %s", verifiedRel, mcRoot)
-}
-
 // commatrixExtractOpenshiftFilterRuleLines returns non-empty nft rule lines from a decoded openshift_filter payload.
 func commatrixExtractOpenshiftFilterRuleLines(nftText string) []string {
 	var rules []string
@@ -968,201 +383,422 @@ func commatrixExtractOpenshiftFilterRuleLines(nftText string) []string {
 	return rules
 }
 
-// commatrixLogOpenshiftFilterRulesByPool logs openshift_filter rules from each mc-<pool>.yaml
-// and, when the cluster API is available, the node names that match each pool's MachineConfigPool nodeSelector.
-func commatrixLogOpenshiftFilterRulesByPool(mcRoot string) {
-	rels, err := commatrixListMachineConfigYAMLRels(mcRoot)
-	if err != nil {
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Commatrix artifacts: openshift_filter rule dump skipped: list MachineConfigs under %s: %v", mcRoot, err)
-
-		return
+// commatrixExtractPortNumbersAfterDport parses TCP/UDP destination port numbers from one nftables rule line.
+func commatrixExtractPortNumbersAfterDport(ruleLine string) []int {
+	lower := strings.ToLower(ruleLine)
+	dportIdx := strings.Index(lower, " dport ")
+	if dportIdx < 0 {
+		return nil
 	}
 
-	sort.Strings(rels)
+	rest := strings.TrimSpace(ruleLine[dportIdx+len(" dport "):])
+	for _, stopWord := range []string{" accept", " drop", " reject", " log", " counter", " limit"} {
+		if stopIdx := strings.Index(strings.ToLower(rest), stopWord); stopIdx >= 0 {
+			rest = strings.TrimSpace(rest[:stopIdx])
+		}
+	}
 
-	for _, rel := range rels {
-		raw, errRead := os.ReadFile(filepath.Join(mcRoot, filepath.FromSlash(rel)))
-		if errRead != nil {
-			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Commatrix artifacts: read MachineConfig %s: %v", rel, errRead)
+	rest = strings.Trim(rest, "{}")
+
+	var ports []int
+
+	for _, token := range strings.Split(rest, ",") {
+		token = strings.TrimSpace(token)
+		if token == "" {
+			continue
+		}
+
+		if dashIdx := strings.Index(token, "-"); dashIdx > 0 {
+			startStr := strings.TrimSpace(token[:dashIdx])
+			endStr := strings.TrimSpace(token[dashIdx+1:])
+
+			startPort, errStart := strconv.Atoi(startStr)
+			endPort, errEnd := strconv.Atoi(endStr)
+			if errStart == nil && errEnd == nil && startPort > 0 && endPort >= startPort && endPort <= 65535 {
+				for p := startPort; p <= endPort && p <= startPort+32; p++ {
+					ports = append(ports, p)
+				}
+			}
 
 			continue
 		}
 
-		pool, hasPool := commatrixMachineConfigPoolNameFromMCRel(rel)
-		if !hasPool {
-			pool = "(unknown pool — expected mc-<pool>.yaml)"
-		}
-
-		var logged bool
-
-		for _, payload := range commatrixCollectDecodedDataURLPayloads(raw) {
-			if !strings.Contains(strings.ToLower(string(payload)), "table inet openshift_filter") {
-				continue
+		for _, match := range commatrixNFTablesPortTokenRe.FindAllString(token, -1) {
+			portNum, errAtoi := strconv.Atoi(match)
+			if errAtoi == nil && portNum > 0 && portNum <= 65535 {
+				ports = append(ports, portNum)
 			}
-
-			logged = true
-
-			targetNodes := "(cluster API unavailable)"
-			if APIClient != nil && hasPool {
-				if nodeNames, errNodes := commatrixNodesFromMachineConfigPools([]string{pool}); errNodes != nil {
-					targetNodes = fmt.Sprintf("(list nodes for pool %q: %v)", pool, errNodes)
-				} else if len(nodeNames) == 0 {
-					targetNodes = "(no nodes matched pool nodeSelector yet)"
-				} else {
-					targetNodes = strings.Join(nodeNames, ", ")
-				}
-			}
-
-			ruleLines := commatrixExtractOpenshiftFilterRuleLines(string(payload))
-			if len(ruleLines) == 0 {
-				klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Commatrix artifacts: MachineConfig %s pool=%q target node(s): %s\nopenshift_filter payload (no discrete rule lines parsed):\n%s",
-					rel, pool, targetNodes, strings.TrimSpace(string(payload)))
-
-				continue
-			}
-
-			var b strings.Builder
-			_, _ = fmt.Fprintf(&b, "Commatrix artifacts: MachineConfig %s pool=%q target node(s): %s\nopenshift_filter rules (%d):",
-				rel, pool, targetNodes, len(ruleLines))
-
-			for i, rule := range ruleLines {
-				_, _ = fmt.Fprintf(&b, "\n  [%d] %s", i+1, rule)
-			}
-
-			klog.Info(b.String())
-		}
-
-		if !logged {
-			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Commatrix artifacts: MachineConfig %s pool=%q: no openshift_filter data: URL payload", rel, pool)
 		}
 	}
+
+	return ports
 }
 
-func commatrixRenderButaneRawToRenderedMC(buRawRoot, renderRoot string) {
-	jobs, err := commatrixDiscoverButaneRenderJobs(buRawRoot)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(jobs).NotTo(BeEmpty(), "no butane inputs (*butane*.yaml/.yml or *.bu) found under %s", buRawRoot)
+// commatrixParseAcceptedTCPDPortsFromNFTables builds the set of TCP dports with accept rules in openshift_filter text.
+func commatrixParseAcceptedTCPDPortsFromNFTables(nftText string) map[int]struct{} {
+	allowed := make(map[int]struct{})
 
-	for _, j := range jobs {
-		absIn := filepath.Join(buRawRoot, j.srcRel)
-		absOut := filepath.Join(renderRoot, j.outRel)
-
-		errMk := os.MkdirAll(filepath.Dir(absOut), 0o750)
-		Expect(errMk).NotTo(HaveOccurred(), "mkdir for butane output %s", absOut)
-
-		filesDir := filepath.Join(buRawRoot, filepath.Dir(j.srcRel))
-
-		butaneCmd := exec.Command("butane", "--strict", "--files-dir", filesDir, absIn, "-o", absOut)
-		butaneCmd.Env = os.Environ()
-
-		butaneCmdOut, butaneCmdErr := butaneCmd.CombinedOutput()
-		Expect(butaneCmdErr).NotTo(HaveOccurred(), "butane %q -> %q: %s", absIn, absOut, strings.TrimSpace(string(butaneCmdOut)))
-	}
-}
-
-// commatrixVerifyDestDirAfterGenerate asserts destDir contains at least one file (recursive) and prints every file (path, mode, size).
-func commatrixVerifyDestDirAfterGenerate(destDir string) {
-	var lines []string
-
-	n := 0
-
-	err := filepath.WalkDir(destDir, func(path string, d os.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
+	for _, ruleLine := range commatrixExtractOpenshiftFilterRuleLines(nftText) {
+		lower := strings.ToLower(ruleLine)
+		if !strings.Contains(lower, "tcp") || !strings.Contains(lower, " dport ") {
+			continue
 		}
 
-		if d.IsDir() {
-			return nil
+		if !strings.Contains(lower, "accept") {
+			continue
 		}
 
-		n++
-
-		rel, relErr := filepath.Rel(destDir, path)
-		if relErr != nil {
-			rel = path
-		}
-
-		fi, errFI := d.Info()
-		if errFI != nil {
-			lines = append(lines, fmt.Sprintf("%s\t?\t?", filepath.ToSlash(rel)))
-
-			return nil
-		}
-
-		lines = append(lines, fmt.Sprintf("%s\t%s\t%d", filepath.ToSlash(rel), fi.Mode().String(), fi.Size()))
-
-		return nil
-	})
-	Expect(err).NotTo(HaveOccurred(), "walk commatrix destDir %q", destDir)
-	Expect(n).To(BeNumerically(">", 0), "expected at least one file under %s", destDir)
-
-	sort.Strings(lines)
-
-	listing := strings.Join(lines, "\n")
-
-	_, _ = fmt.Fprintf(GinkgoWriter, "\n=== commatrix destDir %q (%d files) ===\n%s\n\n", destDir, n, listing)
-
-	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("commatrix destDir %q: %d files\n%s", destDir, n, listing)
-
-	By(fmt.Sprintf("Verifying commatrix output directory (%d files)", n))
-}
-
-func commatrixPickMCPoolName(candidates []string, match func(string) bool) string {
-	for _, p := range candidates {
-		if match(p) {
-			return p
+		for _, portNum := range commatrixExtractPortNumbersAfterDport(ruleLine) {
+			allowed[portNum] = struct{}{}
 		}
 	}
+
+	return allowed
+}
+
+// commatrixFormatPortSet returns sorted port numbers from a port set for logging and selection.
+func commatrixFormatPortSet(portSet map[int]struct{}) []int {
+	ports := make([]int, 0, len(portSet))
+	for portNum := range portSet {
+		ports = append(ports, portNum)
+	}
+
+	sort.Ints(ports)
+
+	return ports
+}
+
+// commatrixPickBlockedTCPPort chooses a TCP port not present in the nft accept set for blocked-connectivity probes.
+func commatrixPickBlockedTCPPort(allowed map[int]struct{}) int {
+	candidates := []int{
+		commatrixAPIPort,
+		commatrixClosedTCPPort,
+		443,
+		8080,
+		8443,
+		9090,
+	}
+
+	for _, candidate := range candidates {
+		if _, open := allowed[candidate]; !open {
+			return candidate
+		}
+	}
+
+	klog.Warningf(
+		"Commatrix: all blocked-port candidates %v are in nft accept rules %v; falling back to default closed port %d",
+		candidates, commatrixFormatPortSet(allowed), commatrixClosedTCPPort)
+
+	return commatrixClosedTCPPort
+}
+
+// commatrixSelectProbePorts picks distinct open (accepted) and blocked probe ports from an nft accept port set.
+func commatrixSelectProbePorts(allowed map[int]struct{}) (openPort, blockedPort int, err error) {
+	if len(allowed) == 0 {
+		return 0, 0, fmt.Errorf("no accepted tcp dport rules found in openshift_filter")
+	}
+
+	if _, ok := allowed[commatrixKubeletPort]; ok {
+		openPort = commatrixKubeletPort
+	} else {
+		openPort = commatrixFormatPortSet(allowed)[0]
+	}
+
+	blockedPort = commatrixPickBlockedTCPPort(allowed)
+	if blockedPort == openPort {
+		return 0, 0, fmt.Errorf("could not pick distinct open/blocked probe ports from allowed set %v",
+			commatrixFormatPortSet(allowed))
+	}
+
+	return openPort, blockedPort, nil
+}
+
+// commatrixAllowedTCPDPortsFromNode lists accepted TCP dports from live openshift_filter rules on a node.
+func commatrixAllowedTCPDPortsFromNode(nodeName string) (map[int]struct{}, error) {
+	nftListShellCmd := "nft list table inet openshift_filter 2>/dev/null || nft list ruleset 2>/dev/null || true"
+
+	nftOutput, err := commatrixRunOnNodeHostShell(nodeName, nftListShellCmd)
+	if err != nil {
+		return nil, fmt.Errorf("list openshift_filter nftables on %q: %w", nodeName, err)
+	}
+
+	allowed := commatrixParseAcceptedTCPDPortsFromNFTables(nftOutput)
+	if len(allowed) == 0 {
+		return nil, fmt.Errorf(
+			"no accepted tcp dport rules in openshift_filter on %q; nft output:\n%s",
+			nodeName, strings.TrimSpace(nftOutput))
+	}
+
+	klog.Infof("Commatrix: node %q accepted tcp dports from nft: %v",
+		nodeName, commatrixFormatPortSet(allowed))
+
+	return allowed, nil
+}
+
+// commatrixResolveSecureProbePorts reads nft rules on nodeName and stores open/blocked ports in workflow state.
+func commatrixResolveSecureProbePorts(nodeName string) error {
+	allowed, err := commatrixAllowedTCPDPortsFromNode(nodeName)
+	if err != nil {
+		return err
+	}
+
+	openPort, blockedPort, errPick := commatrixSelectProbePorts(allowed)
+	if errPick != nil {
+		return errPick
+	}
+
+	commatrixWorkflow.run.SecureOpenPort = openPort
+	commatrixWorkflow.run.SecureBlockedPort = blockedPort
+
+	klog.Infof("Commatrix: secure worker %q probe ports open=%d blocked=%d (from nft accept rules)",
+		nodeName, openPort, blockedPort)
+
+	return nil
+}
+
+// commatrixFilterPoolsOnCluster keeps only pool names that exist as MachineConfigPool objects on the cluster.
+func commatrixFilterPoolsOnCluster(pools []string) []string {
+	filtered := make([]string, 0, len(pools))
+
+	for _, poolName := range pools {
+		mcpB, errPull := mco.Pull(APIClient, poolName)
+		if errPull != nil {
+			klog.Infof("Commatrix: skip pool %q from commatrix MC: MachineConfigPool not found: %v", poolName, errPull)
+
+			continue
+		}
+
+		if _, errGet := mcpB.Get(); errGet != nil {
+			klog.Infof("Commatrix: skip pool %q from commatrix MC: get MachineConfigPool failed: %v", poolName, errGet)
+
+			continue
+		}
+
+		filtered = append(filtered, poolName)
+	}
+
+	sort.Strings(filtered)
+
+	return filtered
+}
+
+// commatrixNodeHasControlPlaneRole reports whether a node has control-plane/master role labels.
+func commatrixNodeHasControlPlaneRole(nb *nodes.Builder) bool {
+	if nb == nil || nb.Object == nil {
+		return false
+	}
+
+	nodeLabels := nb.Object.Labels
+	if nodeLabels == nil {
+		return false
+	}
+
+	if _, ok := nodeLabels["node-role.kubernetes.io/master"]; ok {
+		return true
+	}
+
+	_, hasControlPlane := nodeLabels["node-role.kubernetes.io/control-plane"]
+
+	return hasControlPlane
+}
+
+// commatrixNodeHasWorkerRole reports whether a node has the worker role label.
+func commatrixNodeHasWorkerRole(nb *nodes.Builder) bool {
+	if nb == nil || nb.Object == nil || nb.Object.Labels == nil {
+		return false
+	}
+
+	_, ok := nb.Object.Labels["node-role.kubernetes.io/worker"]
+
+	return ok
+}
+
+// commatrixPoolNodeBuilders returns node builders for all nodes matched by a MachineConfigPool nodeSelector.
+func commatrixPoolNodeBuilders(poolName string) ([]*nodes.Builder, error) {
+	nodeNames, err := commatrixNodesFromMachineConfigPools([]string{poolName})
+	if err != nil {
+		return nil, err
+	}
+
+	builders := make([]*nodes.Builder, 0, len(nodeNames))
+
+	for _, nodeName := range nodeNames {
+		nb, errPull := nodes.Pull(APIClient, nodeName)
+		if errPull != nil {
+			return nil, fmt.Errorf("pull node %q in pool %q: %w", nodeName, poolName, errPull)
+		}
+
+		builders = append(builders, nb)
+	}
+
+	return builders, nil
+}
+
+// commatrixPoolIsControlPlaneOnly reports whether every node in the MCP is a control-plane node.
+func commatrixPoolIsControlPlaneOnly(poolName string) bool {
+	nodeBuilders, err := commatrixPoolNodeBuilders(poolName)
+	if err != nil || len(nodeBuilders) == 0 {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Commatrix: pool %q control-plane check skipped: %v", poolName, err)
+
+		return false
+	}
+
+	for _, nb := range nodeBuilders {
+		if !commatrixNodeHasControlPlaneRole(nb) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// commatrixPoolIsStorageOnly reports whether every node in the MCP is storage-role without worker or control-plane roles.
+func commatrixPoolIsStorageOnly(poolName string) bool {
+	nodeBuilders, err := commatrixPoolNodeBuilders(poolName)
+	if err != nil || len(nodeBuilders) == 0 {
+		return false
+	}
+
+	for _, nb := range nodeBuilders {
+		if nb == nil || nb.Object == nil || nb.Object.Labels == nil {
+			return false
+		}
+
+		nodeLabels := nb.Object.Labels
+		_, hasStorage := nodeLabels["node-role.kubernetes.io/storage"]
+		if !hasStorage {
+			return false
+		}
+
+		if commatrixNodeHasWorkerRole(nb) || commatrixNodeHasControlPlaneRole(nb) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// commatrixPoolHasWorkerNodes reports whether the MCP contains at least one worker or non-control-plane node.
+func commatrixPoolHasWorkerNodes(poolName string) bool {
+	nodeBuilders, err := commatrixPoolNodeBuilders(poolName)
+	if err != nil || len(nodeBuilders) == 0 {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Commatrix: pool %q worker check skipped: %v", poolName, err)
+
+		return false
+	}
+
+	for _, nb := range nodeBuilders {
+		if commatrixNodeHasWorkerRole(nb) {
+			return true
+		}
+
+		if !commatrixNodeHasControlPlaneRole(nb) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// commatrixInferMasterMCPoolNameFromPools selects the control-plane MCP from commatrix-discovered pool names.
+func commatrixInferMasterMCPoolNameFromPools(pools []string) string {
+	onCluster := commatrixFilterPoolsOnCluster(pools)
+
+	klog.Infof("Commatrix: infer master MCP from on-cluster pools: %v", onCluster)
+
+	for _, poolName := range onCluster {
+		if strings.EqualFold(poolName, "master") {
+			klog.Infof("Commatrix: selected master MCP %q (standard pool name)", poolName)
+
+			return poolName
+		}
+	}
+
+	for _, poolName := range onCluster {
+		if commatrixPoolIsControlPlaneOnly(poolName) {
+			klog.Infof("Commatrix: selected master MCP %q (control-plane nodes only)", poolName)
+
+			return poolName
+		}
+	}
+
+	for _, poolName := range onCluster {
+		lower := strings.ToLower(poolName)
+		if strings.Contains(lower, "master") && !strings.Contains(lower, "storage") {
+			klog.Infof("Commatrix: selected master MCP %q (name contains master)", poolName)
+
+			return poolName
+		}
+	}
+
+	klog.Infof("Commatrix: could not infer master MCP from pools %v", onCluster)
 
 	return ""
 }
 
+// commatrixInferSecureMCPoolNameFromPools selects the worker MCP used for host-firewall connectivity probes.
 func commatrixInferSecureMCPoolNameFromPools(pools []string) string {
-	if p := commatrixPickMCPoolName(pools, func(name string) bool {
-		lower := strings.ToLower(name)
+	onCluster := commatrixFilterPoolsOnCluster(pools)
+	masterPool := commatrixInferMasterMCPoolNameFromPools(onCluster)
 
-		return strings.Contains(lower, "appworker") && strings.Contains(lower, "mcp-a")
-	}); p != "" {
-		return p
-	}
+	klog.Infof("Commatrix: infer secure MCP from on-cluster pools=%v masterPool=%q", onCluster, masterPool)
 
-	if p := commatrixPickMCPoolName(pools, func(name string) bool {
-		return strings.Contains(strings.ToLower(name), "appworker")
-	}); p != "" {
-		return p
-	}
+	candidates := make([]string, 0, len(onCluster))
 
-	return commatrixPickMCPoolName(pools, func(name string) bool {
-		lower := strings.ToLower(name)
-
-		return !strings.Contains(lower, "master") && !strings.Contains(lower, "storage")
-	})
-}
-
-func commatrixInferSecureMCPoolName() string {
-	pools := commatrixWorkflow.appliedMCPoolNames
-	if len(pools) == 0 {
-		pools = commatrixWorkflow.generatedMCPoolNames
-	}
-
-	return commatrixInferSecureMCPoolNameFromPools(pools)
-}
-
-func commatrixInferMasterMCPoolNameFromPools(pools []string) string {
-	for _, p := range pools {
-		if strings.EqualFold(p, "master") {
-			return p
+	for _, poolName := range onCluster {
+		if poolName == masterPool {
+			continue
 		}
+
+		if commatrixPoolIsControlPlaneOnly(poolName) {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Commatrix: skip pool %q for secure MCP (control-plane only)", poolName)
+
+			continue
+		}
+
+		if commatrixPoolIsStorageOnly(poolName) {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Commatrix: skip pool %q for secure MCP (storage-only nodes)", poolName)
+
+			continue
+		}
+
+		if !commatrixPoolHasWorkerNodes(poolName) {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Commatrix: skip pool %q for secure MCP (no worker nodes)", poolName)
+
+			continue
+		}
+
+		candidates = append(candidates, poolName)
 	}
 
-	return commatrixPickMCPoolName(pools, func(name string) bool {
-		lower := strings.ToLower(name)
+	if len(candidates) == 0 {
+		for _, poolName := range onCluster {
+			if poolName != masterPool {
+				candidates = append(candidates, poolName)
+			}
+		}
 
-		return strings.Contains(lower, "master") && !strings.Contains(lower, "storage") &&
-			!strings.Contains(lower, "appworker") && !strings.Contains(lower, "gateway")
-	})
+		klog.Infof("Commatrix: no worker MCP matched heuristics; fallback non-master candidates: %v", candidates)
+	}
+
+	if len(candidates) == 0 {
+		klog.Infof("Commatrix: could not infer secure MCP from pools %v", onCluster)
+
+		return ""
+	}
+
+	sort.Strings(candidates)
+
+	if len(candidates) > 1 {
+		klog.Infof("Commatrix: multiple secure MCP candidates %v; using %q", candidates, candidates[0])
+	} else {
+		klog.Infof("Commatrix: selected secure MCP %q", candidates[0])
+	}
+
+	return candidates[0]
 }
 
+// commatrixSetWorkerFromNodeName records the secure-worker node name and external probe IPs in workflow state.
 func commatrixSetWorkerFromNodeName(nodeName string) error {
 	nb, errPull := nodes.Pull(APIClient, nodeName)
 	if errPull != nil {
@@ -1185,6 +821,8 @@ func commatrixResolveConnectivityTopology() error {
 	commatrixWorkflow.run.MasterIPs = nil
 	commatrixWorkflow.run.SecureWorkerName = ""
 	commatrixWorkflow.run.SecureWorkerIPs = nil
+	commatrixWorkflow.run.SecureOpenPort = 0
+	commatrixWorkflow.run.SecureBlockedPort = 0
 
 	masters, err := nodes.List(APIClient, metav1.ListOptions{LabelSelector: commatrixMasterLabelSelector()})
 	if err != nil {
@@ -1194,6 +832,8 @@ func commatrixResolveConnectivityTopology() error {
 	if len(masters) == 0 {
 		return fmt.Errorf("no nodes matched master label %q", commatrixMasterLabelSelector())
 	}
+
+	klog.Infof("Commatrix: resolving connectivity topology from master node %q", masters[0].Definition.Name)
 
 	masterIPs, err := commatrixNodeProbeIPs(masters[0])
 	if err != nil {
@@ -1210,6 +850,18 @@ func commatrixResolveConnectivityTopology() error {
 	if err := commatrixSetWorkerFromNodeName(nftNode); err != nil {
 		return fmt.Errorf("secure worker %q: %w", nftNode, err)
 	}
+
+	if err := commatrixResolveSecureProbePorts(nftNode); err != nil {
+		return fmt.Errorf("resolve secure worker probe ports on %q: %w", nftNode, err)
+	}
+
+	klog.Infof(
+		"Commatrix: connectivity topology masterIPs=%v secureWorker=%q secureWorkerIPs=%v openPort=%d blockedPort=%d",
+		commatrixWorkflow.run.MasterIPs,
+		commatrixWorkflow.run.SecureWorkerName,
+		commatrixWorkflow.run.SecureWorkerIPs,
+		commatrixWorkflow.run.SecureOpenPort,
+		commatrixWorkflow.run.SecureBlockedPort)
 
 	return nil
 }
@@ -1238,7 +890,7 @@ func commatrixProbeHostAddr(raw string) (string, error) {
 	return ip.String(), nil
 }
 
-// commatrixNodeProbeIPs returns IPv4 then IPv6 node addresses for nc probes via eco-goinfra nodes helpers.
+// commatrixNodeProbeIPs returns IPv4 then IPv6 node addresses for TCP probes via eco-goinfra nodes helpers.
 func commatrixNodeProbeIPs(nb *nodes.Builder) ([]string, error) {
 	var ips []string
 
@@ -1259,95 +911,6 @@ func commatrixNodeProbeIPs(nb *nodes.Builder) ([]string, error) {
 	}
 
 	return ips, nil
-}
-
-// commatrixFormatMCDir returns the direct oc commatrix mc output directory (<output_dir>/format-mc).
-func commatrixFormatMCDir() (string, error) {
-	dest := strings.TrimSpace(RDSCoreConfig.CommatrixOutputDir)
-	if dest == "" {
-		return "", fmt.Errorf("CommatrixOutputDir is empty")
-	}
-
-	return filepath.Join(filepath.Clean(dest), commatrixFormatMCSubdir), nil
-}
-
-func commatrixWaitAllMachineConfigPoolsStable(stepLabel string) {
-	By(fmt.Sprintf("%s — wait for all MachineConfigPools to stabilize (ready == updated == machine count; no degraded)", stepLabel))
-
-	err := mco.ListMCPWaitToBeStableFor(APIClient, 90*time.Second, commatrixMCPStableWait)
-	Expect(err).NotTo(HaveOccurred(), "%s: all MCPs did not stabilize within timeout", stepLabel)
-
-	mcpSnapshot, mcpSnapshotErr := commatrixFormatMCPStatusSnapshot()
-	Expect(mcpSnapshotErr).NotTo(HaveOccurred(), "%s: list MachineConfigPools", stepLabel)
-
-	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("%s: MCP snapshot after stable wait:\n%s", stepLabel, mcpSnapshot)
-}
-
-// commatrixMachineConfigPoolNameFromMCRel extracts the MachineConfigPool name from a commatrix MachineConfig path.
-// This workflow requires basenames mc-<pool>.yaml or mc-<pool>.yml (e.g. mc-appworker-mcp-a.yaml → appworker-mcp-a).
-func commatrixMachineConfigPoolNameFromMCRel(rel string) (string, bool) {
-	base := filepath.Base(rel)
-	ext := strings.ToLower(filepath.Ext(base))
-	if ext != ".yaml" && ext != ".yml" {
-		return "", false
-	}
-
-	stem := strings.TrimSuffix(base, filepath.Ext(base))
-	if len(stem) < 4 || !strings.HasPrefix(strings.ToLower(stem), "mc-") {
-		return "", false
-	}
-
-	pool := strings.TrimSpace(stem[3:])
-	if pool == "" {
-		return "", false
-	}
-
-	return pool, true
-}
-
-// commatrixMachineConfigPoolNamesFromMCRels returns sorted unique pool names from mc-<pool>.yaml paths (each rel must already match that layout).
-func commatrixMachineConfigPoolNamesFromMCRels(mcRels []string) []string {
-	seen := make(map[string]struct{})
-
-	var pools []string
-
-	for _, rel := range mcRels {
-		if p, ok := commatrixMachineConfigPoolNameFromMCRel(rel); ok {
-			if _, dup := seen[p]; !dup {
-				seen[p] = struct{}{}
-				pools = append(pools, p)
-			}
-		}
-	}
-
-	sort.Strings(pools)
-
-	return pools
-}
-
-// commatrixMCRelsForPools returns mc-<pool>.yaml paths whose pool name is in poolNames.
-func commatrixMCRelsForPools(mcRels []string, poolNames []string) []string {
-	want := make(map[string]struct{}, len(poolNames))
-	for _, p := range poolNames {
-		want[p] = struct{}{}
-	}
-
-	var out []string
-
-	for _, rel := range mcRels {
-		pool, ok := commatrixMachineConfigPoolNameFromMCRel(rel)
-		if !ok {
-			continue
-		}
-
-		if _, match := want[pool]; match {
-			out = append(out, rel)
-		}
-	}
-
-	sort.Strings(out)
-
-	return out
 }
 
 // commatrixNodesFromMachineConfigPools returns sorted unique node names matching each pool's
@@ -1409,220 +972,33 @@ func commatrixNodesFromMachineConfigPools(poolNames []string) ([]string, error) 
 	return out, nil
 }
 
-// commatrixStopNFTOnNode stops nftables on one node (best-effort during suite cleanup).
-func commatrixStopNFTOnNode(nodeName string) {
-	stopNftablesCmdOut, stopNftablesCmdErr := commatrixRunOnNodeHostDebug(nodeName,
-		[]string{"chroot", "/rootfs", "sh", "-c", "systemctl stop nftables || true"})
-	if stopNftablesCmdErr != nil {
-		klog.Errorf("stop nftables on %s: %v\n%s", nodeName, stopNftablesCmdErr, stopNftablesCmdOut)
-
-		return
-	}
-
-	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("stop nftables on %s: %s", nodeName, strings.TrimSpace(stopNftablesCmdOut))
-}
-
 // commatrixRunOnNodeHostShell runs shellCmd on the node host via the MCO daemon pod (chroot /rootfs).
 func commatrixRunOnNodeHostShell(nodeName, shellCmd string) (string, error) {
 	return commatrixRunOnNodeHostDebug(nodeName, []string{"chroot", "/rootfs", "sh", "-c", shellCmd})
 }
 
-// commatrixGenerateArtifacts runs oc commatrix generate for mc and butane, runs the butane CLI in the same
-// directory as the generated butane YAML (mc-*.yaml next to butane-*.yaml), then asserts parity with direct mc output.
-func commatrixGenerateArtifacts(_ SpecContext) {
-	By("Generating commatrix MachineConfig artifacts")
-
-	Expect(strings.TrimSpace(RDSCoreConfig.CommatrixOutputDir)).NotTo(BeEmpty(),
-		"rdscore_commatrix_output_dir is required for oc commatrix generate")
-
-	destDir := filepath.Clean(strings.TrimSpace(RDSCoreConfig.CommatrixOutputDir))
-	mcDir := filepath.Join(destDir, commatrixFormatMCSubdir)
-	buDir := filepath.Join(destDir, commatrixFormatButaneSubdir)
-
-	for _, d := range []string{mcDir, buDir} {
-		_ = os.RemoveAll(d)
-	}
-
-	for _, d := range []string{destDir, mcDir, buDir} {
-		err := os.MkdirAll(d, 0o750)
-		Expect(err).NotTo(HaveOccurred(), "mkdir %s", d)
-	}
-
-	ocCommatrixMcGenCmdOut, ocCommatrixMcGenCmdErr := commatrixRunOC("commatrix", "generate", "--format", "mc", "--host-open-ports", "--destDir", mcDir)
-	Expect(ocCommatrixMcGenCmdErr).NotTo(HaveOccurred(), "oc commatrix generate (mc): %s", ocCommatrixMcGenCmdOut)
-	commatrixVerifyDestDirAfterGenerate(mcDir)
-
-	ocCommatrixButaneGenCmdOut, ocCommatrixButaneGenCmdErr := commatrixRunOC("commatrix", "generate", "--format", "butane", "--host-open-ports", "--destDir", buDir)
-	Expect(ocCommatrixButaneGenCmdErr).NotTo(HaveOccurred(), "oc commatrix generate (butane): %s", ocCommatrixButaneGenCmdOut)
-
-	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("oc commatrix generate (butane): %s", strings.TrimSpace(ocCommatrixButaneGenCmdOut))
-
-	commatrixVerifyDestDirAfterGenerate(buDir)
-
-	By("Rendering butane to MachineConfig")
-	commatrixRenderButaneRawToRenderedMC(buDir, buDir)
-
-	commatrixVerifyDestDirAfterGenerate(buDir)
-
-	By("Comparing direct mc vs butane-rendered MachineConfigs")
-	commatrixCompareMCDirectVsRendered(mcDir, buDir)
-
-	By("Validating host-firewall nftables in generated MachineConfigs")
-	commatrixVerifyHostFirewallNFTablesInMCRoot(mcDir)
-	commatrixVerifyHostFirewallNFTablesInMCRoot(buDir)
-
-	commatrixLogOpenshiftFilterRulesByPool(mcDir)
-}
-
-// commatrixApplyHostFirewallMC patches NDP, applies host-firewall MachineConfigs, waits for MCP stable, verifies nft chain.
-//
-//nolint:funlen
-func commatrixApplyHostFirewallMC(_ SpecContext) {
-	mcDir, err := commatrixFormatMCDir()
-	if err != nil {
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Apply skipped: %v", err)
-
-		return
-	}
-
-	if _, statErr := os.Stat(mcDir); statErr != nil {
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Apply skipped: format-mc missing (%s): %v", mcDir, statErr)
-
-		return
-	}
-
-	mcRels, err := commatrixListMachineConfigYAMLRels(mcDir)
-	Expect(err).NotTo(HaveOccurred(), "list MachineConfigs under %s", mcDir)
-
-	if len(mcRels) == 0 {
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Apply skipped: no MachineConfig YAML under %s", mcDir)
-
-		return
-	}
-
-	for _, rel := range mcRels {
-		_, ok := commatrixMachineConfigPoolNameFromMCRel(rel)
-		Expect(ok).To(BeTrue(),
-			"format-mc MachineConfigs must be named mc-<pool>.yaml (pool = MachineConfigPool name); invalid path %q", rel)
-	}
-
-	ndp, errNdp := commatrixFindNodeDisruptionPolicyPatch(mcDir)
-	Expect(errNdp).NotTo(HaveOccurred(), "find node-disruption-policy.yaml under format-mc")
-	Expect(ndp).NotTo(BeEmpty(),
-		"node-disruption-policy.yaml required under format-mc (oc commatrix generate output)")
-
-	By("Patching MachineConfiguration cluster node disruption policy")
-
-	Expect(commatrixPatchMachineConfigurationClusterMerge(ndp)).NotTo(HaveOccurred(), "cluster NDP patch failed")
-
-	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("patched NDP from %s", ndp)
-	commatrixWorkflow.ndpApplied = true
-
-	commatrixWorkflow.generatedMCPoolNames = commatrixMachineConfigPoolNamesFromMCRels(mcRels)
-	Expect(commatrixWorkflow.generatedMCPoolNames).NotTo(BeEmpty(), "internal: expected pool name(s) from mc-<pool>.yaml paths")
-
-	securePool := commatrixInferSecureMCPoolNameFromPools(commatrixWorkflow.generatedMCPoolNames)
-	Expect(securePool).NotTo(BeEmpty(),
-		"could not infer secure/firewall MCP from generated MCs; set rdscore_commatrix_secure_mcp_name (e.g. appworker-mcp-a)")
-
-	masterPool := commatrixInferMasterMCPoolNameFromPools(commatrixWorkflow.generatedMCPoolNames)
-	Expect(masterPool).NotTo(BeEmpty(),
-		"could not infer master MCP from generated MCs (expected mc-master.yaml)")
-
-	applyPools := []string{securePool, masterPool}
-	applyRels := commatrixMCRelsForPools(mcRels, applyPools)
-	Expect(applyRels).NotTo(BeEmpty(),
-		"no mc-%s.yaml / mc-%s.yaml under %s", securePool, masterPool, mcDir)
-	Expect(commatrixMCRelsForPools(mcRels, []string{masterPool})).NotTo(BeEmpty(),
-		"no mc-%s.yaml under %s; commatrix generate must emit mc-master.yaml", masterPool, mcDir)
-
-	applyRelSet := make(map[string]struct{}, len(applyRels))
-	for _, rel := range applyRels {
-		applyRelSet[rel] = struct{}{}
-	}
-
-	var skippedRels []string
-
-	for _, rel := range mcRels {
-		if _, applied := applyRelSet[rel]; !applied {
-			skippedRels = append(skippedRels, rel)
-		}
-	}
-
-	By("Applying secure-pool and master MachineConfigs")
-
-	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("apply: pools=%v files=%v skipped=%v", applyPools, applyRels, skippedRels)
-
-	for _, rel := range applyRels {
-		abs := filepath.Join(mcDir, filepath.FromSlash(rel))
-
-		Expect(commatrixApplyMachineConfigYAML(abs)).NotTo(HaveOccurred(), "apply MachineConfig %q", rel)
-
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("apply: applied %q", rel)
-	}
-
-	commatrixWaitAllMachineConfigPoolsStable("apply host firewall MCs")
-
-	var errRec error
-
-	commatrixWorkflow.revertNodeNames, errRec = commatrixNodesFromMachineConfigPools(applyPools)
-	Expect(errRec).NotTo(HaveOccurred(), "resolve nodes for applied pool(s) %v", applyPools)
-	Expect(commatrixWorkflow.revertNodeNames).NotTo(BeEmpty(),
-		"no nodes matched MachineConfigPool nodeSelector(s) for applied pools %v (check pool membership on the cluster)", applyPools)
-
-	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("apply: revert nodes (pools %v): %v",
-		applyPools, commatrixWorkflow.revertNodeNames)
-
-	commatrixWorkflow.appliedMCPoolNames = append([]string(nil), applyPools...)
-	commatrixWorkflow.appliedMCRels = append([]string(nil), applyRels...)
-
-	commatrixWorkflow.mcApplied = true
-
-	securePoolNodes, errSecureNodes := commatrixNodesFromMachineConfigPools([]string{securePool})
-	Expect(errSecureNodes).NotTo(HaveOccurred(), "list nodes in secure pool %q", securePool)
-	Expect(securePoolNodes).NotTo(BeEmpty(), "no nodes in secure pool %q for nft probe", securePool)
-
-	nftNode := securePoolNodes[0]
-	commatrixWorkflow.nftProbeNodeName = nftNode
-
-	By(fmt.Sprintf("Verifying openshift_filter chain on node %s", nftNode))
-
-	nftOpenshiftChainShellCmd := "nft list chain inet openshift_filter OPENSHIFT 2>/dev/null || " +
-		"nft list chain inet openshift_filter OPENCHAIN 2>/dev/null || true"
-
-	var nftOpenshiftChainCmdOut string
-
-	err = wait.PollUntilContextTimeout(context.TODO(), 10*time.Second, 3*time.Minute, true,
-		func(context.Context) (bool, error) {
-			var hostDebugCmdErr error
-
-			nftOpenshiftChainCmdOut, hostDebugCmdErr = commatrixRunOnNodeHostDebug(nftNode,
-				[]string{"chroot", "/rootfs", "sh", "-c", nftOpenshiftChainShellCmd})
-			if hostDebugCmdErr != nil {
-				klog.V(rdscoreparams.RDSCoreLogLevel).Infof("nft list (retry) on %s: %v", nftNode, hostDebugCmdErr)
-
-				return false, nil
-			}
-
-			return strings.TrimSpace(nftOpenshiftChainCmdOut) != "", nil
-		})
-	Expect(err).NotTo(HaveOccurred(), "nft openshift_filter/OPENSHIFT chain not visible on %s", nftNode)
-
-	Expect(strings.ToLower(nftOpenshiftChainCmdOut)).To(ContainSubstring("openshift_filter"))
-}
-
-// commatrixVerifyHostFirewallConnectivity probes API/kubelet TCP reachability from the test runner.
+// commatrixVerifyHostFirewallConnectivity probes TCP reachability from the test runner using ports from openshift_filter rules.
 func commatrixVerifyHostFirewallConnectivity(_ SpecContext) {
 	By("Resolving cluster topology for connectivity probes")
 
 	Expect(commatrixResolveConnectivityTopology()).NotTo(HaveOccurred())
 
-	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Commatrix connectivity probes: masterIPs=%v secure=%s/%v",
-		commatrixWorkflow.run.MasterIPs, commatrixWorkflow.run.SecureWorkerName, commatrixWorkflow.run.SecureWorkerIPs)
+	openPort := commatrixWorkflow.run.SecureOpenPort
+	blockedPort := commatrixWorkflow.run.SecureBlockedPort
+	Expect(openPort).To(BeNumerically(">", 0), "secure worker open probe port must be resolved from nft rules")
+	Expect(blockedPort).To(BeNumerically(">", 0), "secure worker blocked probe port must be resolved from nft rules")
 
-	apiPort := strconv.Itoa(commatrixAPIPort)
-	kubeletPort := strconv.Itoa(commatrixKubeletPort)
-	closedPort := strconv.Itoa(commatrixClosedTCPPort)
+	openPortStr := strconv.Itoa(openPort)
+	blockedPortStr := strconv.Itoa(blockedPort)
+	apiPortStr := strconv.Itoa(commatrixAPIPort)
+
+	klog.Infof(
+		"Commatrix connectivity probes: masterIPs=%v secure=%s/%v openPort=%s blockedPort=%s",
+		commatrixWorkflow.run.MasterIPs,
+		commatrixWorkflow.run.SecureWorkerName,
+		commatrixWorkflow.run.SecureWorkerIPs,
+		openPortStr,
+		blockedPortStr)
 
 	tryProbe := func(desc string, addrs []string, port string, expectConnect bool) {
 		By(desc)
@@ -1630,16 +1006,27 @@ func commatrixVerifyHostFirewallConnectivity(_ SpecContext) {
 		Expect(commatrixTryTCPProbesFromRunner(desc, addrs, port, expectConnect)).NotTo(HaveOccurred(), "%s", desc)
 	}
 
-	tryProbe("Master API reachable from test runner", commatrixWorkflow.run.MasterIPs, apiPort, true)
+	tryProbe("Master API reachable from test runner", commatrixWorkflow.run.MasterIPs, apiPortStr, true)
 
-	tryProbe("Secure-pool worker API blocked from test runner", commatrixWorkflow.run.SecureWorkerIPs, apiPort, false)
+	tryProbe(
+		fmt.Sprintf("Secure-pool worker blocked tcp/%s from test runner (not in nft accept rules)", blockedPortStr),
+		commatrixWorkflow.run.SecureWorkerIPs, blockedPortStr, false)
+
+	tryProbe(
+		fmt.Sprintf("Secure-pool worker open tcp/%s from test runner (from nft accept rules)", openPortStr),
+		commatrixWorkflow.run.SecureWorkerIPs, openPortStr, true)
+
+	securePool := commatrixInferSecureMCPoolNameFromPools(commatrixWorkflow.probePoolNames)
+	if securePool == "" {
+		securePool = commatrixInferSecureMCPoolNameFromPools(commatrixWorkflow.discoveredPoolNames)
+	}
 
 	var securePoolPeerNames []string
 
-	if len(commatrixWorkflow.appliedMCPoolNames) > 0 {
+	if securePool != "" {
 		var errPeers error
 
-		securePoolPeerNames, errPeers = commatrixNodesFromMachineConfigPools(commatrixWorkflow.appliedMCPoolNames)
+		securePoolPeerNames, errPeers = commatrixNodesFromMachineConfigPools([]string{securePool})
 		Expect(errPeers).NotTo(HaveOccurred())
 	}
 
@@ -1662,16 +1049,16 @@ func commatrixVerifyHostFirewallConnectivity(_ SpecContext) {
 		peerIPs, errIP := commatrixNodeProbeIPs(peerNB)
 		Expect(errIP).NotTo(HaveOccurred())
 
-		tryProbe("Peer secure-pool worker API blocked from test runner", peerIPs, apiPort, false)
+		tryProbe(
+			fmt.Sprintf("Peer secure-pool worker blocked tcp/%s from test runner", blockedPortStr),
+			peerIPs, blockedPortStr, false)
 	} else {
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Skipping peer secure-pool worker API probe: fewer than two secure-pool nodes")
+		klog.Infof("Commatrix: skipping peer secure-pool worker probe (securePool=%q nodes=%d)",
+			securePool, len(securePoolPeerNames))
 	}
-
-	tryProbe("Secure-pool worker kubelet reachable from test runner", commatrixWorkflow.run.SecureWorkerIPs, kubeletPort, true)
-
-	tryProbe("Closed test port blocked on secure-pool worker", commatrixWorkflow.run.SecureWorkerIPs, closedPort, false)
 }
 
+// commatrixRunJournalKernelGrep runs journalctl -k on a node host and greps kernel output for filter.
 func commatrixRunJournalKernelGrep(nodeName, since, until, grepFilter string) (string, error) {
 	shellCmd := fmt.Sprintf(`journalctl -k --since %q`, since)
 	if strings.TrimSpace(until) != "" {
@@ -1696,14 +1083,10 @@ func commatrixWaitForJournalKernelGrep(
 
 			raw, pollErr = commatrixRunJournalKernelGrep(nodeName, since, "", grepFilter)
 			if pollErr != nil {
-				klog.V(rdscoreparams.RDSCoreLogLevel).Infof("journal on %s: %v", nodeName, pollErr)
-
-				return false, nil
+				return false, pollErr
 			}
 
 			lines = commatrixParseJournalKernelLines(raw)
-			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("journal on %s since %q filter %q: %d line(s)",
-				nodeName, since, grepFilter, len(lines))
 
 			return len(lines) >= minLines, nil
 		})
@@ -1711,6 +1094,7 @@ func commatrixWaitForJournalKernelGrep(
 	return lines, raw, err
 }
 
+// commatrixParseJournalKernelLines filters journalctl output down to plausible kernel firewall log lines.
 func commatrixParseJournalKernelLines(raw string) []string {
 	var out []string
 
@@ -1757,6 +1141,7 @@ func commatrixExpectFirewallLogRateLimitsInWindow(lines []string, windowLabel st
 	}
 }
 
+// commatrixFirewallLogBucket classifies a journal line into a firewall log-prefix bucket for rate-limit checks.
 func commatrixFirewallLogBucket(line string) (string, bool) {
 	if strings.Contains(line, "TCP_TEST") {
 		return "", false
@@ -1780,7 +1165,7 @@ func commatrixFirewallLogBucket(line string) (string, bool) {
 }
 
 // commatrixVerifyFirewallJournal checks firewall journal rate limits and TCP_TEST log-drop probe.
-// Uses the same secure worker node as connectivity (nft apply probe, nc probes); run connectivity before this spec.
+// Uses the same secure worker node as connectivity; run connectivity before this spec when possible.
 //
 //nolint:funlen // journal: two 1-minute windows, TCP_TEST rule inject/probe, and journal assertions.
 func commatrixVerifyFirewallJournal(_ SpecContext) {
@@ -1823,13 +1208,23 @@ func commatrixVerifyFirewallJournal(_ SpecContext) {
 		commatrixExpectFirewallLogRateLimitsInWindow(window2Lines, commatrixJournalSinceOneMinute)
 	}
 
-	apiPort := commatrixAPIPort
+	testPort := commatrixWorkflow.run.SecureBlockedPort
+	if testPort <= 0 {
+		Expect(commatrixResolveSecureProbePorts(journalNode)).NotTo(HaveOccurred(),
+			"resolve blocked probe port on journal node %q", journalNode)
 
-	By(fmt.Sprintf("Injecting TCP_TEST log rule on node %s", journalNode))
+		testPort = commatrixWorkflow.run.SecureBlockedPort
+	}
+
+	Expect(testPort).To(BeNumerically(">", 0), "journal TCP_TEST probe port must be resolved from nft rules")
+
+	klog.Infof("Commatrix journal: node=%q probeIPs=%v TCP_TEST port=%d", journalNode, journalProbeIPs, testPort)
+
+	By(fmt.Sprintf("Injecting TCP_TEST log rule on node %s for tcp/%d", journalNode, testPort))
 
 	nftInsertHostShellCmd := fmt.Sprintf(
 		`set -e; nft insert rule inet openshift_filter %s tcp dport %d log prefix \"TCP_TEST \" drop`,
-		commatrixNFTablesOpenshiftChain, apiPort)
+		commatrixNFTablesOpenshiftChain, testPort)
 
 	nftInsertCmdOut, nftInsertCmdErr := commatrixRunOnNodeHostShell(journalNode, nftInsertHostShellCmd)
 	Expect(nftInsertCmdErr).NotTo(HaveOccurred(), "nft insert TCP_TEST rule on %s: %s", journalNode, nftInsertCmdOut)
@@ -1844,13 +1239,13 @@ func commatrixVerifyFirewallJournal(_ SpecContext) {
 		_, _ = commatrixRunOnNodeHostShell(journalNode, nftDeleteLogRuleShellCmd)
 	}()
 
-	portStr := strconv.Itoa(apiPort)
+	portStr := strconv.Itoa(testPort)
 
-	By(fmt.Sprintf("Probing %v:%d from test runner (TCP_TEST drop expected)", journalProbeIPs, apiPort))
+	By(fmt.Sprintf("Probing %v:%d from test runner (TCP_TEST drop expected)", journalProbeIPs, testPort))
 
 	for _, probeTargetIP := range journalProbeIPs {
 		if err := commatrixRunTCPProbeFromRunner(false, probeTargetIP, portStr); err != nil {
-			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("local nc to %s:%d (drop expected): %v", probeTargetIP, apiPort, err)
+			klog.Infof("Commatrix journal: probe %s:%d (drop expected): %v", probeTargetIP, testPort, err)
 		}
 	}
 
@@ -1859,12 +1254,12 @@ func commatrixVerifyFirewallJournal(_ SpecContext) {
 	tcpTestLines, tcpTestRaw, err := commatrixWaitForJournalKernelGrep(
 		journalNode, commatrixJournalSinceOneMinute, "TCP_TEST", 1, 3*time.Second, 90*time.Second)
 	Expect(err).NotTo(HaveOccurred(),
-		"TCP_TEST journal: expected at least one TCP_TEST kernel log line after nc to %v:%d on %s (got %d); last output:\n%s",
-		journalProbeIPs, apiPort, journalNode, len(tcpTestLines), tcpTestRaw)
+		"TCP_TEST journal: expected at least one TCP_TEST kernel log line after probe to %v:%d on %s (got %d); last output:\n%s",
+		journalProbeIPs, testPort, journalNode, len(tcpTestLines), tcpTestRaw)
 
 	Expect(tcpTestLines).NotTo(BeEmpty(), "TCP_TEST journal: expected ≥1 TCP_TEST log line on %s", journalNode)
 
-	dptNeedle := fmt.Sprintf("DPT=%d", apiPort)
+	dptNeedle := fmt.Sprintf("DPT=%d", testPort)
 
 	journalJoined := strings.ToUpper(strings.Join(tcpTestLines, "\n"))
 
@@ -1874,106 +1269,7 @@ func commatrixVerifyFirewallJournal(_ SpecContext) {
 		"TCP_TEST journal: journal lines should reference probed destination port %s", dptNeedle)
 }
 
-func commatrixRevertNDP() {
-	clusterJSON, errGet := commatrixGetMachineConfigurationClusterJSON()
-	if errGet != nil {
-		klog.Errorf("revert NDP: %v", errGet)
-
-		return
-	}
-
-	patch, errBuild := commatrixBuildJSONPatchRemoveNDPNFT(string(clusterJSON))
-	if errBuild != nil {
-		klog.Errorf("revert NDP: build JSON patch: %v", errBuild)
-
-		return
-	}
-
-	if len(patch) == 0 || string(patch) == "[]" {
-		commatrixWorkflow.ndpApplied = false
-
-		return
-	}
-
-	if errPatch := commatrixPatchMachineConfigurationClusterJSON(patch); errPatch != nil {
-		klog.Errorf("revert NDP: json patch failed: %v", errPatch)
-
-		return
-	}
-
-	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("revert NDP: patched machineconfiguration/cluster")
-	commatrixWorkflow.ndpApplied = false
-}
-
-func commatrixRevertHostFirewall() {
-	if !commatrixWorkflow.mcApplied {
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("revert skipped: no MachineConfig was applied")
-
-		return
-	}
-
-	mcDir, errMcDir := commatrixFormatMCDir()
-	if errMcDir != nil {
-		klog.Errorf("revert: resolve format-mc dir: %v", errMcDir)
-
-		return
-	}
-
-	for _, nodeName := range commatrixWorkflow.revertNodeNames {
-		commatrixStopNFTOnNode(nodeName)
-	}
-
-	for _, rel := range commatrixWorkflow.appliedMCRels {
-		abs := filepath.Join(mcDir, filepath.FromSlash(rel))
-
-		if errDelete := commatrixDeleteMachineConfigYAML(abs); errDelete != nil {
-			klog.Errorf("revert: delete MachineConfig %q: %v", rel, errDelete)
-
-			continue
-		}
-
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("revert: deleted %q", rel)
-	}
-
-	if errWait := mco.ListMCPWaitToBeStableFor(APIClient, 90*time.Second, commatrixMCPStableWait); errWait != nil {
-		klog.Errorf("revert: MCP stable wait: %v", errWait)
-	}
-
-	commatrixWorkflow.mcApplied = false
-
-	if commatrixWorkflow.ndpApplied {
-		commatrixRevertNDP()
-	}
-
-	destDir := filepath.Clean(strings.TrimSpace(RDSCoreConfig.CommatrixOutputDir))
-	if destDir != "" && destDir != "." && destDir != string(filepath.Separator) {
-		if errRm := os.RemoveAll(destDir); errRm != nil {
-			klog.Errorf("revert: remove output dir %s: %v", destDir, errRm)
-		} else {
-			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("revert: removed output directory %s", destDir)
-		}
-	}
-}
-
-// CommatrixRevertAfterSpec undoes apply changes after the ordered commatrix Describe finishes.
-// Errors are logged only so a failed connectivity/journal spec still attempts cleanup.
-func CommatrixRevertAfterSpec() {
-	By("Reverting commatrix cluster changes")
-	commatrixRevertHostFirewall()
-}
-
-// VerifyCommatrixHostFirewallArtifacts (reportxml 95001) generates commatrix artifacts and validates embedded openshift_filter nftables.
-func VerifyCommatrixHostFirewallArtifacts(ctx SpecContext) {
-	commatrixResetWorkflow()
-	commatrixGenerateArtifacts(ctx)
-}
-
-// VerifyCommatrixHostFirewallApply (reportxml 95002) applies host-firewall MachineConfigs and verifies nftables on a node.
-func VerifyCommatrixHostFirewallApply(ctx SpecContext) {
-	commatrixApplyHostFirewallMC(ctx)
-}
-
-// VerifyCommatrixHostFirewallConnectivity verifies TCP connectivity from the test runner.
+// VerifyCommatrixHostFirewallConnectivity (reportxml 95003/95005/95007) verifies TCP connectivity from the test runner.
 func VerifyCommatrixHostFirewallConnectivity(ctx SpecContext) {
 	Expect(commatrixPrimeWorkflowForVerification()).NotTo(HaveOccurred(),
 		"host-firewall rules must be applied on the cluster before connectivity checks")
@@ -1981,7 +1277,7 @@ func VerifyCommatrixHostFirewallConnectivity(ctx SpecContext) {
 	commatrixVerifyHostFirewallConnectivity(ctx)
 }
 
-// VerifyCommatrixHostFirewallJournal verifies firewall journal rate limits and TCP_TEST logging.
+// VerifyCommatrixHostFirewallJournal (reportxml 95004/95006/95008) verifies firewall journal rate limits and TCP_TEST logging.
 func VerifyCommatrixHostFirewallJournal(ctx SpecContext) {
 	Expect(commatrixPrimeWorkflowForVerification()).NotTo(HaveOccurred(),
 		"host-firewall rules must be applied on the cluster before journal checks")

--- a/tests/system-tests/rdscore/internal/rdscorecommon/commatrix.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/commatrix.go
@@ -63,6 +63,8 @@ const (
 	commatrixClosedTCPPort               = 9999
 	commatrixNFTablesLogKeyword          = "firewall"
 	commatrixHostFirewallMCNameSubstring = "nftables-commatrix"
+	// commatrixTCPProbeTimeout matches legacy nc -w3 probe wait.
+	commatrixTCPProbeTimeout = 3 * time.Second
 )
 
 // commatrixMCPStableWait is how long apply/revert waits for all MachineConfigPools to stabilize.
@@ -504,46 +506,55 @@ func commatrixRunLocalShell(shellCmd string) error {
 	return localCmdErr
 }
 
-// commatrixRunTCPProbeFromRunner runs nc -z from the test runner to host:port.
-func commatrixRunTCPProbeFromRunner(expectConnect bool, host, port string) error {
-	args := []string{"-z", "-v", "-w3"}
-
-	if ip := net.ParseIP(host); ip != nil {
-		if ip.To4() != nil {
-			args = append([]string{"-4"}, args...)
-		} else {
-			args = append([]string{"-6"}, args...)
-		}
+func commatrixTCPProbeNetwork(host string) string {
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return "tcp"
 	}
 
-	args = append(args, host, port)
+	if ip.To4() != nil {
+		return "tcp4"
+	}
 
-	ncCmd := exec.Command("nc", args...)
-	ncCmd.Env = os.Environ()
+	return "tcp6"
+}
 
-	ncCmdOut, ncCmdErr := ncCmd.CombinedOutput()
-	ncCmdLine := strings.Join(args, " ")
+func commatrixDialTCP(host, port string) error {
+	conn, err := net.DialTimeout(commatrixTCPProbeNetwork(host), net.JoinHostPort(host, port), commatrixTCPProbeTimeout)
+	if err != nil {
+		return err
+	}
+
+	return conn.Close()
+}
+
+// commatrixRunTCPProbeFromRunner TCP-dials host:port from the test runner (no external nc binary required).
+func commatrixRunTCPProbeFromRunner(expectConnect bool, host, port string) error {
+	network := commatrixTCPProbeNetwork(host)
+	addr := net.JoinHostPort(host, port)
+	probeDesc := fmt.Sprintf("dial %s %s", network, addr)
 
 	if expectConnect {
-		if ncCmdErr != nil {
-			klog.Infof("local: nc %s failed: %v\n%s", ncCmdLine, ncCmdErr, string(ncCmdOut))
-		} else {
-			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("local: nc %s\n%s", ncCmdLine, string(ncCmdOut))
+		if err := commatrixDialTCP(host, port); err != nil {
+			klog.Infof("probe: %s failed: %v", probeDesc, err)
+
+			return err
 		}
 
-		return ncCmdErr
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("probe: %s succeeded", probeDesc)
+
+		return nil
 	}
 
-	if ncCmdErr == nil {
-		klog.Infof("local: nc unexpectedly connected (%s)\n%s", ncCmdLine, string(ncCmdOut))
+	if err := commatrixDialTCP(host, port); err != nil {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("probe: %s failed as expected: %v", probeDesc, err)
 
-		return fmt.Errorf("expected connection to %s:%s to fail, but nc succeeded", host, port)
+		return nil
 	}
 
-	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("local: nc to %s failed as expected (%s): %v\n%s",
-		host, ncCmdLine, ncCmdErr, string(ncCmdOut))
+	klog.Infof("probe: %s unexpectedly connected", probeDesc)
 
-	return nil
+	return fmt.Errorf("expected connection to %s to fail, but dial succeeded", addr)
 }
 
 func commatrixProbeLabel(addr string) string {

--- a/tests/system-tests/rdscore/internal/rdscorecommon/commatrix.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/commatrix.go
@@ -1299,6 +1299,8 @@ func commatrixNodeProbeIPs(nb *nodes.Builder) ([]string, error) {
 
 // commatrixNodesFromMachineConfigPools returns sorted unique node names matching each pool's
 // MachineConfigPool.spec.nodeSelector on the live cluster.
+//
+//nolint:funlen // pool iteration: pull MCP, validate selector, list nodes, per-pool logging.
 func commatrixNodesFromMachineConfigPools(poolNames []string) ([]string, error) {
 	seen := make(map[string]struct{})
 

--- a/tests/system-tests/rdscore/internal/rdscorecommon/commatrix.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/commatrix.go
@@ -1,5 +1,5 @@
-// Commatrix host-firewall workflow (ginkgo reportxml 95001–95004): generate artifacts, apply MCs,
-// verify TCP connectivity from the test runner, verify firewall journal logging; cleanup runs after apply.
+// Commatrix host-firewall workflow (ginkgo reportxml 95001–95004): optional generate/apply helpers,
+// plus connectivity (95003) and journal (95004) verification against a cluster that already has rules applied.
 //
 //nolint:varnamelen,lll,wsl_v5 // test helpers follow oc/k8s naming; long oc/shell/klog lines are intentional.
 package rdscorecommon
@@ -55,7 +55,8 @@ const (
 	commatrixAPIPort            = 6443
 	commatrixKubeletPort        = 10250
 	commatrixClosedTCPPort      = 9999
-	commatrixNFTablesLogKeyword = "firewall"
+	commatrixNFTablesLogKeyword              = "firewall"
+	commatrixHostFirewallMCNameSubstring   = "nftables-commatrix"
 )
 
 // commatrixMCPStableWait is how long apply/revert waits for all MachineConfigPools to stabilize.
@@ -143,12 +144,9 @@ func commatrixBuildJSONPatchRemoveNDPNFT(clusterJSON string) ([]byte, error) {
 
 // commatrixRunTopology holds node names and InternalIPs resolved for connectivity checks.
 type commatrixRunTopology struct {
-	MCName           string
 	SecureWorkerName string
-	OpenWorkerName   string
 	MasterIP         string
 	SecureWorkerIP   string
-	OpenWorkerIP     string
 }
 
 // commatrixWorkflowState carries shared state for the ordered Commatrix spec.
@@ -167,6 +165,123 @@ var commatrixWorkflow commatrixWorkflowState
 
 func commatrixResetWorkflow() {
 	commatrixWorkflow = commatrixWorkflowState{}
+}
+
+// commatrixPrimeWorkflowForVerification discovers applied host-firewall pools from format-mc artifacts
+// or commatrix MachineConfigs already on the cluster (rules must be applied before 95003/95004).
+func commatrixPrimeWorkflowForVerification() error {
+	if commatrixWorkflow.mcApplied {
+		return nil
+	}
+
+	var poolNames []string
+
+	if mcDir, err := commatrixFormatMCDir(); err == nil {
+		rels, listErr := commatrixListMachineConfigYAMLRels(mcDir)
+		if listErr == nil && len(rels) > 0 {
+			poolNames = commatrixMachineConfigPoolNamesFromMCRels(rels)
+			commatrixWorkflow.generatedMCPoolNames = append([]string(nil), poolNames...)
+		}
+	}
+
+	if len(poolNames) == 0 {
+		pools, err := commatrixHostFirewallPoolNamesFromCluster()
+		if err != nil {
+			return fmt.Errorf("discover host-firewall MachineConfig pools: %w", err)
+		}
+
+		if len(pools) == 0 {
+			return fmt.Errorf(
+				"no commatrix host-firewall MachineConfigs found on cluster or under %s/%s; "+
+					"apply rules before connectivity/journal tests (run 95001/95002 or platform prep)",
+				strings.TrimSpace(RDSCoreConfig.CommatrixOutputDir), commatrixFormatMCSubdir)
+		}
+
+		poolNames = pools
+		commatrixWorkflow.generatedMCPoolNames = append([]string(nil), pools...)
+	}
+
+	securePool := commatrixInferSecureMCPoolNameFromPools(poolNames)
+	if securePool == "" {
+		return fmt.Errorf("could not infer secure/firewall MCP from pools %v", poolNames)
+	}
+
+	masterPool := commatrixInferMasterMCPoolNameFromPools(poolNames)
+
+	applyPools := []string{securePool}
+	if masterPool != "" && masterPool != securePool {
+		applyPools = append(applyPools, masterPool)
+	}
+
+	commatrixWorkflow.appliedMCPoolNames = append([]string(nil), applyPools...)
+
+	secureNodes, err := commatrixNodesFromMachineConfigPools([]string{securePool})
+	if err != nil {
+		return fmt.Errorf("list nodes in secure pool %q: %w", securePool, err)
+	}
+
+	if len(secureNodes) == 0 {
+		return fmt.Errorf("no nodes in secure pool %q for connectivity/journal probes", securePool)
+	}
+
+	commatrixWorkflow.nftProbeNodeName = secureNodes[0]
+	commatrixWorkflow.mcApplied = true
+
+	klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+		"Commatrix: primed verification workflow pools=%v secureWorker=%q",
+		applyPools, commatrixWorkflow.nftProbeNodeName)
+
+	return nil
+}
+
+func commatrixHostFirewallPoolNamesFromCluster() ([]string, error) {
+	ocGetMcJSONCmdOut, ocGetMcJSONCmdErr := commatrixRunOC("get", "mc", "-o", "json")
+	if ocGetMcJSONCmdErr != nil {
+		return nil, ocGetMcJSONCmdErr
+	}
+
+	var mcList struct {
+		Items []struct {
+			Metadata struct {
+				Name string `json:"name"`
+			} `json:"metadata"`
+			Spec struct {
+				Config struct {
+					Role string `json:"role"`
+				} `json:"config"`
+			} `json:"spec"`
+		} `json:"items"`
+	}
+
+	if err := json.Unmarshal([]byte(ocGetMcJSONCmdOut), &mcList); err != nil {
+		return nil, fmt.Errorf("parse MachineConfig list: %w", err)
+	}
+
+	seen := make(map[string]struct{})
+	pools := make([]string, 0)
+
+	for _, item := range mcList.Items {
+		if !strings.Contains(item.Metadata.Name, commatrixHostFirewallMCNameSubstring) {
+			continue
+		}
+
+		role := strings.TrimSpace(item.Spec.Config.Role)
+		if role == "" {
+			continue
+		}
+
+		if _, ok := seen[role]; ok {
+			continue
+		}
+
+		seen[role] = struct{}{}
+
+		pools = append(pools, role)
+	}
+
+	sort.Strings(pools)
+
+	return pools, nil
 }
 
 func commatrixMasterLabelSelector() string {
@@ -200,15 +315,30 @@ func commatrixRunLocalShell(shellCmd string) error {
 
 // commatrixRunTCPProbeFromRunner runs nc -z from the test runner to host:port.
 func commatrixRunTCPProbeFromRunner(expectConnect bool, host, port string) error {
-	var shellCmd string
+	ncCmd := exec.Command("nc", "-z", "-v", "-w3", host, port)
+	ncCmd.Env = os.Environ()
+
+	ncCmdOut, ncCmdErr := ncCmd.CombinedOutput()
 
 	if expectConnect {
-		shellCmd = fmt.Sprintf(`nc -z -v -w3 %s %s`, host, port)
-	} else {
-		shellCmd = fmt.Sprintf(`! nc -z -v -w3 %s %s`, host, port)
+		if ncCmdErr != nil {
+			klog.Infof("local: nc -z -v -w3 %s %s failed: %v\n%s", host, port, ncCmdErr, string(ncCmdOut))
+		} else {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("local: nc -z -v -w3 %s %s\n%s", host, port, string(ncCmdOut))
+		}
+
+		return ncCmdErr
 	}
 
-	return commatrixRunLocalShell(shellCmd)
+	if ncCmdErr == nil {
+		klog.Infof("local: nc unexpectedly connected to %s:%s\n%s", host, port, string(ncCmdOut))
+
+		return fmt.Errorf("expected connection to %s:%s to fail, but nc succeeded", host, port)
+	}
+
+	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("local: nc to %s:%s failed as expected: %v\n%s", host, port, ncCmdErr, string(ncCmdOut))
+
+	return nil
 }
 
 // commatrixRunOnNodeHostDebug runs `oc debug node/<name> -- <hostDebugCmdArgs...>` so `chroot /host` is the node root.
@@ -772,45 +902,6 @@ func commatrixInferMasterMCPoolNameFromPools(pools []string) string {
 	})
 }
 
-func commatrixInferOpenMCPoolName(securePool string) string {
-	pools := commatrixWorkflow.generatedMCPoolNames
-	if len(pools) == 0 {
-		pools = commatrixWorkflow.appliedMCPoolNames
-	}
-	if p := commatrixPickMCPoolName(pools, func(name string) bool {
-		lower := strings.ToLower(name)
-
-		return strings.Contains(lower, "appworker") && strings.Contains(lower, "mcp-b")
-	}); p != "" {
-		return p
-	}
-
-	for _, p := range pools {
-		if p == securePool {
-			continue
-		}
-
-		if strings.Contains(strings.ToLower(p), "appworker") {
-			return p
-		}
-	}
-
-	return ""
-}
-
-func commatrixFirstNodeNameInMCPool(poolName string) (string, error) {
-	names, err := commatrixNodesFromMachineConfigPools([]string{poolName})
-	if err != nil {
-		return "", err
-	}
-
-	if len(names) == 0 {
-		return "", fmt.Errorf("no nodes in MachineConfigPool %q", poolName)
-	}
-
-	return names[0], nil
-}
-
 func commatrixSetWorkerFromNodeName(nodeName string) error {
 	nb, errPull := nodes.Pull(APIClient, nodeName)
 	if errPull != nil {
@@ -828,32 +919,11 @@ func commatrixSetWorkerFromNodeName(nodeName string) error {
 	return nil
 }
 
-func commatrixSetOpenWorkerFromNodeName(nodeName string) error {
-	nb, errPull := nodes.Pull(APIClient, nodeName)
-	if errPull != nil {
-		return fmt.Errorf("pull open-pool node %q: %w", nodeName, errPull)
-	}
-
-	openIP, errIP := commatrixNodeInternalIP(nb)
-	if errIP != nil {
-		return errIP
-	}
-
-	commatrixWorkflow.run.OpenWorkerName = nodeName
-	commatrixWorkflow.run.OpenWorkerIP = openIP
-
-	return nil
-}
-
-// commatrixResolveConnectivityTopology fills master/secure/open node names and InternalIPs once for connectivity and journal specs.
-//
-//nolint:funlen // master + secure (nft probe node) + open pool resolution.
+// commatrixResolveConnectivityTopology fills master and secure-worker names and InternalIPs for connectivity and journal specs.
 func commatrixResolveConnectivityTopology() error {
 	commatrixWorkflow.run.MasterIP = ""
 	commatrixWorkflow.run.SecureWorkerName = ""
 	commatrixWorkflow.run.SecureWorkerIP = ""
-	commatrixWorkflow.run.OpenWorkerName = ""
-	commatrixWorkflow.run.OpenWorkerIP = ""
 
 	masters, err := nodes.List(APIClient, metav1.ListOptions{LabelSelector: commatrixMasterLabelSelector()})
 	if err != nil {
@@ -873,46 +943,11 @@ func commatrixResolveConnectivityTopology() error {
 
 	nftNode := strings.TrimSpace(commatrixWorkflow.nftProbeNodeName)
 	if nftNode == "" {
-		return fmt.Errorf("secure worker: run apply spec first (nft probe node not recorded)")
+		return fmt.Errorf("secure worker: nft probe node not recorded (prime verification workflow first)")
 	}
 
 	if err := commatrixSetWorkerFromNodeName(nftNode); err != nil {
 		return fmt.Errorf("secure worker %q: %w", nftNode, err)
-	}
-
-	openLabel := strings.TrimSpace(RDSCoreConfig.CommatrixOpenPoolNodeLabel)
-	switch {
-	case openLabel != "":
-		openNodes, errList := nodes.List(APIClient, metav1.ListOptions{LabelSelector: openLabel})
-		if errList != nil {
-			return fmt.Errorf("list open-pool nodes: %w", errList)
-		}
-
-		if len(openNodes) == 0 {
-			return fmt.Errorf("no nodes matched open pool label %q", openLabel)
-		}
-
-		if err := commatrixSetOpenWorkerFromNodeName(openNodes[0].Object.Name); err != nil {
-			return err
-		}
-	default:
-		securePool := commatrixInferSecureMCPoolName()
-		openPool := commatrixInferOpenMCPoolName(securePool)
-		if openPool == "" {
-			return fmt.Errorf(
-				"open worker: set rdscore_commatrix_open_pool_node_label or apply host-firewall MCs to one worker pool only")
-		}
-
-		openNode, errOpen := commatrixFirstNodeNameInMCPool(openPool)
-		if errOpen != nil {
-			return fmt.Errorf("open pool %q: %w", openPool, errOpen)
-		}
-
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Commatrix: using node %q from MachineConfigPool %q (open / no-firewall pool)", openNode, openPool)
-
-		if err := commatrixSetOpenWorkerFromNodeName(openNode); err != nil {
-			return err
-		}
 	}
 
 	return nil
@@ -1285,19 +1320,12 @@ func commatrixApplyHostFirewallMC(_ SpecContext) {
 
 // commatrixVerifyHostFirewallConnectivity probes API/kubelet TCP reachability from the test runner.
 func commatrixVerifyHostFirewallConnectivity(_ SpecContext) {
-	if !commatrixWorkflow.mcApplied {
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Connectivity skipped: host-firewall MachineConfigs were not applied")
-
-		return
-	}
-
 	By("Resolving cluster topology for connectivity probes")
 
 	Expect(commatrixResolveConnectivityTopology()).NotTo(HaveOccurred())
 
-	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Commatrix connectivity probes: masterIP=%s secure=%s/%s open=%s/%s",
-		commatrixWorkflow.run.MasterIP, commatrixWorkflow.run.SecureWorkerName, commatrixWorkflow.run.SecureWorkerIP,
-		commatrixWorkflow.run.OpenWorkerName, commatrixWorkflow.run.OpenWorkerIP)
+	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Commatrix connectivity probes: masterIP=%s secure=%s/%s",
+		commatrixWorkflow.run.MasterIP, commatrixWorkflow.run.SecureWorkerName, commatrixWorkflow.run.SecureWorkerIP)
 
 	apiPort := strconv.Itoa(commatrixAPIPort)
 	kubeletPort := strconv.Itoa(commatrixKubeletPort)
@@ -1351,8 +1379,6 @@ func commatrixVerifyHostFirewallConnectivity(_ SpecContext) {
 	tryProbe("Secure-pool worker kubelet reachable from test runner", commatrixWorkflow.run.SecureWorkerIP, kubeletPort, true)
 
 	tryProbe("Closed test port blocked on secure-pool worker", commatrixWorkflow.run.SecureWorkerIP, closedPort, false)
-
-	tryProbe("Open-pool worker kubelet reachable (pool without host-firewall MC)", commatrixWorkflow.run.OpenWorkerIP, kubeletPort, true)
 }
 
 func commatrixRunJournalKernelGrep(nodeName, since, until, grepFilter string) (string, error) {
@@ -1467,12 +1493,6 @@ func commatrixFirewallLogBucket(line string) (string, bool) {
 //
 //nolint:funlen // journal: two 1-minute windows, TCP_TEST rule inject/probe, and journal assertions.
 func commatrixVerifyFirewallJournal(_ SpecContext) {
-	if !commatrixWorkflow.mcApplied {
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Journal checks skipped: host-firewall MachineConfigs were not applied")
-
-		return
-	}
-
 	journalNode := commatrixWorkflow.run.SecureWorkerName
 	Expect(journalNode).NotTo(BeEmpty(), "journal node: run connectivity spec first to resolve secure worker")
 
@@ -1498,14 +1518,17 @@ func commatrixVerifyFirewallJournal(_ SpecContext) {
 	Expect(errWin2).NotTo(HaveOccurred(), "firewall journal window 2 on %s: %s", journalNode, window2Raw)
 
 	window2Lines := commatrixParseJournalKernelLines(window2Raw)
-	Expect(window2Lines).NotTo(BeEmpty(),
-		"firewall journal: expected at least one kernel log line matching %q in the last minute on %s; last output:\n%s",
-		keyword, journalNode, window2Raw)
+	if len(window2Lines) == 0 {
+		_, _ = fmt.Fprintf(GinkgoWriter,
+			"WARNING: firewall journal: no kernel log lines matching %q in the last minute on %s; "+
+				"skipping window-2 rate-limit checks (traffic may be quiet). Last output:\n%s\n",
+			keyword, journalNode, window2Raw)
+	} else {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("firewall journal: %d line(s) matching %q on %s in the last minute",
+			len(window2Lines), keyword, journalNode)
 
-	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("firewall journal: %d line(s) matching %q on %s in the last minute",
-		len(window2Lines), keyword, journalNode)
-
-	commatrixExpectFirewallLogRateLimitsInWindow(window2Lines, commatrixJournalSinceOneMinute)
+		commatrixExpectFirewallLogRateLimitsInWindow(window2Lines, commatrixJournalSinceOneMinute)
+	}
 
 	apiPort := commatrixAPIPort
 	probeTargetIP := journalInternalIP
@@ -1531,9 +1554,7 @@ func commatrixVerifyFirewallJournal(_ SpecContext) {
 
 	By(fmt.Sprintf("Probing %s:%d from test runner", probeTargetIP, apiPort))
 
-	tcpProbeShellCmd := fmt.Sprintf(`nc -z -v -w1 %s %d`, probeTargetIP, apiPort)
-
-	if err := commatrixRunLocalShell(tcpProbeShellCmd); err != nil {
+	if err := commatrixRunTCPProbeFromRunner(false, probeTargetIP, strconv.Itoa(apiPort)); err != nil {
 		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("local nc to %s:%d (drop expected): %v", probeTargetIP, apiPort, err)
 	}
 
@@ -1661,10 +1682,21 @@ func VerifyCommatrixHostFirewallApply(ctx SpecContext) {
 
 // VerifyCommatrixHostFirewallConnectivity verifies TCP connectivity from the test runner.
 func VerifyCommatrixHostFirewallConnectivity(ctx SpecContext) {
+	Expect(commatrixPrimeWorkflowForVerification()).NotTo(HaveOccurred(),
+		"host-firewall rules must be applied on the cluster before connectivity checks")
+
 	commatrixVerifyHostFirewallConnectivity(ctx)
 }
 
 // VerifyCommatrixHostFirewallJournal verifies firewall journal rate limits and TCP_TEST logging.
 func VerifyCommatrixHostFirewallJournal(ctx SpecContext) {
+	Expect(commatrixPrimeWorkflowForVerification()).NotTo(HaveOccurred(),
+		"host-firewall rules must be applied on the cluster before journal checks")
+
+	if strings.TrimSpace(commatrixWorkflow.run.SecureWorkerName) == "" {
+		Expect(commatrixResolveConnectivityTopology()).NotTo(HaveOccurred(),
+			"resolve connectivity topology before journal checks")
+	}
+
 	commatrixVerifyFirewallJournal(ctx)
 }

--- a/tests/system-tests/rdscore/internal/rdscoreconfig/config.go
+++ b/tests/system-tests/rdscore/internal/rdscoreconfig/config.go
@@ -175,10 +175,6 @@ type CoreConfig struct {
 	NMIRedfishWorkerMCPNodeLabel string `yaml:"rdscore_nmi_redfish_worker_node_label" envconfig:"ECO_RDSCORE_NMI_REDFISH_WORKER_NODE_LABEL"`
 	//nolint:lll
 	NMIRedfishCNFMCPNodeLabel string `yaml:"rdscore_nmi_redfish_cnf_node_label" envconfig:"ECO_RDSCORE_NMI_REDFISH_CNF_NODE_LABEL"`
-	//nolint:lll
-	// Commatrix host-firewall workflow: output dir for oc commatrix generate (pools and probe ports are inferred or fixed in code).
-	//nolint:lll
-	CommatrixOutputDir string `yaml:"rdscore_commatrix_output_dir" envconfig:"ECO_RDSCORE_COMMATRIX_OUTPUT_DIR"`
 	//nolint:lll,nolintlint
 	WlkdTolerationList TolerationList `yaml:"rdscore_tolerations_list" envconfig:"ECO_RDSCORE_TOLERATIONS_LIST"`
 	//nolint:lll

--- a/tests/system-tests/rdscore/internal/rdscoreconfig/config.go
+++ b/tests/system-tests/rdscore/internal/rdscoreconfig/config.go
@@ -174,8 +174,15 @@ type CoreConfig struct {
 	//nolint:lll
 	NMIRedfishWorkerMCPNodeLabel string `yaml:"rdscore_nmi_redfish_worker_node_label" envconfig:"ECO_RDSCORE_NMI_REDFISH_WORKER_NODE_LABEL"`
 	//nolint:lll
-	NMIRedfishCNFMCPNodeLabel string         `yaml:"rdscore_nmi_redfish_cnf_node_label" envconfig:"ECO_RDSCORE_NMI_REDFISH_CNF_NODE_LABEL"`
-	WlkdTolerationList        TolerationList `yaml:"rdscore_tolerations_list" envconfig:"ECO_RDSCORE_TOLERATIONS_LIST"`
+	NMIRedfishCNFMCPNodeLabel string `yaml:"rdscore_nmi_redfish_cnf_node_label" envconfig:"ECO_RDSCORE_NMI_REDFISH_CNF_NODE_LABEL"`
+	//nolint:lll
+	// Commatrix host-firewall workflow: output dir plus optional open-pool label (pools and ports are inferred or fixed in code).
+	//nolint:lll
+	CommatrixOutputDir string `yaml:"rdscore_commatrix_output_dir" envconfig:"ECO_RDSCORE_COMMATRIX_OUTPUT_DIR"`
+	//nolint:lll
+	CommatrixOpenPoolNodeLabel string `yaml:"rdscore_commatrix_open_pool_node_label" envconfig:"ECO_RDSCORE_COMMATRIX_OPEN_POOL_NODE_LABEL"`
+	//nolint:lll,nolintlint
+	WlkdTolerationList TolerationList `yaml:"rdscore_tolerations_list" envconfig:"ECO_RDSCORE_TOLERATIONS_LIST"`
 	//nolint:lll
 	WlkdNROPTolerationList TolerationList `yaml:"rdscore_nrop_tolerations_list" envconfig:"ECO_RDSCORE_NROP_TOLERATIONS_LIST"`
 	//nolint:lll,nolintlint

--- a/tests/system-tests/rdscore/internal/rdscoreconfig/config.go
+++ b/tests/system-tests/rdscore/internal/rdscoreconfig/config.go
@@ -176,11 +176,9 @@ type CoreConfig struct {
 	//nolint:lll
 	NMIRedfishCNFMCPNodeLabel string `yaml:"rdscore_nmi_redfish_cnf_node_label" envconfig:"ECO_RDSCORE_NMI_REDFISH_CNF_NODE_LABEL"`
 	//nolint:lll
-	// Commatrix host-firewall workflow: output dir plus optional open-pool label (pools and ports are inferred or fixed in code).
+	// Commatrix host-firewall workflow: output dir for oc commatrix generate (pools and probe ports are inferred or fixed in code).
 	//nolint:lll
 	CommatrixOutputDir string `yaml:"rdscore_commatrix_output_dir" envconfig:"ECO_RDSCORE_COMMATRIX_OUTPUT_DIR"`
-	//nolint:lll
-	CommatrixOpenPoolNodeLabel string `yaml:"rdscore_commatrix_open_pool_node_label" envconfig:"ECO_RDSCORE_COMMATRIX_OPEN_POOL_NODE_LABEL"`
 	//nolint:lll,nolintlint
 	WlkdTolerationList TolerationList `yaml:"rdscore_tolerations_list" envconfig:"ECO_RDSCORE_TOLERATIONS_LIST"`
 	//nolint:lll

--- a/tests/system-tests/rdscore/internal/rdscoreconfig/default.yaml
+++ b/tests/system-tests/rdscore/internal/rdscoreconfig/default.yaml
@@ -208,6 +208,5 @@ rdscore_whereabouts_deploy_3_nad: ''
 rdscore_whereabouts_deploy_4_nad: ''
 rdscore_python_http_server_image: registry.access.redhat.com/ubi9/python-39:latest
 
-# Commatrix
+# Commatrix (default is ephemeral; override for long-lived artifact/debug output, e.g. under CI artifacts)
 rdscore_commatrix_output_dir: '/tmp/commatrix-work'
-rdscore_commatrix_open_pool_node_label: ''

--- a/tests/system-tests/rdscore/internal/rdscoreconfig/default.yaml
+++ b/tests/system-tests/rdscore/internal/rdscoreconfig/default.yaml
@@ -207,3 +207,7 @@ rdscore_whereabouts_deploy_4_port: '1111'
 rdscore_whereabouts_deploy_3_nad: ''
 rdscore_whereabouts_deploy_4_nad: ''
 rdscore_python_http_server_image: registry.access.redhat.com/ubi9/python-39:latest
+
+# Commatrix
+rdscore_commatrix_output_dir: '/tmp/commatrix-work'
+rdscore_commatrix_open_pool_node_label: ''

--- a/tests/system-tests/rdscore/tests/00_validate_top_level.go
+++ b/tests/system-tests/rdscore/tests/00_validate_top_level.go
@@ -1046,3 +1046,28 @@ var _ = Describe(
 			})
 		})
 	})
+
+var _ = Describe(
+	"Commatrix",
+	Ordered,
+	Label("commatrix"),
+	func() {
+		AfterAll(rdscorecommon.CommatrixRevertAfterSpec)
+
+		It("Verifies commatrix artifact generation",
+			Label("commatrix-artifacts"),
+			reportxml.ID("95001"), rdscorecommon.VerifyCommatrixHostFirewallArtifacts)
+
+		It("Verifies commatrix MachineConfig apply and nftables",
+			Label("commatrix-apply"),
+			reportxml.ID("95002"), rdscorecommon.VerifyCommatrixHostFirewallApply, SpecTimeout(20*time.Minute))
+
+		It("Verifies commatrix host-firewall TCP connectivity",
+			Label("commatrix-connectivity"),
+			reportxml.ID("95003"), rdscorecommon.VerifyCommatrixHostFirewallConnectivity)
+
+		It("Verifies commatrix firewall journal logging",
+			Label("commatrix-journal"),
+			reportxml.ID("95004"), rdscorecommon.VerifyCommatrixHostFirewallJournal)
+	},
+)

--- a/tests/system-tests/rdscore/tests/00_validate_top_level.go
+++ b/tests/system-tests/rdscore/tests/00_validate_top_level.go
@@ -727,11 +727,11 @@ var _ = Describe(
 
 			It("Verifies commatrix host-firewall TCP connectivity after ungraceful reboot",
 				Label("commatrix", "commatrix-connectivity"),
-				reportxml.ID("95003"), rdscorecommon.VerifyCommatrixHostFirewallConnectivity)
+				reportxml.ID("95005"), rdscorecommon.VerifyCommatrixHostFirewallConnectivity)
 
 			It("Verifies commatrix firewall journal logging after ungraceful reboot",
 				Label("commatrix", "commatrix-journal"),
-				reportxml.ID("95004"), rdscorecommon.VerifyCommatrixHostFirewallJournal)
+				reportxml.ID("95006"), rdscorecommon.VerifyCommatrixHostFirewallJournal)
 
 			AfterEach(func(ctx SpecContext) {
 				// Check if the test failed using CurrentSpecReport
@@ -1055,11 +1055,11 @@ var _ = Describe(
 
 			It("Verifies commatrix host-firewall TCP connectivity after graceful reboot",
 				Label("commatrix", "commatrix-connectivity"),
-				reportxml.ID("95003"), rdscorecommon.VerifyCommatrixHostFirewallConnectivity)
+				reportxml.ID("95007"), rdscorecommon.VerifyCommatrixHostFirewallConnectivity)
 
 			It("Verifies commatrix firewall journal logging after graceful reboot",
 				Label("commatrix", "commatrix-journal"),
-				reportxml.ID("95004"), rdscorecommon.VerifyCommatrixHostFirewallJournal)
+				reportxml.ID("95008"), rdscorecommon.VerifyCommatrixHostFirewallJournal)
 
 			AfterEach(func(ctx SpecContext) {
 				// Check if the test failed using CurrentSpecReport

--- a/tests/system-tests/rdscore/tests/00_validate_top_level.go
+++ b/tests/system-tests/rdscore/tests/00_validate_top_level.go
@@ -364,6 +364,14 @@ var _ = Describe(
 				reportxml.ID("82910"),
 				rdscorecommon.VerifyWhereaboutsInterDeploymentPodCommunicationOnTheSameNodeAfterNodePowerOff)
 
+			It("Verifies commatrix host-firewall TCP connectivity",
+				Label("commatrix", "commatrix-connectivity"),
+				reportxml.ID("95003"), rdscorecommon.VerifyCommatrixHostFirewallConnectivity)
+
+			It("Verifies commatrix firewall journal logging",
+				Label("commatrix", "commatrix-journal"),
+				reportxml.ID("95004"), rdscorecommon.VerifyCommatrixHostFirewallJournal)
+
 			AfterEach(func(ctx SpecContext) {
 				// Check if the test failed using CurrentSpecReport
 				if CurrentSpecReport().Failed() {
@@ -717,6 +725,14 @@ var _ = Describe(
 				reportxml.ID("82734"),
 				rdscorecommon.VerifyPodCommunicationOnDifferentNodesAfterClusterReboot)
 
+			It("Verifies commatrix host-firewall TCP connectivity after ungraceful reboot",
+				Label("commatrix", "commatrix-connectivity"),
+				reportxml.ID("95003"), rdscorecommon.VerifyCommatrixHostFirewallConnectivity)
+
+			It("Verifies commatrix firewall journal logging after ungraceful reboot",
+				Label("commatrix", "commatrix-journal"),
+				reportxml.ID("95004"), rdscorecommon.VerifyCommatrixHostFirewallJournal)
+
 			AfterEach(func(ctx SpecContext) {
 				// Check if the test failed using CurrentSpecReport
 				if CurrentSpecReport().Failed() {
@@ -1037,6 +1053,14 @@ var _ = Describe(
 				reportxml.ID("82736"),
 				rdscorecommon.VerifyPodCommunicationOnDifferentNodesAfterClusterReboot)
 
+			It("Verifies commatrix host-firewall TCP connectivity after graceful reboot",
+				Label("commatrix", "commatrix-connectivity"),
+				reportxml.ID("95003"), rdscorecommon.VerifyCommatrixHostFirewallConnectivity)
+
+			It("Verifies commatrix firewall journal logging after graceful reboot",
+				Label("commatrix", "commatrix-journal"),
+				reportxml.ID("95004"), rdscorecommon.VerifyCommatrixHostFirewallJournal)
+
 			AfterEach(func(ctx SpecContext) {
 				// Check if the test failed using CurrentSpecReport
 				if CurrentSpecReport().Failed() {
@@ -1046,28 +1070,3 @@ var _ = Describe(
 			})
 		})
 	})
-
-var _ = Describe(
-	"Commatrix",
-	Ordered,
-	Label("commatrix"),
-	func() {
-		AfterAll(rdscorecommon.CommatrixRevertAfterSpec)
-
-		It("Verifies commatrix artifact generation",
-			Label("commatrix-artifacts"),
-			reportxml.ID("95001"), rdscorecommon.VerifyCommatrixHostFirewallArtifacts)
-
-		It("Verifies commatrix MachineConfig apply and nftables",
-			Label("commatrix-apply"),
-			reportxml.ID("95002"), rdscorecommon.VerifyCommatrixHostFirewallApply, SpecTimeout(20*time.Minute))
-
-		It("Verifies commatrix host-firewall TCP connectivity",
-			Label("commatrix-connectivity"),
-			reportxml.ID("95003"), rdscorecommon.VerifyCommatrixHostFirewallConnectivity)
-
-		It("Verifies commatrix firewall journal logging",
-			Label("commatrix-journal"),
-			reportxml.ID("95004"), rdscorecommon.VerifyCommatrixHostFirewallJournal)
-	},
-)


### PR DESCRIPTION
Add ordered Commatrix Ginkgo specs (reportxml 95001-95004) for oc commatrix host-firewall MachineConfigs: artifact generation, MC apply with nftables verification, TCP connectivity from the test runner, and kernel journal rate-limit checks.

- Implement workflow in rdscorecommon/commatrix.go (MCP apply/revert, topology resolution, nc probes, journalctl windows)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive host-firewall system tests covering artifact generation, ordered apply/revert, TCP connectivity checks across configured, ungraceful, and graceful reboot phases, kernel/journal logging validation, and distinct test IDs per phase.

* **Documentation**
  * Added a README describing expected artifacts, probe behavior, logging assertions, timeouts, and required execution order.

* **Chores**
  * Added a configurable Commatrix output directory with a sensible default for the test workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->