### PR TITLE
ocp-sriov: add RDMA Metrics API test cases

### DIFF
--- a/tests/ocp/sriov/internal/tsparams/consts.go
+++ b/tests/ocp/sriov/internal/tsparams/consts.go
@@ -26,6 +26,8 @@ const (
 	// LabelSriovNetAppNsTestCases represents sriov network application namespace label that can be used
 	// for test cases selection.
 	LabelSriovNetAppNsTestCases = "sriovnet-app-ns"
+	// LabelRdmaMetricsAPITestCases represents Rdma Metrics label that can be used for test cases selection.
+	LabelRdmaMetricsAPITestCases = "rdmametricsapi"
 
 	// MCOWaitTimeout represent timeout for mco operations.
 	MCOWaitTimeout = 35 * time.Minute

--- a/tests/ocp/sriov/tests/rdmametricsapi.go
+++ b/tests/ocp/sriov/tests/rdmametricsapi.go
@@ -1,0 +1,497 @@
+package tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nad"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/namespace"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nodes"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/sriov"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/cluster"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/sriovoperator"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/sriov/internal/ocpsriovinittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/sriov/internal/sriovenv"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/sriov/internal/sriovocpenv"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/ocp/sriov/internal/tsparams"
+	"gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/types"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+var _ = Describe("rdmaMetricsAPI", Ordered, Label(tsparams.LabelRdmaMetricsAPITestCases, tsparams.LabelSriovHWEnabled),
+	ContinueOnFailure, func() {
+		var (
+			workerNodeList           []*nodes.Builder
+			sriovInterfacesUnderTest []string
+			sriovNetNodeState        *sriov.PoolConfigBuilder
+			tPol1, tPol2             *sriov.PolicyBuilder
+			tNet1, tNet2             *sriov.NetworkBuilder
+		)
+
+		BeforeAll(func() {
+			By("Verifying if Rdma Metrics API tests can be executed on given cluster")
+
+			err := sriovocpenv.DoesClusterHaveEnoughNodes(1, 1)
+			if err != nil {
+				Skip(fmt.Sprintf("Skipping test - cluster doesn't have enough nodes: %v", err))
+			}
+
+			By("Validating SR-IOV interfaces")
+
+			workerNodeList, err = nodes.List(APIClient,
+				metav1.ListOptions{LabelSelector: labels.Set(SriovOcpConfig.WorkerLabelMap).String()})
+			Expect(err).ToNot(HaveOccurred(), "Failed to discover worker nodes")
+
+			Expect(sriovocpenv.ValidateSriovInterfaces(workerNodeList, 2)).ToNot(HaveOccurred(),
+				"Failed to get required SR-IOV interfaces")
+
+			sriovInterfacesUnderTest, err = SriovOcpConfig.GetSriovInterfaces(2)
+			Expect(err).ToNot(HaveOccurred(), "Failed to retrieve SR-IOV interfaces for testing")
+
+			By("Fetching SR-IOV Vendor ID for interface under test")
+
+			sriovVendor, err := sriovoperator.DiscoverInterfaceUnderTestVendorID(
+				APIClient, SriovOcpConfig.OcpSriovOperatorNamespace,
+				sriovInterfacesUnderTest[0], workerNodeList[0].Definition.Name)
+			Expect(err).ToNot(HaveOccurred(), "Failed to fetch SR-IOV Vendor ID for interface under test")
+
+			By("Skipping test cases if the Sriov device is not of Mellanox")
+
+			if sriovVendor != tsparams.MlxVendorID {
+				Skip("Rdma metrics is supported only on Mellanox devices")
+			}
+		})
+
+		Context("Rdma metrics in exclusive mode", func() {
+			BeforeAll(func() {
+				By("Enable RDMA exclusive mode with NetworkPoolConfig")
+
+				sriovNetNodeState = setRdmaMode("exclusive")
+
+				By("Create Sriov Node Policy and Network")
+
+				tPol1 = defineAndCreateNodePolicy("rdmapolicy1", "sriovpf1", sriovInterfacesUnderTest[0], 6, 1)
+				tPol2 = defineAndCreateNodePolicy("rdmapolicy2", "sriovpf2", sriovInterfacesUnderTest[1], 6, 1)
+				tNet1 = defineAndCreateSriovNetworkWithRdma("sriovnet1", tPol1.Object.Spec.ResourceName, true)
+				tNet2 = defineAndCreateSriovNetworkWithRdma("sriovnet2", tPol2.Object.Spec.ResourceName, true)
+
+				err := cluster.WaitForMcpStable(APIClient, tsparams.MCOWaitTimeout, 1*time.Minute,
+					SriovOcpConfig.MCPLabel)
+				Expect(err).ToNot(HaveOccurred(), "Failed to wait for Sriov state to be stable")
+
+				By("Ensure RDMA is in exclusive mode")
+
+				verifyRdmaModeStatus("exclusive", workerNodeList)
+			})
+			It("1 Pod with 1 VF", reportxml.ID("77651"), func() {
+				By("Define and Create Test Pod")
+
+				testPod := defineAndCreateRdmaPod(tNet1.Object.Name, "")
+
+				By("Verify allocatable devices doesn't change after sriov-device-plugin pod restart")
+				verifyAllocatableResources(testPod, tPol1.Object.Spec.ResourceName)
+
+				By("Verify Rdma metrics are available inside Pod but not on Host")
+				verifyRdmaMetrics(testPod, "net1")
+			})
+			It("1 Pod with 2 VF of same PF", reportxml.ID("77650"), func() {
+				By("Define and Create Test Pod")
+
+				testPod := defineAndCreateRdmaPod(tNet1.Object.Name, tNet1.Object.Name)
+
+				By("Verify allocatable devices doesn't change after sriov-device-plugin pod restart")
+				verifyAllocatableResources(testPod, tPol1.Object.Spec.ResourceName)
+
+				By("Verify Rdma metrics are available inside Pod but not on Host")
+				verifyRdmaMetrics(testPod, "net1")
+				verifyRdmaMetrics(testPod, "net2")
+			})
+			It("1 Pod with 2 VF of different PF", reportxml.ID("77649"), func() {
+				By("Define and Create Test Pod")
+
+				testPod := defineAndCreateRdmaPod(tNet1.Object.Name, tNet2.Object.Name)
+
+				By("Verify allocatable devices doesn't change after sriov-device-plugin pod restart")
+				verifyAllocatableResources(testPod, tPol1.Object.Spec.ResourceName)
+				verifyAllocatableResources(testPod, tPol2.Object.Spec.ResourceName)
+
+				By("Verify Rdma metrics are available inside Pod but not on Host")
+				verifyRdmaMetrics(testPod, "net1")
+				verifyRdmaMetrics(testPod, "net2")
+			})
+
+			AfterEach(func() {
+				By("Cleaning test namespace")
+
+				err := namespace.NewBuilder(APIClient, tsparams.TestNamespaceName).CleanObjects(
+					tsparams.DefaultTimeout, pod.GetGVR())
+				Expect(err).ToNot(HaveOccurred(), "Failed to clean test namespace")
+			})
+
+			AfterAll(func() {
+				By("Removing SR-IOV configuration")
+
+				err := sriovoperator.RemoveSriovConfigurationAndWaitForSriovAndMCPStable(
+					APIClient,
+					SriovOcpConfig.WorkerLabelEnvVar,
+					SriovOcpConfig.OcpSriovOperatorNamespace,
+					tsparams.MCOWaitTimeout,
+					tsparams.DefaultTimeout)
+				Expect(err).ToNot(HaveOccurred(), "Failed to remove SR-IOV configuration")
+
+				By("Cleaning test namespace")
+
+				err = namespace.NewBuilder(APIClient, tsparams.TestNamespaceName).CleanObjects(
+					tsparams.DefaultTimeout, pod.GetGVR())
+				Expect(err).ToNot(HaveOccurred(), "Failed to clean test namespace")
+
+				By("Delete SriovPoolConfig")
+
+				err = sriovNetNodeState.Delete()
+				Expect(err).ToNot(HaveOccurred(), "Failed to delete SriovPoolConfig")
+
+				err = cluster.WaitForMcpStable(
+					APIClient, tsparams.MCOWaitTimeout, 1*time.Minute, SriovOcpConfig.MCPLabel)
+				Expect(err).ToNot(HaveOccurred(), "Failed to wait for SriovNodeState to be stable")
+			})
+		})
+
+		Context("Rdma metrics in shared mode", func() {
+			BeforeAll(func() {
+				By("Set Rdma Mode to shared")
+
+				sriovNetNodeState = setRdmaMode("shared")
+
+				By("Create Sriov Node Policy and Network")
+
+				tPol1 = defineAndCreateNodePolicy("rdmapolicy1", "sriovpf1", sriovInterfacesUnderTest[0], 1, 0)
+				tNet1 = defineAndCreateSriovNetworkWithRdma("sriovnet1", tPol1.Object.Spec.ResourceName, false)
+
+				err := cluster.WaitForMcpStable(APIClient, tsparams.MCOWaitTimeout, 1*time.Minute,
+					SriovOcpConfig.MCPLabel)
+				Expect(err).ToNot(HaveOccurred(), "Failed to wait for Sriov state to be stable")
+
+				By("Ensure RDMA is in shared mode")
+
+				verifyRdmaModeStatus("shared", workerNodeList)
+			})
+			It("1 Pod with 1 VF", reportxml.ID("77653"), func() {
+				By("Define and Create Test Pod")
+
+				testPod := defineAndCreateRdmaPod(tNet1.Object.Name, "")
+
+				By("Verify allocatable devices doesn't change after sriov-device-plugin pod restart")
+				verifyAllocatableResources(testPod, tPol1.Object.Spec.ResourceName)
+
+				By("Fetch PCI Address and Rdma device from Pod Annotations")
+
+				pciAddress, rdmaDevice, err := getRdmaInterfacePci(testPod, "net1")
+				Expect(err).ToNot(HaveOccurred(),
+					"Could not get PCI Address and/or Rdma device from Pod Annotations")
+				Expect(pciAddress).To(Not(BeEmpty()), "pci-address field is empty")
+				Expect(rdmaDevice).To(Not(BeEmpty()), "rdma-device field is empty")
+
+				By("Verify Rdma Metrics should not be present inside Pod")
+
+				podOutput, err := testPod.ExecCommand(
+					[]string{"bash", "-c", fmt.Sprintf("ls /sys/bus/pci/devices/%s/infiniband/%s/ports/1/hw_counters",
+						pciAddress, rdmaDevice)})
+				Expect(err).To(HaveOccurred(), "Expected command to fail as the path is not present on Pod")
+				Expect(podOutput.String()).To(ContainSubstring("No such file or directory"),
+					fmt.Sprintf("Expected error 'No such file or directory' in the output %s", podOutput.String()))
+
+				By("Verify Rdma Metrics should be present on Host")
+
+				nodeOutput, err := cluster.ExecCmdWithStdout(APIClient,
+					fmt.Sprintf("ls /sys/bus/pci/devices/%s/infiniband/%s/ports/1/hw_counters", pciAddress, rdmaDevice),
+					metav1.ListOptions{LabelSelector: fmt.Sprintf("kubernetes.io/hostname=%s", testPod.Object.Spec.NodeName)})
+				Expect(err).ToNot(HaveOccurred(),
+					fmt.Sprintf("Failed to run command %s on node %s",
+						fmt.Sprintf("ls /sys/bus/pci/devices/%s/infiniband/%s/ports/1/hw_counters",
+							pciAddress, rdmaDevice), testPod.Object.Spec.NodeName))
+				Expect(nodeOutput[testPod.Object.Spec.NodeName]).To(ContainSubstring("out_of_buffer"),
+					fmt.Sprintf("Failed to find the counters in the output %s", nodeOutput[testPod.Object.Spec.NodeName]))
+			})
+
+			AfterEach(func() {
+				By("Cleaning test namespace")
+
+				err := namespace.NewBuilder(APIClient, tsparams.TestNamespaceName).CleanObjects(
+					tsparams.DefaultTimeout, pod.GetGVR())
+				Expect(err).ToNot(HaveOccurred(), "Failed to clean test namespace")
+			})
+
+			AfterAll(func() {
+				By("Removing SR-IOV configuration")
+
+				err := sriovoperator.RemoveSriovConfigurationAndWaitForSriovAndMCPStable(
+					APIClient,
+					SriovOcpConfig.WorkerLabelEnvVar,
+					SriovOcpConfig.OcpSriovOperatorNamespace,
+					tsparams.MCOWaitTimeout,
+					tsparams.DefaultTimeout)
+				Expect(err).ToNot(HaveOccurred(), "Failed to remove SR-IOV configuration")
+
+				By("Delete SriovPoolConfig")
+
+				err = sriovNetNodeState.Delete()
+				Expect(err).ToNot(HaveOccurred(), "Failed to delete SriovPoolConfig")
+
+				err = cluster.WaitForMcpStable(
+					APIClient, tsparams.MCOWaitTimeout, 1*time.Minute, SriovOcpConfig.MCPLabel)
+				Expect(err).ToNot(HaveOccurred(), "Failed to wait for SriovNodeState to be stable")
+			})
+		})
+	})
+
+func setRdmaMode(mode string) *sriov.PoolConfigBuilder {
+	sriovPoolConfig, err := sriov.NewPoolConfigBuilder(
+		APIClient, "rdmasubsystem", SriovOcpConfig.OcpSriovOperatorNamespace).
+		WithNodeSelector(SriovOcpConfig.WorkerLabelMap).
+		WithMaxUnavailable(intstr.FromInt32(1)).
+		WithRDMAMode(mode).
+		Create()
+	Expect(err).ToNot(HaveOccurred(), "Failed to create SriovNetworkPoolConfig")
+
+	return sriovPoolConfig
+}
+
+func verifyRdmaModeStatus(mode string, nodelist []*nodes.Builder) {
+	By("Verify RdmaMode status through SriovNetworkNodeState API")
+
+	var allNodes []string
+
+	for _, node := range nodelist {
+		allNodes = append(allNodes, node.Object.Name)
+	}
+
+	sriovNodeStates, err := sriov.ListNetworkNodeState(APIClient, SriovOcpConfig.OcpSriovOperatorNamespace)
+	Expect(err).ToNot(HaveOccurred(), "Failed to fetch SriovNetworkNodeStates")
+
+	validatedNodes := 0
+
+	for _, nodeState := range sriovNodeStates {
+		if slices.Contains(allNodes, nodeState.Objects.Name) {
+			Expect(nodeState.Objects.Spec.System.RdmaMode).To(Equal(mode), "SriovNodeState Spec is not correctly updated")
+			Expect(nodeState.Objects.Status.System.RdmaMode).To(Equal(mode), "SriovNodeState Status is not correctly updated")
+
+			validatedNodes++
+		}
+	}
+
+	Expect(validatedNodes).To(Equal(len(allNodes)), "RDMA mode was not validated on all expected worker nodes")
+
+	By("Verify RdmaMode status through host cli")
+
+	outputNodes, err := cluster.ExecCmdWithStdout(
+		APIClient, "rdma system show",
+		metav1.ListOptions{LabelSelector: labels.Set(SriovOcpConfig.WorkerLabelMap).String()})
+	Expect(err).ToNot(HaveOccurred(), "Failed to get output of rdma system show")
+	Expect(outputNodes).To(HaveLen(len(allNodes)), "Did not get rdma output from all expected worker nodes")
+
+	for node, output := range outputNodes {
+		Expect(output).To(ContainSubstring(mode), fmt.Sprintf("RDMA is not set to %s on node %s", mode, node))
+	}
+}
+
+func verifyAllocatableResources(tPod *pod.Builder, resName string) {
+	testPodNode, err := nodes.Pull(APIClient, tPod.Object.Spec.NodeName)
+	Expect(err).ToNot(HaveOccurred(), "Failed to pull test pod's host worker node")
+
+	resKey := corev1.ResourceName("openshift.io/" + resName)
+	oldAllocatableSriovDevices, found := testPodNode.Object.Status.Allocatable[resKey]
+	Expect(found).To(BeTrue(), "Allocatable SR-IOV resource key not found on node")
+
+	oldNum, ok := oldAllocatableSriovDevices.AsInt64()
+	Expect(ok).To(BeTrue(), "Failed to convert allocatable SR-IOV resource to int64")
+
+	sriovDevicePluginPods, err := pod.List(APIClient, SriovOcpConfig.OcpSriovOperatorNamespace, metav1.ListOptions{
+		LabelSelector: labels.Set{"app": "sriov-device-plugin"}.String(),
+		FieldSelector: fields.SelectorFromSet(fields.Set{"spec.nodeName": tPod.Object.Spec.NodeName}).String()})
+	Expect(err).ToNot(HaveOccurred(), "Failed to list sriov device plugin pods")
+	Expect(len(sriovDevicePluginPods)).To(Equal(1), "Failed to fetch the sriov device plugin pod")
+
+	_, err = sriovDevicePluginPods[0].DeleteAndWait(1 * time.Minute)
+	Expect(err).ToNot(HaveOccurred(), "Failed to delete the sriov device plugin pod")
+
+	Eventually(func() error {
+		sriovDevicePluginPods, err = pod.List(APIClient, SriovOcpConfig.OcpSriovOperatorNamespace, metav1.ListOptions{
+			LabelSelector: labels.Set{"app": "sriov-device-plugin"}.String(),
+			FieldSelector: fields.SelectorFromSet(fields.Set{"spec.nodeName": tPod.Object.Spec.NodeName}).String()})
+		if err != nil {
+			return err
+		}
+
+		if len(sriovDevicePluginPods) != 1 {
+			return fmt.Errorf("expected 1 sriov-device-plugin pod, got %d", len(sriovDevicePluginPods))
+		}
+
+		return nil
+	}, 1*time.Minute, 2*time.Second).Should(Succeed(), "Failed to find the new sriov device plugin pod")
+
+	Eventually(func() (int64, error) {
+		testNode, err := nodes.Pull(APIClient, tPod.Object.Spec.NodeName)
+		if err != nil {
+			return 0, err
+		}
+
+		newAllocatableSriovDevices, found := testNode.Object.Status.Allocatable[resKey]
+		if !found {
+			return 0, fmt.Errorf("allocatable SR-IOV resource key not found on refreshed node")
+		}
+
+		newNum, ok := newAllocatableSriovDevices.AsInt64()
+		if !ok {
+			return 0, fmt.Errorf("failed to convert new allocatable SR-IOV resource value to int64")
+		}
+
+		return newNum, nil
+	}, 1*time.Minute, 2*time.Second).Should(Equal(oldNum), "New allocatable resource is not same as old")
+}
+
+func getRdmaInterfacePci(tPod *pod.Builder, podInterface string) (string, string, error) {
+	type PodNetworkStatusAnnotation struct {
+		Name       string   `json:"name"`
+		Interface  string   `json:"interface"`
+		Ips        []string `json:"ips,omitempty"`
+		Mac        string   `json:"mac,omitempty"`
+		Default    bool     `json:"default,omitempty"`
+		Mtu        int      `json:"mtu,omitempty"`
+		DeviceInfo struct {
+			Type    string `json:"type"`
+			Version string `json:"version"`
+			Pci     struct {
+				PciAddress string `json:"pci-address"`
+				RdmaDevice string `json:"rdma-device"`
+			} `json:"pci"`
+		} `json:"device-info,omitempty"`
+	}
+
+	var annotation []PodNetworkStatusAnnotation
+
+	err := json.Unmarshal([]byte(tPod.Object.Annotations["k8s.v1.cni.cncf.io/network-status"]), &annotation)
+	Expect(err).ToNot(HaveOccurred(), "Failed to Unmarshal Pod Network Status annotation")
+
+	for _, annotationObject := range annotation {
+		if annotationObject.Interface == podInterface {
+			if annotationObject.DeviceInfo.Pci.PciAddress != "" && annotationObject.DeviceInfo.Pci.RdmaDevice != "" {
+				return annotationObject.DeviceInfo.Pci.PciAddress, annotationObject.DeviceInfo.Pci.RdmaDevice, nil
+			}
+
+			return "", "", fmt.Errorf("PCI Address or Rdma Device are not present in the Interface %v", annotationObject)
+		}
+	}
+
+	return "", "", fmt.Errorf("interface %s not found", podInterface)
+}
+
+func defineAndCreateNodePolicy(polName, resName, sriovInterface string, numVfs, endVf int) *sriov.PolicyBuilder {
+	testPolicy, err := sriov.NewPolicyBuilder(APIClient,
+		polName, SriovOcpConfig.OcpSriovOperatorNamespace, resName, numVfs, []string{sriovInterface},
+		SriovOcpConfig.WorkerLabelMap).
+		WithDevType("netdevice").
+		WithVFRange(0, endVf).
+		WithRDMA(true).
+		Create()
+
+	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Failed to create SriovNodePolicy %s", polName))
+
+	return testPolicy
+}
+
+func defineAndCreateSriovNetworkWithRdma(netName, resName string, withRdma bool) *sriov.NetworkBuilder {
+	testNetBuilder := sriov.NewNetworkBuilder(
+		APIClient, netName, SriovOcpConfig.OcpSriovOperatorNamespace, tsparams.TestNamespaceName, resName).
+		WithMacAddressSupport().
+		WithIPAddressSupport().
+		WithStaticIpam().
+		WithLogLevel("debug")
+
+	if withRdma {
+		testNetBuilder.WithMetaPluginRdma()
+	}
+
+	_, err := testNetBuilder.Create()
+	Expect(err).ToNot(HaveOccurred(),
+		fmt.Sprintf("Failed to create Sriov Network %s", netName))
+
+	err = sriovenv.WaitForNADCreation(netName, tsparams.TestNamespaceName, tsparams.NADTimeout)
+	Expect(err).ToNot(HaveOccurred(),
+		"Failed to wait for NAD creation for Sriov Network %s with error %v",
+		netName, err)
+
+	return testNetBuilder
+}
+
+func defineAndCreateRdmaPod(netName1, netName2 string) *pod.Builder {
+	netAnnotations := []*types.NetworkSelectionElement{
+		{
+			Name:       netName1,
+			MacRequest: tsparams.TestPodServerMAC,
+			IPRequest:  []string{tsparams.ServerIPv4IPAddress},
+		},
+	}
+
+	if len(netName2) != 0 {
+		netAnnotations = append(netAnnotations, &types.NetworkSelectionElement{
+			Name:       netName2,
+			MacRequest: tsparams.TestPodClientMAC,
+			IPRequest:  []string{tsparams.ClientIPv4IPAddress},
+		})
+	}
+
+	for _, net := range netAnnotations {
+		Eventually(func() error {
+			_, err := nad.Pull(APIClient, net.Name, tsparams.TestNamespaceName)
+
+			return err
+		}, 10*time.Second, 1*time.Second).Should(BeNil(), fmt.Sprintf("Failed to pull NAD %s", net.Name))
+	}
+
+	tPod, err := pod.NewBuilder(
+		APIClient, "testpod", tsparams.TestNamespaceName, SriovOcpConfig.OcpSriovTestContainer).
+		WithSecondaryNetwork(netAnnotations).
+		WithPrivilegedFlag().
+		CreateAndWaitUntilRunning(2 * time.Minute)
+	Expect(err).ToNot(HaveOccurred(), "Failed to create Pod testpod")
+	Expect(tPod.Exists()).To(BeTrue(), "Pod testpod does not exist after creation")
+
+	return tPod
+}
+
+func verifyRdmaMetrics(inputPod *pod.Builder, iName string) {
+	By("Fetch PCI Address and Rdma device from Pod Annotations")
+
+	pciAddress, rdmaDevice, err := getRdmaInterfacePci(inputPod, iName)
+	Expect(err).ToNot(HaveOccurred(),
+		"Could not get PCI Address and/or Rdma device from Pod Annotations")
+	Expect(pciAddress).To(Not(BeEmpty()), "pci-address field is empty")
+	Expect(rdmaDevice).To(Not(BeEmpty()), "rdma-device field is empty")
+
+	By("Rdma metrics should be present inside the Pod")
+
+	podOutput, err := inputPod.ExecCommand(
+		[]string{"bash", "-c", fmt.Sprintf("ls /sys/bus/pci/devices/%s/infiniband/%s/ports/1/hw_counters",
+			pciAddress, rdmaDevice)})
+	Expect(err).ToNot(HaveOccurred(), "Failed to check counters directory on Pod")
+	Expect(podOutput.String()).To(ContainSubstring("out_of_buffer"),
+		fmt.Sprintf("Failed to find the counters in the output %s", podOutput.String()))
+
+	By("Rdma metrics should not be present in the Host")
+
+	_, err = cluster.ExecCmdWithStdout(APIClient,
+		fmt.Sprintf("ls /sys/bus/pci/devices/%s/infiniband/%s/ports/1/hw_counters", pciAddress, rdmaDevice),
+		metav1.ListOptions{LabelSelector: fmt.Sprintf("kubernetes.io/hostname=%s", inputPod.Object.Spec.NodeName)})
+	Expect(err).To(HaveOccurred(), "Failed to check counters directory on Host")
+	Expect(err.Error()).To(ContainSubstring("command terminated with exit code 2"), "Failure is not as expected")
+}


### PR DESCRIPTION
Co-authored-by: AI Assistant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive test suite validating SR-IOV RDMA metrics on Mellanox devices for exclusive and shared RDMA modes.
  * Verifies RDMA metrics presence/absence and resource stability across configurations, including plugin restarts and cleanup.
  * Added a test selector to enable running the Rdma Metrics API test cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/eco-gotests/pull/1408?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->