### PR TITLE
cnf ran ptp: fix iface aliases in older versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,13 +50,17 @@ run-internal-pkg-unit-tests:
 	@echo "Executing eco-gotests internal package unit tests"
 	UNIT_TEST=true go test -v ./tests/internal/...
 
+run-ran-pkg-unit-tests:
+	@echo "Executing eco-gotests RAN package unit tests"
+	UNIT_TEST=true go test -tags=unit_test -v ./tests/cnf/ran/ptp/internal/iface
+
 run-system-tests-pkg-unit-tests:
 	@echo "Executing eco-gotests internal package unit tests"
 	UNIT_TEST=true go test -v ./tests/system-tests/diskencryption/internal/helper
 	UNIT_TEST=true go test -v ./tests/system-tests/diskencryption/internal/stdin-matcher
 
 # Note: To add more unit tests for more packages, add corresponding targets here
-test: run-internal-pkg-unit-tests run-system-tests-pkg-unit-tests
-	
+test: run-internal-pkg-unit-tests run-system-tests-pkg-unit-tests run-ran-pkg-unit-tests
+
 coverage-html: test
 	go tool cover -html cover.out

--- a/tests/cnf/ran/ptp/internal/iface/iface.go
+++ b/tests/cnf/ran/ptp/internal/iface/iface.go
@@ -7,9 +7,27 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/version"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/tsparams"
 	"k8s.io/klog/v2"
 )
+
+// useLegacyNICNaming is a flag that indicates whether to use the legacy NIC naming system. It is set to true if the PTP
+// version is 4.19- and false otherwise.
+var useLegacyNICNaming bool
+
+// InitNICNaming initializes the NIC naming system. It checks the PTP version and uses the legacy NIC naming system for
+// 4.19- and the modern NIC naming system for 4.20+. It returns an error if the version could not be compared.
+func InitNICNaming(ptpVersion string) error {
+	atLeast420, err := version.IsVersionStringInRange(ptpVersion, "4.20.0-0", "")
+	if err != nil {
+		return fmt.Errorf("failed to check if PTP version is at least 4.20: %w", err)
+	}
+
+	useLegacyNICNaming = !atLeast420
+
+	return nil
+}
 
 // nicNameRegexp is a regular expression that matches the name of a network interface. It is used for generating the NIC
 // name from the interface name. It comes from the upstream cloud-event-proxy package.
@@ -21,13 +39,13 @@ var nicNameRegexp = regexp.MustCompile(`^(.+?)(\d+)(?:np\d+)?(\..+)?$`)
 // canonical way to manipulate interface names in this test suite. The zero value is never valid.
 type Name string
 
-// GetNIC returns the NIC name associated with the interface. It follows the same system as the upstream
-// cloud-event-proxy package when determining the NIC name. See the upstream function at
-// https://github.com/redhat-cne/cloud-event-proxy/blob/ca4ced05bcc35e3cfccee41059528a0f315d6c3c/
-// plugins/ptp_operator/utils/utils.go#L23.
+// GetNIC returns the NIC name alias associated with the interface. It defaults to the modern NIC naming system, but
+// will use the legacy system if [InitNICNaming] has been called with a PTP version of 4.19 or earlier.
 //
 // Since this method is an identity operation for NIC names, it will return the special NIC names [ClockRealtime] and
