### PR TITLE
system-tests: extend SRIOV sync delay and whereabouts deployment timeout

### DIFF
--- a/tests/system-tests/rdscore/internal/rdscorecommon/sriov-pod-level-bond.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/sriov-pod-level-bond.go
@@ -1246,6 +1246,8 @@ func waitForPodLevelBondNodesSriovSync() error {
 		RDSCoreConfig.PodLevelBondPodTwoScheduleOnHost,
 	}
 
+	anyNodeResynced := false
+
 	for _, nodeName := range nodeNames {
 		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Checking SRIOVNetworkNodeState sync status on node %q", nodeName)
 
@@ -1259,6 +1261,13 @@ func waitForPodLevelBondNodesSriovSync() error {
 			return fmt.Errorf("SRIOVNetworkNodeState not found for node %q: %w", nodeName, err)
 		}
 
+		if sriovNodeState.Objects.Status.SyncStatus == rdscoreparams.SriovNetworkNodeStateSucceededStatus {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+				"SRIOVNetworkNodeState on node %q is already Succeeded, no wait needed", nodeName)
+
+			continue
+		}
+
 		klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
 			"Waiting up to %v for SRIOVNetworkNodeState sync status '%s' on node %q",
 			timeout, rdscoreparams.SriovNetworkNodeStateSucceededStatus, nodeName)
@@ -1270,6 +1279,16 @@ func waitForPodLevelBondNodesSriovSync() error {
 
 		klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
 			"Successfully waited for SRIOVNetworkNodeState sync on node %q", nodeName)
+
+		anyNodeResynced = true
+	}
+
+	if anyNodeResynced {
+		// Wait for the SR-IOV device plugin to re-enumerate VFs and advertise updated
+		// resources to the kubelet.
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+			"Waiting 120s for SR-IOV device plugin to advertise updated resources after sync")
+		time.Sleep(120 * time.Second)
 	}
 
 	return nil

