### PR TITLE
[release-4.20] hw-accel: fix the in-tree replacement module name

### DIFF
--- a/tests/hw-accel/kmm/modules/tests/intree-replacement-test.go
+++ b/tests/hw-accel/kmm/modules/tests/intree-replacement-test.go
@@ -25,7 +25,7 @@ var _ = Describe("KMM", Ordered, Label(kmmparams.LabelSuite, kmmparams.LabelSani
 
 	Context("Module", Label("in-tree-replace"), func() {
 
-		moduleName := kmmparams.InTreeReplacementNamespace
+		moduleName := "replace"
 		kmodName := "replace"
 		serviceAccountName := "replace-manager"
 		image := fmt.Sprintf("%s/%s/%s:$KERNEL_FULL_VERSION",


### PR DESCRIPTION
## Summary

Cherry-pick of #967 to `release-4.20`.

Fixes the in-tree replacement test (test_id:62745) which has been consistently failing due to a module name mismatch introduced when build arguments were updated.

## Changes

One-line fix: use the correct module name so the built `.ko` file matches what modprobe expects to load.

## Testing

- Fix verified on `main` — test passes
- `release-4.20` currently fails 100% of runs for this test