### PR TITLE
system-tests: enhance failure reporting with resource dumps (#1172)

### DIFF
--- a/tests/system-tests/rdscore/ENHANCED_FAILURE_REPORTING.md
+++ b/tests/system-tests/rdscore/ENHANCED_FAILURE_REPORTING.md
@@ -1,0 +1,450 @@
+# Enhanced Failure Reporting for RDS Core Tests
+
+This document explains the enhanced failure reporting capabilities added to RDS Core tests and how to use the k8sreporter framework for debugging test failures.
+
+## Overview
+
+This enhancement adds comprehensive resource status dumping when tests fail, making it easier to diagnose issues with pods, deployments, and statefulsets without needing to manually inspect the cluster after failures.
+
+## Changes Implemented
+
+### Enhanced Reporter Configuration
+
+**File:** `tests/system-tests/rdscore/internal/rdscoreparams/rdscorevars.go`
+
+**What Changed:**
+
+1. **Fixed Namespace Configuration** - Replaced demo namespaces with actual RDS Core test namespaces:
+   - SR-IOV workloads: `rds-sriov-wlkd`
+   - Storage (ODF/Ceph): `rds-cephfs-ns`, `rds-cephrbd-ns`, `rds-cephrbd-block-ns`
+   - Whereabouts: `rds-whereabouts`
+   - MACVLAN: `rds-macvlan`
+   - IPVLAN: `rds-ipvlan`
+   - EgressIP: `rds-egressip-ns-one`, `rds-egressip-ns-two`
+   - Egress Service: `rds-egress-ns`
+   - MetalLB/FRR: `rds-metallb-supporttools-ns`, `openshift-frr-k8s`
+   - NROP: `rds-nrop`
+   - Pod-level bonding: `rds-pod-level-bond`
+   - Rootless DPDK: `rds-dpdk`
+   - OpenShift networking:  `openshift-multus`
+
+2. **Enhanced Resource Types** - Added critical resource types for better debugging:
+   ```go
+   ReporterCRDsToDump = []k8sreporter.CRData{
+       {Cr: &corev1.PodList{}},                      // Pods
+       {Cr: &appsv1.DeploymentList{}},               // Deployments
+       {Cr: &appsv1.StatefulSetList{}},              // StatefulSets
+       {Cr: &appsv1.ReplicaSetList{}},               // ReplicaSets
+       {Cr: &corev1.EventList{}},                    // Events (critical!)
+       {Cr: &corev1.PersistentVolumeList{}},         // PersistentVolumes
+       {Cr: &corev1.PersistentVolumeClaimList{}},    // PersistentVolumeClaims
+   }
+   ```
+
+**Why This Matters:**
+- **Events** are crucial for understanding scheduling failures (e.g., "0/7 nodes available")
+- **Deployments/StatefulSets** show replica readiness and rollout status
+- **ReplicaSets** help trace pod ownership and version issues
+- **PersistentVolumes/PersistentVolumeClaims** help debug storage provisioning and binding failures
+
+### Resource Status Dump Functions
+
+**File:** `tests/system-tests/rdscore/internal/rdscorecommon/resource-status-dump.go` (NEW)
+
+Five new helper functions for comprehensive debugging:
+
+#### 1. `DumpPodStatusOnFailure(podBuilder *pod.Builder, err error)`
+
+**Purpose:** Automatically dumps detailed pod status when `WaitUntilReady()` fails
+
+**Information Dumped:**
+- Pod phase (Pending, Running, Failed, etc.)
+- Pod conditions with reasons and messages
+- Container statuses (Ready, Waiting, Terminated)
+- Init container statuses (often cause of Pending state)
+- Scheduling information (node assignment, nomination)
+- Owner references (traces back to Deployment/StatefulSet)
+- Resource requirements (helps diagnose scheduling failures)
+
+**Usage Example:**
+```go
+// After calling WaitUntilReady
+err := podTwo.WaitUntilReady(3 * time.Minute)
+
+// Dump detailed status if it failed
+if err != nil {
+    DumpPodStatusOnFailure(podTwo, err)
+}
+
+Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Pod %q in %q ns is not Ready",
+    podTwo.Definition.Name, podTwo.Definition.Namespace))
+```
+
+**Output Example:**
+```text
+========================================
+Pod "rdscore-sriov2-two-8b47b4-5rwz6" in namespace "rds-sriov-wlkd" Failed to Become Ready
+========================================
+Pod Phase: Pending
+
+Pod Conditions:
+  - Type: PodScheduled, Status: False, Reason: Unschedulable
+    Message: 0/7 nodes are available: 3 node(s) didn't match pod affinity rules, 3 node(s) had untolerated taint(s)...
+
+Container Statuses:
+  - Name: testpmd-container, Ready: false, RestartCount: 0
+    State: Waiting
+    Reason: ContainerCreating
+
+Scheduling: Pod has not been scheduled to any node
+
+Owner References:
+  - Kind: ReplicaSet, Name: rdscore-sriov2-two-8b47b4, Controller: true
+
+Resource Requirements:
+  Container testpmd-container:
+    Requests:
+      openshift.io/sriovnic: 2
+      cpu: 4
+      memory: 1Gi
+========================================
+```
+
+#### 2. `DumpDeploymentStatus(ctx SpecContext, namespace string)`
+
+**Purpose:** Dumps all Deployment statuses in a namespace (useful in AfterEach hooks)
+
+**Information Dumped:**
+- Replica counts (Desired, Current, Ready, Available, Updated, Unavailable)
+- Deployment conditions (Available, Progressing, ReplicaFailure)
+- Update strategy (RollingUpdate, Recreate)
+- Pod selector labels
+
+**Usage Example:**
+```go
+AfterEach(func(ctx SpecContext) {
+    if CurrentSpecReport().Failed() {
+        By("Dumping deployment status due to test failure")
+        DumpDeploymentStatus(ctx, "rds-sriov-wlkd")
+    }
+})
+```
+
+#### 3. `DumpStatefulSetStatus(ctx SpecContext, namespace string)`
+
+**Purpose:** Dumps all StatefulSet statuses in a namespace
+
+**Information Dumped:**
+- Replica counts (Desired, Current, Ready, Updated)
+- Current and update revisions
+- StatefulSet conditions
+- Update strategy
+- Service name and selector labels
+
+**Usage Example:**
+```go
+AfterEach(func(ctx SpecContext) {
+    if CurrentSpecReport().Failed() {
+        By("Dumping statefulset status due to test failure")
+        DumpStatefulSetStatus(ctx, "rds-whereabouts")
+    }
+})
+```
+
+#### 4. `DumpPersistentVolumeStatus(ctx SpecContext)`
+
+**Purpose:** Dumps cluster-wide PersistentVolume statuses for storage debugging
+
+**Information Dumped:**
+- Phase (Available, Bound, Released, Failed)
+- Capacity and access modes
+- Reclaim policy (Retain, Delete, Recycle)
+- Storage class and volume mode
+- Claim reference (which PVC is bound)
+- Node affinity (for local volumes)
+- Volume source type (CSI, RBD, CephFS, NFS, etc.)
+
+**Usage Example:**
+```go
+AfterEach(func(ctx SpecContext) {
+    if CurrentSpecReport().Failed() {
+        By("Dumping PV status due to storage test failure")
+        DumpPersistentVolumeStatus(ctx)
+    }
+})
+```
+
+#### 5. `DumpPersistentVolumeClaimStatus(ctx SpecContext, namespace string)`
+
+**Purpose:** Dumps all PersistentVolumeClaim statuses in a namespace for storage debugging
+
+**Information Dumped:**
+- Phase (Pending, Bound, Lost)
+- Requested vs allocated storage capacity
+- Access modes and storage class
+- Volume name (bound PV)
+- Volume mode (Filesystem/Block)
+- PVC conditions (Resizing, FileSystemResizePending, etc.)
+- Selector labels
+
+**Usage Example:**
+```go
+AfterEach(func(ctx SpecContext) {
+    if CurrentSpecReport().Failed() {
+        By("Dumping PVC status due to storage test failure")
+        DumpPersistentVolumeClaimStatus(ctx, "rds-cephfs-ns")
+        DumpPersistentVolumeClaimStatus(ctx, "openshift-storage")
+    }
+})
+```
+
+## How k8sreporter Works
+
+### Architecture
+
+k8sreporter is a Go library that dumps Kubernetes cluster state to the filesystem for post-test analysis.
+
+**GitHub Repository:** https://github.com/openshift-kni/k8sreporter
+
+### Core Components
+
+1. **KubernetesReporter** - Main object that manages dumping operations
+2. **Namespace Filter** - Selects which namespaces to dump
+3. **CRData** - Specifies which Custom Resources to collect
+4. **AddToScheme** - Extends the runtime scheme for custom CRDs
+
+### How It's Integrated
+
+```go
+// In rds_suite_test.go
+var _ = JustAfterEach(func() {
+    reporter.ReportIfFailed(
+        CurrentSpecReport(),
+        currentFile,
+        rdscoreparams.ReporterNamespacesToDump,  // ← Our enhanced config
+        rdscoreparams.ReporterCRDsToDump)        // ← Our enhanced config
+})
+```
+
+### Dump Trigger Flow
+
+```text
+Test Fails
+    ↓
+JustAfterEach Hook Executes
+    ↓
+reporter.ReportIfFailed() Checks Failure State
+    ↓
+Creates k8sreporter.KubernetesReporter
+    ↓
+Calls reporter.Dump(duration, folderName)
+    ↓
+Collects Resources from Configured Namespaces
+    ↓
+Writes to Filesystem at {ReportsDirAbsPath}/failed_{testname}/{test_full_text}/
+```
+
+### Configuration
+
+Reporter behavior is controlled by environment variables or YAML config:
+
+```bash
+# Enable dump on test failure
+export ECO_DUMP_FAILED_TESTS=true
+
+# Specify dump directory
+export ECO_REPORTS_DUMP_DIR=/tmp/test-reports
+
+# Set logging verbosity
+export ECO_VERBOSE_LEVEL=100
+```
+
+**Default Config:** `tests/internal/config/default.yaml`
+
+## Checking k8sreporter Results
+
+### 1. Locate Dump Directory
+
+The dump location is determined by:
+- Environment variable: `ECO_REPORTS_DUMP_DIR`
+- YAML config: `reports_dump_dir`
+- Default: Usually project root or `/tmp`
+
+### 2. Directory Structure
+
+```text
+{ReportsDirAbsPath}/
+└── failed_{testname}/
+    └── {Test_Description_With_Underscores}/
+        ├── nodes.log                                    # All cluster nodes (JSON)
+        ├── events.log                                   # Kubernetes events
+        ├── rds-sriov-wlkd_rdscore-sriov2-two-xxx_pods_logs.log
+        ├── rds-sriov-wlkd_rdscore-sriov2-two-xxx_pods_specs.log
+        ├── rds-sriov-wlkd_deployments.log               # All deployments in namespace
+        ├── rds-sriov-wlkd_statefulsets.log              # All statefulsets
+        ├── rds-sriov-wlkd_replicasets.log               # All replicasets
+        ├── rds-sriov-wlkd_events.log                    # Namespace-specific events
+        └── pod_exec_logs.log                            # Custom pod execution logs
+```
+
+### 3. Example: Investigating Test ID 80423 Failure
+
+**Test:** "Verifies SR-IOV workloads on different nodes and same SR-IOV network post reboot"
+
+**Failure:** Pod `rdscore-sriov2-two-8b47b4-5rwz6` not ready
+
+**Investigation Steps:**
+
+1. **Find the dump directory:**
+   ```bash
+   cd {ReportsDirAbsPath}/failed_rds_suite_test
+   ls -la
+   # Look for folder matching test description
+   cd "Verifies_SR-IOV_workloads_on_different_nodes_..."
+   ```
+
+2. **Check pod spec and logs:**
+   ```bash
+   # Pod specification (JSON)
+   jq '.' rds-sriov-wlkd_rdscore-sriov2-two-*_pods_specs.log
+
+   # Pod logs
+   cat rds-sriov-wlkd_rdscore-sriov2-two-*_pods_logs.log
+   ```
+
+3. **Check events for scheduling issues:**
+   ```bash
+   # Namespace-specific events
+   cat rds-sriov-wlkd_events.log | grep -i "failed\|error\|insufficient"
+
+   # Common patterns:
+   # - "Insufficient openshift.io/sriovnic"
+   # - "Failed to pull image"
+   # - "0/N nodes available"
+   ```
+
+4. **Check deployment status:**
+   ```bash
+   # View deployment conditions
+   jq '.[] | {name: .metadata.name, replicas: .status, conditions: .status.conditions}' \
+      rds-sriov-wlkd_deployments.log
+   ```
+
+5. **Check node resources:**
+   ```bash
+   # See allocatable resources on all nodes
+   jq '.[] | {name: .metadata.name, allocatable: .status.allocatable}' nodes.log
+   ```
+
+### 4. Common Failure Patterns and Where to Look
+
+| Failure Pattern | Check These Files | Look For |
+|----------------|-------------------|----------|
+| Pod stuck in Pending | `events.log`, pod specs | Scheduling reasons, resource requests, node taints |
+| Pod CrashLoopBackOff | Pod logs, pod specs | Container exit codes, OOMKilled, application errors |
+| ImagePullBackOff | `events.log`, pod specs | Image name/tag, registry credentials |
+| Deployment not progressing | `deployments.log`, `replicasets.log` | Deployment conditions, ReplicaSet status |
+| StatefulSet pods not ready | `statefulsets.log`, `events.log` | Revision mismatches, PVC issues |
+| Network connectivity issues | Pod logs, `events.log` | CNI errors, IP allocation failures |
+| SR-IOV resource unavailable | `nodes.log`, `events.log` | Allocatable SR-IOV resources, device plugin status |
+
+### 5. Automated Analysis Tips
+
+```bash
+# Find all failed pods
+jq -r '.[] | select(.status.phase != "Running" and .status.phase != "Succeeded") |
+  "\(.metadata.namespace)/\(.metadata.name): \(.status.phase)"' *_pods_specs.log
+
+# Find all pods with high restart counts
+jq -r '.[] | select(.status.containerStatuses[]?.restartCount > 0) |
+  "\(.metadata.name): \(.status.containerStatuses[0].restartCount) restarts"' *_pods_specs.log
+
+# Extract all error/warning events
+jq -r '.[] | select(.type == "Warning" or .type == "Error") |
+  "[\(.type)] \(.involvedObject.name): \(.message)"' events.log
+
+# Check node pressure conditions
+jq -r '.[] | .status.conditions[] | select(.status == "True" and .type != "Ready") |
+  "\(.type): \(.message)"' nodes.log
+```
+
+## Integration with Existing Tests
+
+### For Existing Test Cases
+
+**Before:**
+```go
+err = podTwo.WaitUntilReady(3 * time.Minute)
+Expect(err).ToNot(HaveOccurred(),
+    fmt.Sprintf("Pod %q in %q ns is not Ready", podTwo.Definition.Name, podTwo.Definition.Namespace))
+```
+
+**After (Recommended):**
+```go
+err = podTwo.WaitUntilReady(3 * time.Minute)
+
+if err != nil {
+    DumpPodStatusOnFailure(podTwo, err)
+}
+
+Expect(err).ToNot(HaveOccurred(),
+    fmt.Sprintf("Pod %q in %q ns is not Ready", podTwo.Definition.Name, podTwo.Definition.Namespace))
+```
+
+### For New Test Cases
+
+Consider adding resource dumps in AfterEach hooks for comprehensive failure debugging:
+
+```go
+AfterEach(func(ctx SpecContext) {
+    if CurrentSpecReport().Failed() {
+        By("Dumping resource status due to test failure")
+
+        // Dump node status (already exists)
+        rdscorecommon.DumpNodeStatus(ctx)
+
+        // NEW: Dump deployment status
+        rdscorecommon.DumpDeploymentStatus(ctx, "rds-sriov-wlkd")
+
+        // NEW: Dump statefulset status (if applicable)
+        // rdscorecommon.DumpStatefulSetStatus(ctx, "rds-whereabouts")
+    }
+
+    // Cleanup
+    By("Ensure all nodes are Ready")
+    rdscorecommon.EnsureInNodeReadiness(ctx)
+})
+```
+
+## Benefits
+
+1. **Reduced Debugging Time** - Immediate visibility into failure root causes
+2. **No Manual Cluster Inspection** - All relevant data captured automatically
+3. **Historical Analysis** - Dumps preserved for post-mortem review
+4. **Better Bug Reports** - Include dumps in bug reports for faster triage
+5. **Pattern Recognition** - Easily identify recurring failure patterns
+6. **CI/CD Integration** - Dumps available in Jenkins artifacts
+
+## Ginkgo Integration
+
+The `DumpPodStatusOnFailure` function uses Ginkgo's `AddReportEntry` with `ReportEntryVisibilityFailureOrVerbose`:
+
+```go
+AddReportEntry(
+    fmt.Sprintf("Pod %s Failure Details", podName),
+    debugInfo,
+    ReportEntryVisibilityFailureOrVerbose,  // Only shown on failure or with -v
+)
+```
+
+This means:
+- Report entries appear in JUnit XML output
+- Only visible in console when tests fail or run with `--vv`
+- Structured data for CI/CD parsing
+
+## References
+
+- **k8sreporter GitHub:** https://github.com/openshift-kni/k8sreporter
+- **Ginkgo v2 Documentation:** https://onsi.github.io/ginkgo/
+- **Ginkgo AddReportEntry:** https://pkg.go.dev/github.com/onsi/ginkgo/v2#AddReportEntry
+- **eco-goinfra Library:** https://github.com/rh-ecosystem-edge/eco-goinfra

--- a/tests/system-tests/rdscore/internal/rdscorecommon/resource-status-dump.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/resource-status-dump.go
@@ -1,0 +1,728 @@
+package rdscorecommon
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/golang/glog"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/deployment"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/statefulset"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/storage"
+
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/system-tests/rdscore/internal/rdscoreinittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/system-tests/rdscore/internal/rdscoreparams"
+)
+
+// DumpPodStatusOnFailure dumps comprehensive pod status information when a pod fails to become ready.
+// This function provides detailed debugging information including pod conditions, container statuses,
+// and scheduling information to help diagnose test failures.
+//
+// Parameters:
+//   - podBuilder: The pod.Builder object that failed to become ready
+//   - err: The error returned from WaitUntilReady (typically context.DeadlineExceeded)
+//
+// The function logs to glog and adds a Ginkgo ReportEntry that is only visible on test failure.
+//
+//nolint:gocognit,gocyclo,funlen
+func DumpPodStatusOnFailure(podBuilder *pod.Builder, err error) {
+	if err == nil || podBuilder == nil || podBuilder.Object == nil {
+		return
+	}
+
+	podName := podBuilder.Definition.Name
+	podNS := podBuilder.Definition.Namespace
+
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("========================================")
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Pod %q in namespace %q Failed to Become Ready", podName, podNS)
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("========================================")
+
+	// 1. Pod Phase
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Pod Phase: %s", podBuilder.Object.Status.Phase)
+
+	// 2. Pod Conditions (critical for understanding why pod is not ready)
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("")
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Pod Conditions:")
+
+	if len(podBuilder.Object.Status.Conditions) > 0 {
+		for _, cond := range podBuilder.Object.Status.Conditions {
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("  - Type: %s, Status: %s, Reason: %s",
+				cond.Type, cond.Status, cond.Reason)
+
+			if cond.Message != "" {
+				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("    Message: %s", cond.Message)
+			}
+		}
+	} else {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("  <none>")
+	}
+
+	// 3. Container Statuses
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("")
+
+	if len(podBuilder.Object.Status.ContainerStatuses) > 0 {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Container Statuses:")
+
+		for _, containerStatus := range podBuilder.Object.Status.ContainerStatuses {
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("  - Name: %s, Ready: %t, RestartCount: %d",
+				containerStatus.Name, containerStatus.Ready, containerStatus.RestartCount)
+
+			if containerStatus.State.Waiting != nil {
+				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("    State: Waiting")
+				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("    Reason: %s", containerStatus.State.Waiting.Reason)
+
+				if containerStatus.State.Waiting.Message != "" {
+					glog.V(rdscoreparams.RDSCoreLogLevel).Infof("    Message: %s", containerStatus.State.Waiting.Message)
+				}
+			}
+
+			if containerStatus.State.Terminated != nil {
+				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("    State: Terminated")
+				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("    Reason: %s, ExitCode: %d",
+					containerStatus.State.Terminated.Reason, containerStatus.State.Terminated.ExitCode)
+
+				if containerStatus.State.Terminated.Message != "" {
+					glog.V(rdscoreparams.RDSCoreLogLevel).Infof("    Message: %s", containerStatus.State.Terminated.Message)
+				}
+			}
+
+			if containerStatus.State.Running != nil {
+				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("    State: Running since %s",
+					containerStatus.State.Running.StartedAt.Format(time.RFC3339))
+			}
+		}
+	}
+
+	// 4. Init Container Statuses (often the cause of Pending state)
+	if len(podBuilder.Object.Status.InitContainerStatuses) > 0 {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("")
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Init Container Statuses:")
+
+		for _, ics := range podBuilder.Object.Status.InitContainerStatuses {
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("  - Name: %s, Ready: %t, RestartCount: %d",
+				ics.Name, ics.Ready, ics.RestartCount)
+
+			if ics.State.Waiting != nil {
+				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("    State: Waiting")
+				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("    Reason: %s", ics.State.Waiting.Reason)
+
+				if ics.State.Waiting.Message != "" {
+					glog.V(rdscoreparams.RDSCoreLogLevel).Infof("    Message: %s", ics.State.Waiting.Message)
+				}
+			}
+
+			if ics.State.Terminated != nil {
+				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("    State: Terminated")
+				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("    Reason: %s, ExitCode: %d",
+					ics.State.Terminated.Reason, ics.State.Terminated.ExitCode)
+			}
+		}
+	}
+
+	// 5. Scheduling Information
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("")
+
+	if podBuilder.Object.Spec.NodeName == "" {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Scheduling: Pod has not been scheduled to any node")
+
+		if podBuilder.Object.Status.NominatedNodeName != "" {
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("  Nominated Node: %s", podBuilder.Object.Status.NominatedNodeName)
+		}
+	} else {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Scheduled to Node: %s", podBuilder.Object.Spec.NodeName)
+	}
+
+	// 6. Owner References (to trace back to Deployment/StatefulSet/etc.)
+	if len(podBuilder.Object.OwnerReferences) > 0 {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("")
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Owner References:")
+
+		for _, owner := range podBuilder.Object.OwnerReferences {
+			// Safely handle nil Controller field
+			isController := false
+			if owner.Controller != nil {
+				isController = *owner.Controller
+			}
+
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("  - Kind: %s, Name: %s, Controller: %t",
+				owner.Kind, owner.Name, isController)
+		}
+	}
+
+	// 7. Resource Requirements (helpful for understanding scheduling failures)
+	if len(podBuilder.Object.Spec.Containers) > 0 {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("")
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Resource Requirements:")
+
+		for _, container := range podBuilder.Object.Spec.Containers {
+			if len(container.Resources.Requests) > 0 || len(container.Resources.Limits) > 0 {
+				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("  Container %s:", container.Name)
+
+				if len(container.Resources.Requests) > 0 {
+					glog.V(rdscoreparams.RDSCoreLogLevel).Infof("    Requests:")
+
+					for resourceName, quantity := range container.Resources.Requests {
+						glog.V(rdscoreparams.RDSCoreLogLevel).Infof("      %s: %s", resourceName, quantity.String())
+					}
+				}
+
+				if len(container.Resources.Limits) > 0 {
+					glog.V(rdscoreparams.RDSCoreLogLevel).Infof("    Limits:")
+
+					for resourceName, quantity := range container.Resources.Limits {
+						glog.V(rdscoreparams.RDSCoreLogLevel).Infof("      %s: %s", resourceName, quantity.String())
+					}
+				}
+			}
+		}
+	}
+
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("")
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("========================================")
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("End of Pod %q Status Dump", podName)
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("========================================")
+
+	// Add to Ginkgo report (only visible on failure or in verbose mode)
+	AddReportEntry(
+		fmt.Sprintf("Pod %s Failure Details", podName),
+		fmt.Sprintf("Pod %q in namespace %q failed with phase %s. Check logs above for detailed status.",
+			podName, podNS, podBuilder.Object.Status.Phase),
+		ReportEntryVisibilityFailureOrVerbose,
+	)
+}
+
+// DumpDeploymentStatus dumps comprehensive status information for all Deployments in a given namespace.
+// This function is useful for debugging test failures related to deployment readiness issues.
+//
+// Parameters:
+//   - ctx: The SpecContext for the current test (can be canceled)
+//   - namespace: The namespace to query for deployments
+//
+// The function creates a fresh context if the spec context is canceled and logs deployment details.
+//
+//nolint:funlen
+func DumpDeploymentStatus(ctx SpecContext, namespace string) {
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("========================================")
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Deployment Status Dump for Namespace: %s", namespace)
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("========================================")
+
+	// Check if the incoming context was already canceled
+	if ctx.Err() != nil {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+			"WARNING: SpecContext was already canceled (%v), using fresh context for dump", ctx.Err())
+	}
+
+	var deployments []*deployment.Builder
+
+	// Create a fresh context to ensure dump works even if spec context is canceled
+	dumpCtx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+
+	err := wait.PollUntilContextTimeout(dumpCtx, 15*time.Second, 1*time.Minute, true,
+		func(context.Context) (bool, error) {
+			var listErr error
+
+			deployments, listErr = deployment.List(APIClient, namespace)
+			if listErr != nil {
+				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to list deployments (retrying...): %v", listErr)
+
+				return false, nil
+			}
+
+			return true, nil
+		})
+	if err != nil {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to retrieve deployment list after retries: %v", err)
+
+		return
+	}
+
+	if len(deployments) == 0 {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("No deployments found in namespace %q", namespace)
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("========================================")
+
+		return
+	}
+
+	for _, deploy := range deployments {
+		if deploy.Object == nil {
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Skipping deployment with nil Object")
+
+			continue
+		}
+
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("")
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Deployment: %s", deploy.Object.Name)
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("----------------------------------------")
+
+		// Replica Status
+		desiredReplicas := int32(0)
+		if deploy.Object.Spec.Replicas != nil {
+			desiredReplicas = *deploy.Object.Spec.Replicas
+		}
+
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Replicas:")
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("  Desired: %d", desiredReplicas)
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("  Current: %d", deploy.Object.Status.Replicas)
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("  Ready: %d", deploy.Object.Status.ReadyReplicas)
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("  Available: %d", deploy.Object.Status.AvailableReplicas)
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("  Updated: %d", deploy.Object.Status.UpdatedReplicas)
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("  Unavailable: %d", deploy.Object.Status.UnavailableReplicas)
+
+		// Deployment Conditions
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("")
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Conditions:")
+
+		if len(deploy.Object.Status.Conditions) > 0 {
+			for _, cond := range deploy.Object.Status.Conditions {
+				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("  - Type: %s, Status: %s, Reason: %s",
+					cond.Type, cond.Status, cond.Reason)
+
+				if cond.Message != "" {
+					glog.V(rdscoreparams.RDSCoreLogLevel).Infof("    Message: %s", cond.Message)
+				}
+			}
+		} else {
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("  <none>")
+		}
+
+		// Strategy
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("")
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Strategy: %s", deploy.Object.Spec.Strategy.Type)
+
+		// Selector
+		if deploy.Object.Spec.Selector != nil && len(deploy.Object.Spec.Selector.MatchLabels) > 0 {
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("")
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Selector Labels:")
+
+			for key, value := range deploy.Object.Spec.Selector.MatchLabels {
+				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("  %s: %s", key, value)
+			}
+		}
+	}
+
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("")
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("========================================")
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("End of Deployment Status Dump for Namespace: %s", namespace)
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("========================================")
+}
+
+// DumpStatefulSetStatus dumps comprehensive status information for all StatefulSets in a given namespace.
+// This function is useful for debugging test failures related to statefulset readiness issues.
+//
+// Parameters:
+//   - ctx: The SpecContext for the current test (can be canceled)
+//   - namespace: The namespace to query for statefulsets
+//
+// The function creates a fresh context if the spec context is canceled and logs statefulset details.
+//
+//nolint:funlen
+func DumpStatefulSetStatus(ctx SpecContext, namespace string) {
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("========================================")
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("StatefulSet Status Dump for Namespace: %s", namespace)
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("========================================")
+
+	// Check if the incoming context was already canceled
+	if ctx.Err() != nil {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+			"WARNING: SpecContext was already canceled (%v), using fresh context for dump", ctx.Err())
+	}
+
+	var statefulsets []*statefulset.Builder
+
+	// Create a fresh context to ensure dump works even if spec context is canceled
+	dumpCtx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+
+	err := wait.PollUntilContextTimeout(dumpCtx, 15*time.Second, 1*time.Minute, true,
+		func(context.Context) (bool, error) {
+			var listErr error
+
+			statefulsets, listErr = statefulset.List(APIClient, namespace)
+			if listErr != nil {
+				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to list statefulsets (retrying...): %v", listErr)
+
+				return false, nil
+			}
+
+			return true, nil
+		})
+	if err != nil {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to retrieve statefulset list after retries: %v", err)
+
+		return
+	}
+
+	if len(statefulsets) == 0 {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("No statefulsets found in namespace %q", namespace)
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("========================================")
+
+		return
+	}
+
+	for _, sts := range statefulsets {
+		if sts.Object == nil {
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Skipping statefulset with nil Object")
+
+			continue
+		}
+
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("")
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("StatefulSet: %s", sts.Object.Name)
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("----------------------------------------")
+
+		// Replica Status
+		desiredReplicas := int32(0)
+		if sts.Object.Spec.Replicas != nil {
+			desiredReplicas = *sts.Object.Spec.Replicas
+		}
+
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Replicas:")
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("  Desired: %d", desiredReplicas)
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("  Current: %d", sts.Object.Status.Replicas)
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("  Ready: %d", sts.Object.Status.ReadyReplicas)
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("  Updated: %d", sts.Object.Status.UpdatedReplicas)
+
+		// StatefulSet-specific status
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("")
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Current Revision: %s", sts.Object.Status.CurrentRevision)
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Update Revision: %s", sts.Object.Status.UpdateRevision)
+
+		if sts.Object.Status.ObservedGeneration > 0 {
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Observed Generation: %d", sts.Object.Status.ObservedGeneration)
+		}
+
+		// StatefulSet Conditions
+		if len(sts.Object.Status.Conditions) > 0 {
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("")
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Conditions:")
+
+			for _, cond := range sts.Object.Status.Conditions {
+				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("  - Type: %s, Status: %s, Reason: %s",
+					cond.Type, cond.Status, cond.Reason)
+
+				if cond.Message != "" {
+					glog.V(rdscoreparams.RDSCoreLogLevel).Infof("    Message: %s", cond.Message)
+				}
+			}
+		}
+
+		// Update Strategy
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("")
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Update Strategy: %s", sts.Object.Spec.UpdateStrategy.Type)
+
+		// Service Name
+		if sts.Object.Spec.ServiceName != "" {
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Service Name: %s", sts.Object.Spec.ServiceName)
+		}
+
+		// Selector
+		if sts.Object.Spec.Selector != nil && len(sts.Object.Spec.Selector.MatchLabels) > 0 {
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("")
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Selector Labels:")
+
+			for key, value := range sts.Object.Spec.Selector.MatchLabels {
+				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("  %s: %s", key, value)
+			}
+		}
+	}
+
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("")
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("========================================")
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("End of StatefulSet Status Dump for Namespace: %s", namespace)
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("========================================")
+}
+
+// DumpPersistentVolumeStatus dumps comprehensive status information for all PersistentVolumes in the cluster.
+// This function is useful for debugging test failures related to storage provisioning and PVC binding issues.
+//
+// Parameters:
+//   - ctx: The SpecContext for the current test (can be canceled)
+//
+// The function creates a fresh context if the spec context is canceled and logs PV details.
+//
+//nolint:funlen
+func DumpPersistentVolumeStatus(ctx SpecContext) {
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("========================================")
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("PersistentVolume Status Dump (Cluster-wide)")
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("========================================")
+
+	// Check if the incoming context was already canceled
+	if ctx.Err() != nil {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+			"WARNING: SpecContext was already canceled (%v), using fresh context for dump", ctx.Err())
+	}
+
+	var pvs []*storage.PVBuilder
+
+	// Create a fresh context to ensure dump works even if spec context is canceled
+	dumpCtx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+
+	err := wait.PollUntilContextTimeout(dumpCtx, 15*time.Second, 1*time.Minute, true,
+		func(context.Context) (bool, error) {
+			var listErr error
+
+			pvs, listErr = storage.ListPV(APIClient)
+			if listErr != nil {
+				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to list PersistentVolumes (retrying...): %v", listErr)
+
+				return false, nil
+			}
+
+			return true, nil
+		})
+	if err != nil {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to retrieve PersistentVolume list after retries: %v", err)
+
+		return
+	}
+
+	if len(pvs) == 0 {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("No PersistentVolumes found in cluster")
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("========================================")
+
+		return
+	}
+
+	for _, persistentVolume := range pvs {
+		if persistentVolume.Object == nil {
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Skipping PersistentVolume with nil Object")
+
+			continue
+		}
+
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("")
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("PersistentVolume: %s", persistentVolume.Object.Name)
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("----------------------------------------")
+
+		// Phase and basic info
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Phase: %s", persistentVolume.Object.Status.Phase)
+
+		// Capacity
+		if capacity, ok := persistentVolume.Object.Spec.Capacity["storage"]; ok {
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Capacity: %s", capacity.String())
+		}
+
+		// Access Modes
+		if len(persistentVolume.Object.Spec.AccessModes) > 0 {
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Access Modes:")
+
+			for _, mode := range persistentVolume.Object.Spec.AccessModes {
+				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("  - %s", mode)
+			}
+		}
+
+		// Reclaim Policy
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Reclaim Policy: %s",
+			persistentVolume.Object.Spec.PersistentVolumeReclaimPolicy)
+
+		// Storage Class
+		if persistentVolume.Object.Spec.StorageClassName != "" {
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Storage Class: %s", persistentVolume.Object.Spec.StorageClassName)
+		}
+
+		// Volume Mode
+		if persistentVolume.Object.Spec.VolumeMode != nil {
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Volume Mode: %s", *persistentVolume.Object.Spec.VolumeMode)
+		}
+
+		// Claim Reference (which PVC is bound)
+		if persistentVolume.Object.Spec.ClaimRef != nil {
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Claim Reference:")
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("  Namespace: %s", persistentVolume.Object.Spec.ClaimRef.Namespace)
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("  Name: %s", persistentVolume.Object.Spec.ClaimRef.Name)
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("  UID: %s", persistentVolume.Object.Spec.ClaimRef.UID)
+		} else {
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Claim Reference: <none> (unbound)")
+		}
+
+		// Node Affinity (important for local volumes)
+		if persistentVolume.Object.Spec.NodeAffinity != nil && persistentVolume.Object.Spec.NodeAffinity.Required != nil {
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("")
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Node Affinity:")
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("  Required NodeSelectorTerms: %d",
+				len(persistentVolume.Object.Spec.NodeAffinity.Required.NodeSelectorTerms))
+		}
+
+		// Volume Source Type (helps understand backend)
+		volumeSource := "Unknown"
+
+		switch {
+		case persistentVolume.Object.Spec.HostPath != nil:
+			volumeSource = "HostPath"
+		case persistentVolume.Object.Spec.NFS != nil:
+			volumeSource = "NFS"
+		case persistentVolume.Object.Spec.ISCSI != nil:
+			volumeSource = "iSCSI"
+		case persistentVolume.Object.Spec.RBD != nil:
+			volumeSource = "RBD (Ceph)"
+		case persistentVolume.Object.Spec.CephFS != nil:
+			volumeSource = "CephFS"
+		case persistentVolume.Object.Spec.CSI != nil:
+			volumeSource = fmt.Sprintf("CSI (%s)", persistentVolume.Object.Spec.CSI.Driver)
+		case persistentVolume.Object.Spec.Local != nil:
+			volumeSource = "Local"
+		}
+
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("")
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Volume Source: %s", volumeSource)
+	}
+
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("")
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("========================================")
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("End of PersistentVolume Status Dump")
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("========================================")
+}
+
+// DumpPersistentVolumeClaimStatus dumps comprehensive status information for all PersistentVolumeClaims in a namespace.
+// This function is useful for debugging test failures related to PVC binding and provisioning issues.
+//
+// Parameters:
+//   - ctx: The SpecContext for the current test (can be canceled)
+//   - namespace: The namespace to query for PVCs
+//
+// The function creates a fresh context if the spec context is canceled and logs PVC details.
+//
+//nolint:funlen,gocognit
+func DumpPersistentVolumeClaimStatus(ctx SpecContext, namespace string) {
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("========================================")
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("PersistentVolumeClaim Status Dump for Namespace: %s", namespace)
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("========================================")
+
+	// Check if the incoming context was already canceled
+	if ctx.Err() != nil {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+			"WARNING: SpecContext was already canceled (%v), using fresh context for dump", ctx.Err())
+	}
+
+	var pvcs []*storage.PVCBuilder
+
+	// Create a fresh context to ensure dump works even if spec context is canceled
+	dumpCtx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+
+	err := wait.PollUntilContextTimeout(dumpCtx, 15*time.Second, 1*time.Minute, true,
+		func(context.Context) (bool, error) {
+			var listErr error
+
+			pvcs, listErr = storage.ListPVC(APIClient, namespace)
+			if listErr != nil {
+				glog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+					"Failed to list PersistentVolumeClaims in namespace %q (retrying...): %v", namespace, listErr)
+
+				return false, nil
+			}
+
+			return true, nil
+		})
+	if err != nil {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+			"Failed to retrieve PersistentVolumeClaim list for namespace %q after retries: %v", namespace, err)
+
+		return
+	}
+
+	if len(pvcs) == 0 {
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("No PersistentVolumeClaims found in namespace %q", namespace)
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("========================================")
+
+		return
+	}
+
+	for _, pvc := range pvcs {
+		if pvc.Object == nil {
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Skipping PersistentVolumeClaim with nil Object")
+
+			continue
+		}
+
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("")
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("PersistentVolumeClaim: %s", pvc.Object.Name)
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("----------------------------------------")
+
+		// Phase
+		glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Phase: %s", pvc.Object.Status.Phase)
+
+		// Access Modes
+		if len(pvc.Object.Spec.AccessModes) > 0 {
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Access Modes:")
+
+			for _, mode := range pvc.Object.Spec.AccessModes {
+				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("  - %s", mode)
+			}
+		}
+
+		// Requested Storage
+		if storage, ok := pvc.Object.Spec.Resources.Requests["storage"]; ok {
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Requested Storage: %s", storage.String())
+		}
+
+		// Allocated Storage (actual)
+		if storage, ok := pvc.Object.Status.Capacity["storage"]; ok {
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Allocated Storage: %s", storage.String())
+		}
+
+		// Storage Class
+		if pvc.Object.Spec.StorageClassName != nil && *pvc.Object.Spec.StorageClassName != "" {
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Storage Class: %s", *pvc.Object.Spec.StorageClassName)
+		} else {
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Storage Class: <default>")
+		}
+
+		// Volume Mode
+		if pvc.Object.Spec.VolumeMode != nil {
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Volume Mode: %s", *pvc.Object.Spec.VolumeMode)
+		}
+
+		// Volume Name (bound PV)
+		if pvc.Object.Spec.VolumeName != "" {
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Volume Name: %s", pvc.Object.Spec.VolumeName)
+		} else {
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Volume Name: <none> (not bound)")
+		}
+
+		// PVC Conditions
+		if len(pvc.Object.Status.Conditions) > 0 {
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("")
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Conditions:")
+
+			for _, cond := range pvc.Object.Status.Conditions {
+				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("  - Type: %s, Status: %s, Reason: %s",
+					cond.Type, cond.Status, cond.Reason)
+
+				if cond.Message != "" {
+					glog.V(rdscoreparams.RDSCoreLogLevel).Infof("    Message: %s", cond.Message)
+				}
+
+				if !cond.LastTransitionTime.IsZero() {
+					glog.V(rdscoreparams.RDSCoreLogLevel).Infof("    Last Transition: %s",
+						cond.LastTransitionTime.Format(time.RFC3339))
+				}
+			}
+		}
+
+		// Selector (if present)
+		if pvc.Object.Spec.Selector != nil {
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("")
+			glog.V(rdscoreparams.RDSCoreLogLevel).Infof("Selector:")
+
+			if len(pvc.Object.Spec.Selector.MatchLabels) > 0 {
+				glog.V(rdscoreparams.RDSCoreLogLevel).Infof("  Match Labels:")
+
+				for key, value := range pvc.Object.Spec.Selector.MatchLabels {
+					glog.V(rdscoreparams.RDSCoreLogLevel).Infof("    %s: %s", key, value)
+				}
+			}
+		}
+	}
+
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("")
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("========================================")
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("End of PersistentVolumeClaim Status Dump for Namespace: %s", namespace)
+	glog.V(rdscoreparams.RDSCoreLogLevel).Infof("========================================")
+}