--- a/tests/system-tests/rdscore/internal/rdscorecommon/sriov-pod-level-bond.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/sriov-pod-level-bond.go
@@ -44,6 +44,7 @@ const (
 const (
 	sriovDevicePluginRecoveryDelay   = 2 * time.Minute
 	sriovNetworkNodeStateSyncTimeout = 15 * time.Minute
+	sriovResourcePollInterval        = 5 * time.Second
 	sriovResourcePrefix              = "openshift.io"
 )
 
@@ -1253,7 +1254,7 @@ func waitForPodLevelBondNodesSriovSync() error {
 		RDSCoreConfig.PodLevelBondPodTwoScheduleOnHost,
 	}
 
-	resyncedNodes := []string{}
+	var resyncedNodes []string
 
 	for _, nodeName := range nodeNames {
 		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Checking SRIOVNetworkNodeState sync status on node %q", nodeName)
@@ -1342,7 +1343,7 @@ func waitForSriovResourcesOnNodes(nodeNames, resourceNames []string) error {
 			var finalQty resource.Quantity
 
 			err := wait.PollUntilContextTimeout(
-				context.Background(), 5*time.Second, sriovDevicePluginRecoveryDelay, true,
+				context.TODO(), sriovResourcePollInterval, sriovDevicePluginRecoveryDelay, true,
 				func(ctx context.Context) (bool, error) {
 					nodeBuilder, pullErr := nodes.Pull(APIClient, nodeName)
 					if pullErr != nil {

--- a/tests/system-tests/rdscore/internal/rdscorecommon/sriov-pod-level-bond.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/sriov-pod-level-bond.go
@@ -39,6 +39,11 @@ const (
 	mtuSize                        = "8900"
 )
 
+const (
+	sriovDevicePluginRecoveryDelay   = 2 * time.Minute
+	sriovNetworkNodeStateSyncTimeout = 15 * time.Minute
+)
+
 var (
 	podLevelBondPodLabelMap = map[string]string{"systemtest-test": "rdscore-pod-level-bond-privileged"}
 )
@@ -1240,7 +1245,6 @@ func waitForPodLevelBondNodesSriovSync() error {
 	By("Waiting for SRIOVNetworkNodeState to reach Succeeded sync status on pod-level bond nodes")
 
 	sriovNamespace := rdscoreparams.SriovOperatorNamespace
-	timeout := 15 * time.Minute
 	nodeNames := []string{
 		RDSCoreConfig.PodLevelBondPodOneScheduleOnHost,
 		RDSCoreConfig.PodLevelBondPodTwoScheduleOnHost,
@@ -1270,9 +1274,10 @@ func waitForPodLevelBondNodesSriovSync() error {
 
 		klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
 			"Waiting up to %v for SRIOVNetworkNodeState sync status '%s' on node %q",
-			timeout, rdscoreparams.SriovNetworkNodeStateSucceededStatus, nodeName)
+			sriovNetworkNodeStateSyncTimeout, rdscoreparams.SriovNetworkNodeStateSucceededStatus, nodeName)
 
-		err = sriovNodeState.WaitUntilSyncStatus(rdscoreparams.SriovNetworkNodeStateSucceededStatus, timeout)
+		err = sriovNodeState.WaitUntilSyncStatus(
+			rdscoreparams.SriovNetworkNodeStateSucceededStatus, sriovNetworkNodeStateSyncTimeout)
 		if err != nil {
 			return fmt.Errorf("timeout waiting for SRIOVNetworkNodeState sync on node %q: %w", nodeName, err)
 		}
@@ -1285,10 +1290,11 @@ func waitForPodLevelBondNodesSriovSync() error {
 
 	if anyNodeResynced {
 		// Wait for the SR-IOV device plugin to re-enumerate VFs and advertise updated
-		// resources to the kubelet.
+		// resources to kubelet.
 		klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
-			"Waiting 120s for SR-IOV device plugin to advertise updated resources after sync")
-		time.Sleep(120 * time.Second)
+			"Waiting %v for SR-IOV device plugin to advertise updated resources after sync",
+			sriovDevicePluginRecoveryDelay)
+		time.Sleep(sriovDevicePluginRecoveryDelay)
 	}
 
 	return nil

--- a/tests/system-tests/rdscore/internal/rdscorecommon/sriov-pod-level-bond.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/sriov-pod-level-bond.go
@@ -1316,9 +1316,26 @@ func getSriovResourceNamesForPodLevelBond() ([]string, error) {
 	resourceNames := make([]string, 0, len(networkNames))
 
 	for _, netName := range networkNames {
-		net, err := sriov.PullNetwork(APIClient, netName, rdscoreparams.SriovOperatorNamespace)
+		var net *sriov.NetworkBuilder
+
+		err := wait.PollUntilContextTimeout(
+			context.TODO(), 5*time.Second, time.Minute*1, true,
+			func(ctx context.Context) (bool, error) {
+				var pullErr error
+
+				net, pullErr = sriov.PullNetwork(APIClient, netName, rdscoreparams.SriovOperatorNamespace)
+				if pullErr != nil {
+					klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+						"Failed to pull SriovNetwork %q, retrying: %v", netName, pullErr)
+
+					return false, nil
+				}
+
+				return true, nil
+			})
 		if err != nil {
-			return nil, fmt.Errorf("failed to pull SriovNetwork %q: %w", netName, err)
+			return nil, fmt.Errorf("failed to pull SriovNetwork %q after %v: %w",
+				netName, time.Minute*1, err)
 		}
 
 		resourceName := sriovResourcePrefix + "/" + net.Object.Spec.ResourceName
@@ -1355,10 +1372,18 @@ func waitForSriovResourcesOnNodes(nodeNames, resourceNames []string) error {
 
 					qty, exists := nodeBuilder.Object.Status.Allocatable[corev1.ResourceName(resourceName)]
 					if !exists {
+						klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+							"Resource %q not yet present in allocatable resources on node %q, retrying",
+							resourceName, nodeName)
+
 						return false, nil
 					}
 
 					if qty.IsZero() {
+						klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+							"Resource %q on node %q has zero allocatable quantity, retrying",
+							resourceName, nodeName)
+
 						return false, nil
 					}
 

--- a/tests/system-tests/rdscore/internal/rdscorecommon/sriov-pod-level-bond.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/sriov-pod-level-bond.go
@@ -16,8 +16,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/wait"
 
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nodes"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/system-tests/internal/apiobjectshelper"
 
@@ -42,6 +44,7 @@ const (
 const (
 	sriovDevicePluginRecoveryDelay   = 2 * time.Minute
 	sriovNetworkNodeStateSyncTimeout = 15 * time.Minute
+	sriovResourcePrefix              = "openshift.io"
 )
 
 var (
@@ -1250,7 +1253,7 @@ func waitForPodLevelBondNodesSriovSync() error {
 		RDSCoreConfig.PodLevelBondPodTwoScheduleOnHost,
 	}
 
-	anyNodeResynced := false
+	resyncedNodes := []string{}
 
 	for _, nodeName := range nodeNames {
 		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Checking SRIOVNetworkNodeState sync status on node %q", nodeName)
@@ -1285,16 +1288,91 @@ func waitForPodLevelBondNodesSriovSync() error {
 		klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
 			"Successfully waited for SRIOVNetworkNodeState sync on node %q", nodeName)
 
-		anyNodeResynced = true
+		resyncedNodes = append(resyncedNodes, nodeName)
 	}
 
-	if anyNodeResynced {
-		// Wait for the SR-IOV device plugin to re-enumerate VFs and advertise updated
-		// resources to kubelet.
+	if len(resyncedNodes) > 0 {
+		resourceNames, err := getSriovResourceNamesForPodLevelBond()
+		if err != nil {
+			return fmt.Errorf("failed to get SR-IOV resource names for pod-level bond: %w", err)
+		}
+
+		return waitForSriovResourcesOnNodes(resyncedNodes, resourceNames)
+	}
+
+	return nil
+}
+
+// getSriovResourceNamesForPodLevelBond returns the full Kubernetes resource names
+// (e.g. "openshift.io/sriovleftmlxbond") for the two SR-IOV networks used by the
+// pod-level bond workload, by reading their ResourceName from the SriovNetwork CRs.
+func getSriovResourceNamesForPodLevelBond() ([]string, error) {
+	networkNames := []string{
+		RDSCoreConfig.PodLevelBondSRIOVNetOne,
+		RDSCoreConfig.PodLevelBondSRIOVNetTwo,
+	}
+
+	resourceNames := make([]string, 0, len(networkNames))
+
+	for _, netName := range networkNames {
+		net, err := sriov.PullNetwork(APIClient, netName, rdscoreparams.SriovOperatorNamespace)
+		if err != nil {
+			return nil, fmt.Errorf("failed to pull SriovNetwork %q: %w", netName, err)
+		}
+
+		resourceName := sriovResourcePrefix + "/" + net.Object.Spec.ResourceName
 		klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
-			"Waiting %v for SR-IOV device plugin to advertise updated resources after sync",
-			sriovDevicePluginRecoveryDelay)
-		time.Sleep(sriovDevicePluginRecoveryDelay)
+			"SriovNetwork %q has resource name %q", netName, resourceName)
+
+		resourceNames = append(resourceNames, resourceName)
+	}
+
+	return resourceNames, nil
+}
+
+// waitForSriovResourcesOnNodes polls each node's status.allocatable until all expected
+// SR-IOV resources show a non-zero count, confirming the device plugin has re-enumerated
+// the VFs after a sync.
+func waitForSriovResourcesOnNodes(nodeNames, resourceNames []string) error {
+	for _, nodeName := range nodeNames {
+		for _, resourceName := range resourceNames {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+				"Waiting for SR-IOV resource %q to become available on node %q", resourceName, nodeName)
+
+			var finalQty resource.Quantity
+
+			err := wait.PollUntilContextTimeout(
+				context.Background(), 5*time.Second, sriovDevicePluginRecoveryDelay, true,
+				func(ctx context.Context) (bool, error) {
+					nodeBuilder, pullErr := nodes.Pull(APIClient, nodeName)
+					if pullErr != nil {
+						klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+							"Failed to pull node %q: %v", nodeName, pullErr)
+
+						return false, nil
+					}
+
+					qty, exists := nodeBuilder.Object.Status.Allocatable[corev1.ResourceName(resourceName)]
+					if !exists {
+						return false, nil
+					}
+
+					if qty.IsZero() {
+						return false, nil
+					}
+
+					finalQty = qty
+
+					return true, nil
+				})
+			if err != nil {
+				return fmt.Errorf("SR-IOV resource %q did not become available on node %q within %v: %w",
+					resourceName, nodeName, sriovDevicePluginRecoveryDelay, err)
+			}
+
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+				"SR-IOV resource %q is available on node %q with quantity %s", resourceName, nodeName, &finalQty)
+		}
 	}
 
 	return nil

--- a/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-deployment.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-deployment.go
@@ -66,7 +66,7 @@ const (
 	// DefaultAffinityWeight value for the weight of the pod affinity or anti-affinity.
 	DefaultAffinityWeight = 100
 	// DefaultDeploymentTimeout value for the timeout of the deployment creation.
-	DefaultDeploymentTimeout = 5 * time.Minute
+	DefaultDeploymentTimeout = 10 * time.Minute
 	// DefaultDeploymentPollingInterval value for the polling interval of the deployment creation.
 	DefaultDeploymentPollingInterval = 15 * time.Second
 	// DefaultCleanupPollingInterval value for the polling interval of the cleanup.


### PR DESCRIPTION
1. Add delay after SR-IOV node resync to allow SR-IOV device plugin to re-enumerate VFs and advertise updated resources to the kubelet. 
2. Extend whereabouts deployment timeout to cover Whereabouts reconciler cycle (up to 3 min at */3 * * * *) plus pod scheduling and startup time after a node power-off eviction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved SR‑IOV pod-level sync to wait only for nodes that require resync, track which nodes were resynced, and verify expected device-plugin resources become available on affected nodes.
  * Added shared timeouts, recovery windows, and polling settings for SR‑IOV recovery and resource detection to reduce flakiness.
  * Extended deployment wait timeout from 5 to 10 minutes to accommodate slower environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/eco-gotests/pull/1407?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->