### PR TITLE
cnf network: fix metallb and nmstate tests

### DIFF
--- a/tests/cnf/core/network/metallb/tests/bgp-connect-time-tests.go
+++ b/tests/cnf/core/network/metallb/tests/bgp-connect-time-tests.go
@@ -141,7 +141,7 @@ var _ = Describe("FRR", Ordered, Label(tsparams.LabelBGPTestCases), ContinueOnFa
 
 				// Return the integer value of ConnectRetryTimer for assertion
 				return connectTimeValue
-			}, 60*time.Second, 5*time.Second).Should(Equal(120),
+			}, 60*time.Second, 5*time.Second).Should(Equal(60),
 				"Failed to fetch BGP connect time")
 
 			By("Update the BGP Peers connect timer to 10 seconds")

--- a/tests/cnf/core/network/nmstate/tests/altnames.go
+++ b/tests/cnf/core/network/nmstate/tests/altnames.go
@@ -539,6 +539,27 @@ var _ = Describe("NMState Altnames:", Ordered, Label(tsparams.LabelAltnames), Co
 				validateAltnamesFromNodeNetworkState(nnstate, sriovIf0, altnames1, false)(Default)
 			}
 
+			By("Waiting for SriovNetworkNodeState to reflect the new altname")
+
+			Eventually(func() error {
+				nodeState := sriov.NewNetworkNodeStateBuilder(
+					APIClient, workerNodes[0].Object.Name, NetConfig.SriovOperatorNamespace)
+
+				nics, err := nodeState.GetNICs()
+				if err != nil {
+					return err
+				}
+
+				for _, nic := range nics {
+					if nic.Name == altnames1[0] {
+						return nil
+					}
+				}
+
+				return fmt.Errorf("altname %s not yet found in SriovNetworkNodeState interfaces", altnames1[0])
+			}).WithTimeout(30*time.Second).WithPolling(5*time.Second).Should(Succeed(),
+				"SriovNetworkNodeState did not reflect the new altname in time")
+
 			By("Creating SriovNetworkNodePolicy with altname as interface name")
 
 			sriovPolicy, err := sriov.NewPolicyBuilder(APIClient,


### PR DESCRIPTION
- Fix race condition in nmstate altnames test (88007) by waiting for SriovNetworkNodeState to reflect the new PF altname before creating the SriovNetworkNodePolicy, preventing policy rejection due to the SRIOV operator not yet discovering the renamed interface.
- Update the default ConnectRetryTimer to 60 seconds to align with frr version 10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated BGP connection timer validation for improved network failover testing
  * Enhanced SR-IOV network interface testing with improved state verification to ensure proper interface name propagation and consistency across system components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->