### PR TITLE
system-tests: fix NROP pod cleanup timeout in BeforeAll hook

### DIFF
--- a/tests/system-tests/rdscore/internal/rdscorecommon/nrop-validation.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/nrop-validation.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/deployment"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/system-tests/internal/apiobjectshelper"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -108,18 +108,18 @@ func VerifyNROPWorkload(ctx SpecContext) {
 
 	deleteDeployments(nropDeploy1Name, RDSCoreConfig.WlkdNROPOneNS)
 
-	By(fmt.Sprintf("Ensuring pods from %q deployment are gone", sriovDeploy1OneName))
+	By(fmt.Sprintf("Ensuring pods from %q deployment are gone", nropDeploy1Name))
 
 	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Ensuring pods from %q deployment in %q namespace are gone",
 		nropDeploy1Name, RDSCoreConfig.WlkdNROPOneNS)
 
-	Eventually(func() bool {
-		oldPods, _ := pod.List(APIClient, RDSCoreConfig.WlkdNROPOneNS,
-			metav1.ListOptions{LabelSelector: nropDeployOneLabel})
-
-		return len(oldPods) == 0
-	}).WithContext(ctx).WithPolling(3*time.Second).WithTimeout(1*time.Minute).Should(
-		BeTrue(), "pods matching label() still present")
+	err := apiobjectshelper.EnsureAllPodsRemoved(
+		APIClient,
+		RDSCoreConfig.WlkdNROPOneNS,
+		nropDeployOneLabel)
+	Expect(err).ToNot(HaveOccurred(),
+		fmt.Sprintf("Failed to ensure pods from %q deployment are removed from %q namespace",
+			nropDeploy1Name, RDSCoreConfig.WlkdNROPOneNS))
 
 	By("Defining container configuration")
 


### PR DESCRIPTION
BeforeAll hook "Setups EgressService with Cluster ExternalTrafficPolicy" was failing in job 5691 due to 60-second timeout waiting for NROP deployment pods to terminate. NROP pods (NUMA-pinned, CPU-isolated) require longer cleanup time.

Changes:
- Replace Eventually() block with apiobjectshelper.EnsureAllPodsRemoved() to increase timeout from 60 seconds to 6 minutes
- Fix copy-paste error: sriovDeploy1OneName → nropDeploy1Name in log message
- Add apiobjectshelper import for EnsureAllPodsRemoved() function
- Remove unused metav1 import

The fix ensures NROP pod cleanup has adequate time to complete, preventing BeforeAll failure that blocks the entire "Graceful Cluster Reboot" suite. When the enhanced EnsureAllPodsRemoved() is merged to main, NROP cleanup will automatically gain diagnostic logging and force deletion capabilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored pod cleanup verification in deployment tests using helper utilities to improve code maintainability and reduce inline polling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->