### PR TITLE
system-tests: extend ptp sync time interval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,10 +26,4 @@ reports
 
 tests/hw-accel/nfd/**/*.md
 tests/hw-accel/nfd/*.md
-
-# Claude
-.claude/settings.local.json
 CLAUDE.local.md
-
-# Local configuration
-.env

--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,10 @@ reports
 
 tests/hw-accel/nfd/**/*.md
 tests/hw-accel/nfd/*.md
+
+# Claude
+.claude/settings.local.json
 CLAUDE.local.md
+
+# Local configuration
+.env

--- a/tests/system-tests/ran-du/tests/hard-reboot.go
+++ b/tests/system-tests/ran-du/tests/hard-reboot.go
@@ -154,10 +154,10 @@ var _ = Describe(
 					}
 
 					if RanDuTestConfig.PtpEnabled {
-						timeInterval := 3 * time.Minute
+						timeInterval := 6 * time.Minute
 						time.Sleep(timeInterval)
 
-						By("Check PTP status for the last 3 minutes")
+						By("Check PTP status for the last 6 minutes")
 
 						ptpOnSync, err := ptp.ValidatePTPStatus(APIClient, timeInterval)
 						Expect(err).ToNot(HaveOccurred(), "PTP Error: %s", err)

--- a/tests/system-tests/ran-du/tests/launch-workload-multiple-iter-loadavg.go
+++ b/tests/system-tests/ran-du/tests/launch-workload-multiple-iter-loadavg.go
@@ -61,10 +61,10 @@ var _ = Describe(
 				Expect(err).ToNot(HaveOccurred(), "pod not ready: %s", err)
 
 				if RanDuTestConfig.PtpEnabled {
-					timeInterval := 3 * time.Minute
+					timeInterval := 6 * time.Minute
 					time.Sleep(timeInterval)
 
-					By("Check PTP status for the last 3 minutes after workload deployment")
+					By("Check PTP status for the last 6 minutes after workload deployment")
 
 					ptpOnSync, err := ptp.ValidatePTPStatus(APIClient, timeInterval)
 					Expect(err).ToNot(HaveOccurred(), "PTP Error: %s", err)

--- a/tests/system-tests/ran-du/tests/launch-workload.go
+++ b/tests/system-tests/ran-du/tests/launch-workload.go
@@ -53,10 +53,10 @@ var _ = Describe(
 			Expect(err).ToNot(HaveOccurred(), "pod not ready: %s", err)
 
 			if RanDuTestConfig.PtpEnabled {
-				timeInterval := 3 * time.Minute
+				timeInterval := 6 * time.Minute
 				time.Sleep(timeInterval)
 
-				By("Check PTP status for the last 3 minutes after workload deployment")
+				By("Check PTP status for the last 6 minutes after workload deployment")
 
 				ptpOnSync, err := ptp.ValidatePTPStatus(APIClient, timeInterval)
 				Expect(err).ToNot(HaveOccurred(), "PTP Error: %s", err)

--- a/tests/system-tests/ran-du/tests/soft-reboot.go
+++ b/tests/system-tests/ran-du/tests/soft-reboot.go
@@ -165,10 +165,10 @@ var _ = Describe(
 					}
 
 					if RanDuTestConfig.PtpEnabled {
-						timeInterval := 3 * time.Minute
+						timeInterval := 6 * time.Minute
 						time.Sleep(timeInterval)
 
-						By("Check PTP status for the last 3 minutes")
+						By("Check PTP status for the last 6 minutes")
 
 						ptpOnSync, err := ptp.ValidatePTPStatus(APIClient, timeInterval)
 						Expect(err).ToNot(HaveOccurred(), "PTP Error: %s", err)


### PR DESCRIPTION
This PR extends the time interval to check if the host is synced to 6 minutes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended PTP (Precision Time Protocol) validation wait times and synchronization check windows from 3 minutes to 6 minutes in system test scenarios. This affects tests for reboot operations and workload deployment validation procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->