-// [Master] unchanged.
+// [Master] unchanged, regardless of the naming system used.
+//
+// Interface names shorter than 2 characters are considered invalid and will return the zero value.
 func (iface Name) GetNIC() NICName {
 	if len(iface) < 2 {
 		klog.V(tsparams.LogLevel).Infof("Failed to get NIC name for interface %q: interface name is too short", iface)
@@ -39,6 +57,20 @@ func (iface Name) GetNIC() NICName {
 		return NICName(iface)
 	}
 
+	if useLegacyNICNaming {
+		return iface.getNICLegacy()
+	}
+
+	return iface.getNICModern()
+}
+
+// getNICModern returns the NIC name associated with the interface. It follows the same system as the upstream
+// cloud-event-proxy package when determining the NIC name. See the upstream function at
+// https://github.com/redhat-cne/cloud-event-proxy/blob/ca4ced05bcc35e3cfccee41059528a0f315d6c3c/
+// plugins/ptp_operator/utils/utils.go#L23.
+//
+// This method assumes that the interface name is longer than 2 characters and not one of the special NIC names.
+func (iface Name) getNICModern() NICName {
 	matches := nicNameRegexp.FindStringSubmatch(string(iface))
 
 	// Even if there is no VLAN part, the matches slice will just have an empty string for the VLAN part, not have
@@ -54,6 +86,24 @@ func (iface Name) GetNIC() NICName {
 		"Failed to get NIC name for interface %q: interface name does not match known format", iface)
 
 	return ""
+}
+
+// getNICLegacy returns the NIC name for the interface using the legacy NIC naming system. It is applicable to PTP
+// operator versions 4.19 and earlier.
+//
+// The logic is to simply replace the last digit in the interface name with an 'x'. If the interface name has a VLAN,
+// the VLAN is preserved.
+//
+// This method assumes that the interface name is longer than 2 characters and not one of the special NIC names.
+func (iface Name) getNICLegacy() NICName {
+	withoutVLAN, vlan, hasVLAN := strings.Cut(string(iface), ".")
+	withoutVLAN = withoutVLAN[:len(withoutVLAN)-1] + "x"
+
+	if hasVLAN {
+		return NICName(fmt.Sprintf("%s.%s", withoutVLAN, vlan))
+	}
+
+	return NICName(withoutVLAN)
 }
 
 // NICName represents a network interface name. It can be derived from [Name] using the [GetNIC] method. The zero value

--- a/tests/cnf/ran/ptp/internal/iface/iface_test.go
+++ b/tests/cnf/ran/ptp/internal/iface/iface_test.go
@@ -1,0 +1,158 @@
+//go:build unit_test
+
+package iface
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitNICNaming(t *testing.T) {
+	testCases := []struct {
+		name       string
+		ptpVersion string
+		wantLegacy bool
+	}{
+		{
+			name:       "PTP 4.19 uses legacy naming",
+			ptpVersion: "4.19.0",
+			wantLegacy: true,
+		},
+		{
+			name:       "PTP 4.20 uses modern naming",
+			ptpVersion: "4.20.0",
+			wantLegacy: false,
+		},
+		{
+			name:       "PTP 4.20 pre-release uses modern naming",
+			ptpVersion: "4.20.0-20251212.151256",
+			wantLegacy: false,
+		},
+		{
+			name:       "unparsable version uses modern naming by default",
+			ptpVersion: "not-a-version",
+			wantLegacy: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := InitNICNaming(testCase.ptpVersion)
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.wantLegacy, useLegacyNICNaming)
+		})
+	}
+}
+
+//nolint:funlen // long due to number of test cases
+func TestNameGetNIC(t *testing.T) {
+	testCases := []struct {
+		name       string
+		ptpVersion string
+		iface      Name
+		wantNIC    NICName
+	}{
+		// Modern naming (PTP >= 4.20)
+		{
+			name:       "modern replaces trailing digit sequence",
+			ptpVersion: "4.20.0",
+			iface:      "eth1",
+			wantNIC:    "ethx",
+		},
+		{
+			name:       "modern handles SR-IOV interface",
+			ptpVersion: "4.20.0",
+			iface:      "ens2f0",
+			wantNIC:    "ens2fx",
+		},
+		{
+			name:       "modern strips np suffix before deriving NIC",
+			ptpVersion: "4.20.0",
+			iface:      "eth0np0",
+			wantNIC:    "ethx",
+		},
+		{
+			name:       "modern handles VF with np suffix",
+			ptpVersion: "4.20.0",
+			iface:      "ens2f0np0",
+			wantNIC:    "ens2fx",
+		},
+		{
+			name:       "modern preserves VLAN",
+			ptpVersion: "4.20.0",
+			iface:      "ens2f0.100",
+			wantNIC:    "ens2fx.100",
+		},
+		{
+			name:       "modern handles PCI-style interface name",
+			ptpVersion: "4.20.0",
+			iface:      "enp0s2f0",
+			wantNIC:    "enp0s2fx",
+		},
+		// Legacy naming (PTP <= 4.19)
+		{
+			name:       "legacy replaces last character including np suffix",
+			ptpVersion: "4.19.0",
+			iface:      "eth0np0",
+			wantNIC:    "eth0npx",
+		},
+		{
+			name:       "legacy handles SR-IOV interface",
+			ptpVersion: "4.19.0",
+			iface:      "ens2f0",
+			wantNIC:    "ens2fx",
+		},
+		{
+			name:       "legacy handles VF with np suffix differently from modern",
+			ptpVersion: "4.19.0",
+			iface:      "ens2f0np0",
+			wantNIC:    "ens2f0npx",
+		},
+		{
+			name:       "legacy preserves VLAN",
+			ptpVersion: "4.19.0",
+			iface:      "ens2f0.100",
+			wantNIC:    "ens2fx.100",
+		},
+		// Special and invalid names (naming system independent)
+		{
+			name:       "clock realtime is unchanged",
+			ptpVersion: "4.19.0",
+			iface:      "CLOCK_REALTIME",
+			wantNIC:    ClockRealtime,
+		},
+		{
+			name:       "master is unchanged",
+			ptpVersion: "4.20.0",
+			iface:      "master",
+			wantNIC:    Master,
+		},
+		{
+			name:       "single character interface is invalid",
+			ptpVersion: "4.19.0",
+			iface:      "a",
+			wantNIC:    "",
+		},
+		{
+			name:       "empty interface is invalid",
+			ptpVersion: "4.19.0",
+			iface:      "",
+			wantNIC:    "",
+		},
+		{
+			name:       "unrecognized format is invalid",
+			ptpVersion: "4.20.0",
+			iface:      "invalid",
+			wantNIC:    "",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := InitNICNaming(testCase.ptpVersion)
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.wantNIC, testCase.iface.GetNIC())
+		})
+	}
+}

