### PR TITLE
cnf network: fix QinQ tcpdump capture by enabling line-buffered output

### DIFF
--- a/tests/cnf/core/network/sriov/tests/qinq.go
+++ b/tests/cnf/core/network/sriov/tests/qinq.go
@@ -78,8 +78,8 @@ var _ = Describe(
 				"-port 4444 -listen & testcmd -interface net3 -protocol tcp -port 4444 -listen"}
 			testCmdBond0 = []string{"bash", "-c", "sleep 5; testcmd -interface bond0.100 -protocol tcp " +
 				"-port 4444 -listen"}
-			tcpDumpNet1CMD              = []string{"bash", "-c", "tcpdump -i net1 -e > /tmp/tcpdump"}
-			tcpDumpReadFileCMD          = []string{"bash", "-c", "tail -20 /tmp/tcpdump"}
+			tcpDumpNet1CMD              = []string{"bash", "-c", "tcpdump -l -i net1 -e > /tmp/tcpdump"}
+			tcpDumpReadFileCMD          = []string{"bash", "-c", "tail -100 /tmp/tcpdump"}
 			tcpDumpDot1ADOutput         = "(ethertype 802\\.1Q-QinQ \\(0x88a8\\)).*?(ethertype 802\\.1Q.*?vlan 100)"
 			tcpDumpDot1QOutput          = "(ethertype 802\\.1Q \\(0x8100\\)).*?(ethertype 802\\.1Q.*?vlan 100)"
 			tcpDumpDot1QDPDKOutput      = "(ethertype 802\\.1Q \\(0x8100\\)).*?(ethertype 802\\.1Q \\(0x8100\\), vlan 100)"
@@ -1052,7 +1052,7 @@ func defineAndCreateClientDPDKPod(
 			Add: []corev1.Capability{"IPC_LOCK", "SYS_RESOURCE", "NET_RAW", "NET_ADMIN"},
 		},
 	}
-	testCommand := []string{"bash", "-c", "tcpdump -i net2 -e > /tmp/tcpdump"}
+	testCommand := []string{"bash", "-c", "tcpdump -l -i net2 -e > /tmp/tcpdump"}
 
 	dpdkContainerCfg, err := pod.NewContainerBuilder(podName, NetConfig.DpdkTestContainer,
 		[]string{"/bin/bash", "-c", "sleep INF"}).WithSecurityContext(&securityContext).


### PR DESCRIPTION
Without the -l flag, tcpdump uses full buffering when stdout is redirected to a file, causing the capture file to appear empty when read by tail. Also increase tail line count from 20 to 100 to ensure QinQ frames are visible even when broadcast traffic is present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced QinQ traffic test capture with improved line-buffering and expanded data collection for standard and DPDK test clients, increasing test reliability and observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->