--- a/tests/system-tests/rdscore/internal/rdscoreparams/rdscorevars.go
+++ b/tests/system-tests/rdscore/internal/rdscoreparams/rdscorevars.go
@@ -2,6 +2,7 @@ package rdscoreparams
 
 import (
 	"github.com/openshift-kni/k8sreporter"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -10,13 +11,66 @@ var (
 	Labels = []string{Label}
 
 	// ReporterNamespacesToDump tells to the reporter from where to collect logs.
+	// Updated to include all RDS Core test namespaces instead of demo namespaces.
 	ReporterNamespacesToDump = map[string]string{
-		"demo-ns-one": "demo-ns-one",
-		"demo-ns-two": "demo-ns-two",
+		// SR-IOV workload namespaces
+		"rds-sriov-wlkd": "rds-sriov-wlkd",
+
+		// Storage (ODF/Ceph) test namespaces
+		"rds-cephfs-ns":        "rds-cephfs-ns",
+		"rds-cephrbd-ns":       "rds-cephrbd-ns",
+		"rds-cephrbd-block-ns": "rds-cephrbd-block-ns",
+
+		// Whereabouts IP management namespaces
+		"rds-whereabouts": "rds-whereabouts",
+
+		// MACVLAN test namespaces
+		"rds-macvlan": "rds-macvlan",
+
+		// IPVLAN test namespaces
+		"rds-ipvlan": "rds-ipvlan",
+
+		// EgressIP test namespaces
+		"rds-egressip-ns-one": "rds-egressip-ns-one",
+		"rds-egressip-ns-two": "rds-egressip-ns-two",
+
+		// Egress Service test namespace
+		"rds-egress-ns": "rds-egress-ns",
+
+		// MetalLB and FRR test namespaces
+		"rds-metallb-supporttools-ns": "rds-metallb-supporttools-ns",
+		"openshift-frr-k8s":           "openshift-frr-k8s",
+
+		// NROP (NUMA Resources Operator) test namespaces
+		"rds-nrop": "rds-nrop",
+
+		// Pod-level bonding test namespace
+		"rds-pod-level-bond": "rds-pod-level-bond",
+
+		// Rootless DPDK test namespace
+		"rds-dpdk": "rds-dpdk",
+
+		// OpenShift system namespaces (for cluster-wide resources)
+		"openshift-multus":     "openshift-multus",
+		"openshift-monitoring": "openshift-monitoring",
+		"openshift-storage":    "openshift-storage",
 	}
 
 	// ReporterCRDsToDump tells to the reporter what CRs to dump.
+	// Enhanced to include Deployments, StatefulSets, ReplicaSets, Events, and storage resources
+	// for better failure debugging.
 	ReporterCRDsToDump = []k8sreporter.CRData{
+		// Core workload resources
 		{Cr: &corev1.PodList{}},
+		{Cr: &appsv1.DeploymentList{}},
+		{Cr: &appsv1.StatefulSetList{}},
+		{Cr: &appsv1.ReplicaSetList{}},
+
+		// Events are critical for understanding scheduling failures and other issues
+		{Cr: &corev1.EventList{}},
+
+		// Storage resources for debugging PVC binding and provisioning issues
+		{Cr: &corev1.PersistentVolumeList{}},
+		{Cr: &corev1.PersistentVolumeClaimList{}},
 	}
 )


### PR DESCRIPTION
Add comprehensive resource status dumping for better debugging of test failures, particularly pod scheduling, readiness, and storage issues.

- Update ReporterNamespacesToDump with actual RDS Core namespaces
- Add openshift-monitoring and openshift-storage namespaces
- Add Deployments, StatefulSets, ReplicaSets, and Events to dumps
- Add PersistentVolumes and PersistentVolumeClaims to dumps
- Add DumpPodStatusOnFailure() for detailed pod status logging
- Add DumpDeploymentStatus() for deployment status inspection
- Add DumpStatefulSetStatus() for statefulset status inspection
- Add DumpPersistentVolumeStatus() for cluster-wide PV diagnostics
- Add DumpPersistentVolumeClaimStatus() for namespace PVC diagnostics
- Add documentation in ENHANCED_FAILURE_REPORTING.md