### PR TITLE
tests/ocp/sriov: fix reconcile race and ICMP check in metricsExporter

### DIFF
--- a/tests/ocp/sriov/tests/metricsExporter.go
+++ b/tests/ocp/sriov/tests/metricsExporter.go
@@ -304,9 +304,21 @@ func runMetricsNettoVfioTests(clientPf, serverPf, clientWorker, serverWorker, de
 		"Failed to add server mac address in client pod mac table. Output: %s", outputbuf.String()))
 
 	By("ICMP check between client and server pods")
-	Eventually(func() error {
-		return sriovocpenv.ICMPConnectivityCheck(cPod, []string{tsparams.ServerIPv4IPAddress}, "net1")
-	}, 1*time.Minute, 2*time.Second).Should(HaveOccurred(), "ICMP fail scenario could not be executed")
+
+	// Derive the expected ICMP outcome from the device type that defineMetricsPolicy() actually
+	// configured on the server policy. With true vfio-pci (Intel), the VF is exclusively owned
+	// by DPDK and ICMP fails. With netdevice+RDMA (Mellanox "vfiopci" mode), the kernel network
+	// stack remains active on the VF and ICMP succeeds.
+	if serverResources.policy.Definition.Spec.DeviceType == "vfio-pci" {
+		Eventually(func() error {
+			return sriovocpenv.ICMPConnectivityCheck(cPod, []string{tsparams.ServerIPv4IPAddress}, "net1")
+		}, 1*time.Minute, 2*time.Second).Should(HaveOccurred(), "ICMP fail scenario could not be executed")
+	} else {
+		Eventually(func() error {
+			return sriovocpenv.ICMPConnectivityCheck(cPod, []string{tsparams.ServerIPv4IPAddress}, "net1")
+		}, 1*time.Minute, 2*time.Second).ShouldNot(HaveOccurred(),
+			"ICMP connectivity check failed for netdevice+RDMA server")
+	}
 
 	checkMetricsWithPromQL()
 }
@@ -472,16 +484,23 @@ func defineMetricsDPDKPod(role, devType, worker string) *pod.Builder {
 }
 
 func createMetricsTestResources(cRes, sRes metricsTestResource) *pod.Builder {
+	// Create all policies first so the SR-IOV daemon sees them in the same reconcile generation.
+	// Creating policies and networks in an interleaved loop (policy1 → network1 → NAD wait →
+	// policy2) introduces a gap that causes the daemon to process them in separate generations.
+	// The first generation reports "Succeeded" with only one device plugin resource registered,
+	// and WaitForSriovStable returns prematurely — leaving the server DPDK pod Pending.
 	for _, res := range []metricsTestResource{cRes, sRes} {
-		By("Create SriovNetworkNodePolicy")
+		By(fmt.Sprintf("Create SriovNetworkNodePolicy %s", res.policy.Definition.Name))
 
 		_, err := res.policy.Create()
 		Expect(err).ToNot(HaveOccurred(),
 			fmt.Sprintf("Failed to Create SriovNetworkNodePolicy %s", res.policy.Definition.Name))
+	}
 
-		By("Create SriovNetwork")
+	for _, res := range []metricsTestResource{cRes, sRes} {
+		By(fmt.Sprintf("Create SriovNetwork %s", res.network.Definition.Name))
 
-		_, err = res.network.Create()
+		_, err := res.network.Create()
 		Expect(err).ToNot(HaveOccurred(),
 			fmt.Sprintf("Failed to create SriovNetwork %s", res.network.Definition.Name))
 


### PR DESCRIPTION
## Summary

Fixes two bugs causing OCP-75931 (`SriovMetricsExporter Netdevice to Vfiopci Different PF`) to fail intermittently with `context deadline exceeded` when creating the DPDK server pod.

### 1. Split reconcile race in `createMetricsTestResources`

The previous loop interleaved policy and network creation:
`policy1 → network1 → WaitForNADCreation → policy2 → ...`

The `WaitForNADCreation` delay between the two `SriovNetworkNodePolicy` creates caused the SR-IOV daemon to process them in **separate reconcile generations**:
- Gen N: only `clientnetdevice` policy → device plugin registers only that resource → reports "Succeeded"
- Gen N+1: both policies → configures Port 2 VFs → restarts device plugin with both resources

`WaitForSriovStable` sees gen N's "Succeeded" (before gen N+1 sets "InProgress") and returns early. The server DPDK pod sits Pending with `Insufficient openshift.io/servervfiopci` for the full 2-minute timeout.

**Fix:** Create all `SriovNetworkNodePolicy` resources first, then all `SriovNetwork` resources, so both policies land in the same reconcile generation.

### 2. Wrong ICMP expectation for Mellanox NICs

The test unconditionally expected ICMP to **fail** between client and server pods. This is correct for Intel NICs where `vfio-pci` gives DPDK exclusive VF ownership. However, `defineMetricsPolicy()` configures Mellanox NICs with `netdevice+RDMA` instead, so the kernel network stack remains active and ICMP **succeeds**.

**Fix:** Branch on the server policy's `DeviceType` to assert the correct outcome per NIC type.

## Test plan

- [x] Previously verified on wsfd-advnetlab244 (Mellanox CX6-DX) with `--focus="Netdevice to Vfiopci"` — all three subtests (Same PF, Different PF, Different Worker) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated metrics export tests to conditionally validate ICMP connectivity based on the server policy’s device type (expected to fail for `vfio-pci`, succeed otherwise).
  * Improved test reliability by reordering test resource setup: create SR-IOV node policies for both client and server first, then provision networks afterward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->