### PR TITLE
system-tests: increase DPDK pod readiness timeout for post-reboot resilience

### DIFF
--- a/tests/system-tests/rdscore/internal/rdscorecommon/sriov-rootless-dpdk.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/sriov-rootless-dpdk.go
@@ -402,7 +402,7 @@ func retrieveClientDPDKPod(apiClient *clients.Settings, podNamePattern, podNames
 			podNamePattern, podNamespace, err)
 	}
 
-	err = podObj.WaitUntilReady(time.Second * 30)
+	err = podObj.WaitUntilReady(150 * time.Second)
 	if err != nil {
 		klog.V(100).Infof("The rootless DPDK client pod %s in namespace %s is not in Ready condition: %v",
 			podNamePattern, podNamespace, err)


### PR DESCRIPTION
Post reboot DPDK test failed with API server timeout when checking pod readiness after graceful cluster reboot.

Root cause: retrieveClientDPDKPod() used 30-second timeout, which was too short for eco-goinfra's API retry logic (120s per-request timeout) to handle transient API server slowdowns during post-reboot recovery.

Changes:
- Increase WaitUntilReady timeout from 30s to 150s in retrieveClientDPDKPod()
- Allows eco-goinfra retry logic (commit 08ec2cb5) to work properly
- Improves resilience for all 12 DPDK rootless tests across 3 test suites
- No impact on successful tests (pods ready quickly complete at same speed)
- Only affects failure detection time for tests that would fail anyway

The 150-second timeout provides sufficient buffer for API server recovery in post-reboot scenarios while remaining conservative compared to other SRIOV validation tests that use 3-minute timeouts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased timeout for rootless DPDK pod readiness verification to enhance system test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->