--- a/tests/cnf/ran/ptp/ptp_suite_test.go
+++ b/tests/cnf/ran/ptp/ptp_suite_test.go
@@ -15,7 +15,9 @@ import (
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/querier"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/rancluster"
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/raninittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/ranparam"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/consumer"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/iface"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/metrics"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/mustgather"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/ptp/internal/tsparams"
@@ -53,6 +55,11 @@ var _ = BeforeSuite(func() {
 
 	err = metrics.EnsureClocksAreLocked(prometheusAPI)
 	Expect(err).ToNot(HaveOccurred(), "Failed to assert clock state is locked")
+
+	By("initializing the NIC naming system based on the PTP version")
+
+	err = iface.InitNICNaming(RANConfig.Spoke1OperatorVersions[ranparam.PTP])
+	Expect(err).ToNot(HaveOccurred(), "Failed to initialize NIC naming system based on the PTP version")
 
 	By("updating the PTP ServiceMonitor scrape interval to 1s")
 


### PR DESCRIPTION
This commit adds a mechanism to switch between the two naming systems
for interface aliases based on the PTP version. 4.19- uses a simpler
system and 4.20+ uses the more complex but more accurate system. A
future improvement would use the port-aliases endpoint from the
linuxptp-daemon instead of duplicating the daemon's logic.

Since the iface package does not have direct access to the version, it
defaults to the modern system then provides a function to potentially
change that based on version. This function is called in BeforeSuite,
where we have access to the PTP operator version.

Additionally, unit tests are added to cover the behavior of the changes.

Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added version-dependent NIC naming initialization (legacy vs modern) driven by the configured PTP version and applied during PTP test suite setup.
* **Tests**
  * Added unit tests to verify NIC naming transformations across modern/legacy version cases, VLAN handling, interface naming patterns, and invalid input behavior.
* **Chores**
  * Extended the automated test workflow to run the additional RAN unit tests and include them in the main unit test target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->