### PR TITLE
cnf-network: fix ip forwarding per ipv6 interface

### DIFF
--- a/tests/cnf/core/network/metallb/tests/ip-forwarding.go
+++ b/tests/cnf/core/network/metallb/tests/ip-forwarding.go
@@ -169,7 +169,7 @@ var _ = Describe("IP Forwarding per Interface", Ordered,
 			networkOperator, err := network.PullOperator(APIClient)
 			Expect(err).ToNot(HaveOccurred(), "Failed to pull network operator for restore")
 
-			_, err = networkOperator.SetIPForwarding(originalIPForwarding, 10*time.Minute)
+			networkOperator, err = networkOperator.SetIPForwarding(originalIPForwarding, 10*time.Minute)
 			Expect(err).ToNot(HaveOccurred(), "Failed to restore ipForwarding")
 
 			_, err = networkOperator.SetLocalGWMode(originalRoutingViaHost, 10*time.Minute)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced IP forwarding test cleanup procedures to properly manage network operator state. The test now correctly captures and uses the returned operator object after restoring original IP forwarding settings, ensuring subsequent network configuration and gateway mode operations execute with accurate state, preventing potential cascading failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->