### PR TITLE
cnf network: migrate metallb deployment tests

### DIFF
--- a/tests/cnf/core/network/metallb/internal/metallbenv/metallbenv.go
+++ b/tests/cnf/core/network/metallb/internal/metallbenv/metallbenv.go
@@ -67,31 +67,20 @@ func CreateNewMetalLbDaemonSetAndWaitUntilItsRunning(timeout time.Duration, node
 	logLevel ...mlboperator.MetalLBLogLevel) error {
 	klog.V(90).Infof("Verifying if MetalLB daemonset is running")
 
-	// Check if MetalLB DaemonSet already exists
-	metalLbIo, err := metallb.Pull(APIClient, tsparams.MetalLbIo, NetConfig.MlbOperatorNamespace)
-	if err == nil {
-		klog.V(90).Infof("MetalLB daemonset is running. Removing existing daemonset.")
-
-		_, err = metalLbIo.Delete()
-		if err != nil {
-			return fmt.Errorf("failed to delete existing MetalLB daemonset: %w", err)
-		}
-
-		err = waitForDsDeletion(tsparams.MetalLbDsName, NetConfig.MlbOperatorNamespace, 30*time.Second)
-		if err != nil {
-			return fmt.Errorf("failed to wait for speaker daemonset deletion")
-		}
+	// Wait for both operand controller and speaker workloads to be removed before recreating the CR.
+	if err := DeleteMetalLbCRAndWait(timeout); err != nil {
+		return fmt.Errorf("failed to delete existing MetalLB CR: %w", err)
 	}
 
 	klog.V(90).Infof("Creating a new MetalLB speaker daemonSet.")
 
 	// Create new MetalLB DaemonSet
-	metalLbIo = metallb.NewBuilder(APIClient, tsparams.MetalLbIo, NetConfig.MlbOperatorNamespace, nodeLabel)
+	metalLbIo := metallb.NewBuilder(APIClient, tsparams.MetalLbIo, NetConfig.MlbOperatorNamespace, nodeLabel)
 	if len(logLevel) > 0 {
 		metalLbIo.Definition.Spec.LogLevel = logLevel[0]
 	}
 
-	_, err = metalLbIo.Create()
+	_, err := metalLbIo.Create()
 	if err != nil {
 		return fmt.Errorf("failed to create MetalLB daemonset: %w", err)
 	}
@@ -158,6 +147,10 @@ func waitForDsDeletion(dsName, dsNamespace string, timeout time.Duration) error 
 		context.TODO(), 3*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 			_, err := daemonset.Pull(APIClient, dsName, dsNamespace)
 			if err != nil {
+				if !isResourceMissing(err) {
+					return false, fmt.Errorf("failed to pull daemonset %s/%s: %w", dsNamespace, dsName, err)
+				}
+
 				klog.V(90).Infof("daemonset %s does not exist in namespace %s", dsName, dsNamespace)
 
 				return true, nil
@@ -167,6 +160,62 @@ func waitForDsDeletion(dsName, dsNamespace string, timeout time.Duration) error 
 
 			return false, nil
 		})
+}
+
+// DeleteMetalLbCRAndWait removes the MetalLB CR and waits until the operand controller deployment
+// and speaker daemonset are fully removed. Callers must wait for both workloads to disappear before
+// recreating the CR to avoid races with a lingering controller or speaker.
+func DeleteMetalLbCRAndWait(timeout time.Duration) error {
+	metalLbIo, err := metallb.Pull(APIClient, tsparams.MetalLbIo, NetConfig.MlbOperatorNamespace)
+	if err != nil {
+		if isResourceMissing(err) {
+			return nil
+		}
+
+		return fmt.Errorf("failed to pull MetalLB CR: %w", err)
+	}
+
+	_, err = metalLbIo.Delete()
+	if err != nil {
+		return fmt.Errorf("failed to delete MetalLB CR: %w", err)
+	}
+
+	err = waitForDeploymentDeletion(tsparams.MetalLbControllerName, NetConfig.MlbOperatorNamespace, timeout)
+	if err != nil {
+		return fmt.Errorf("failed to wait for MetalLB controller deployment deletion: %w", err)
+	}
+
+	if err := waitForDsDeletion(tsparams.MetalLbDsName, NetConfig.MlbOperatorNamespace, timeout); err != nil {
+		return fmt.Errorf("failed to wait for MetalLB speaker daemonset deletion: %w", err)
+	}
+
+	return nil
+}
+
+func waitForDeploymentDeletion(deploymentName, deploymentNamespace string, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(
+		context.TODO(), 3*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+			_, err := deployment.Pull(APIClient, deploymentName, deploymentNamespace)
+			if err != nil {
+				if !isResourceMissing(err) {
+					return false, fmt.Errorf("failed to pull deployment %s/%s: %w",
+						deploymentNamespace, deploymentName, err)
+				}
+
+				klog.V(90).Infof("deployment %s does not exist in namespace %s", deploymentName, deploymentNamespace)
+
+				return true, nil
+			}
+
+			klog.V(90).Infof("deployment %s exists in namespace %s, waiting for deletion...",
+				deploymentName, deploymentNamespace)
+
+			return false, nil
+		})
+}
+
+func isResourceMissing(err error) bool {
+	return strings.Contains(err.Error(), "does not exist in namespace")
 }
 
 // GetMetalLbIPByIPStack returns metalLb IP addresses  from env var typo:ECO_CNF_CORE_NET_MLB_ADDR_LIST

--- a/tests/cnf/core/network/metallb/internal/tsparams/consts.go
+++ b/tests/cnf/core/network/metallb/internal/tsparams/consts.go
@@ -21,6 +21,8 @@ const (
 	BGPPassword = "bgp-test"
 	// LabelGRTestCases represents graceful restart label that can be used for test cases selection.
 	LabelGRTestCases = "gracefulrestart"
+	// LabelMetalLBDeployment represents metallb-deployment label that can be used for test cases selection.
+	LabelMetalLBDeployment = "metallb-deployment"
 	// MlbAddressListError an error message when the ECO_CNF_CORE_NET_MLB_ADDR_LIST is incorrect.
 	MlbAddressListError = "An unexpected error occurred while " +
 		"determining the IP addresses from the ECO_CNF_CORE_NET_MLB_ADDR_LIST environment variable."

--- a/tests/cnf/core/network/metallb/internal/tsparams/mlbvars.go
+++ b/tests/cnf/core/network/metallb/internal/tsparams/mlbvars.go
@@ -50,6 +50,8 @@ var (
 	MetalLbIo = "metallb"
 	// MetalLbDsName default metalLb speaker daemonset names.
 	MetalLbDsName = "speaker"
+	// MetalLbControllerName default metalLb controller deployment name.
+	MetalLbControllerName = "controller"
 	// FrrDsName default metalLb frr daemonset name.
 	FrrDsName = "frr-k8s"
 	// FRRK8sDefaultLabel represents the default metalLb FRRK8S pod label.

--- a/tests/cnf/core/network/metallb/tests/metallb-deployment.go
+++ b/tests/cnf/core/network/metallb/tests/metallb-deployment.go
@@ -1,0 +1,203 @@
+package tests
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/daemonset"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/deployment"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/metallb"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/metallb/mlboperator"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netinittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/metallb/internal/metallbenv"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/metallb/internal/tsparams"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	controllerPriorityClass   = "example"
+	speakerPriorityClass      = "high-priority"
+	runtimeClassName          = "myclass"
+	tolerationKeyExample      = "example"
+	controllerAnnotationKey   = "controller-annotation"
+	controllerAnnotationValue = "demo-controller"
+	controllerAffinityLabel   = "controller-test"
+	speakerAnnotationKey      = "speaker-annotation"
+	speakerAnnotationValue    = "demo-speaker"
+	speakerAffinityLabel      = "speaker-test"
+)
+
+var _ = Describe("MetalLB Deployment", Label(tsparams.LabelMetalLBDeployment), Ordered, ContinueOnFailure, func() {
+	BeforeAll(func() {
+		By("Removing existing MetalLB configuration")
+
+		err := metallbenv.DeleteMetalLbCRAndWait(tsparams.DefaultTimeout)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		By("Removing MetalLB configuration")
+
+		err := metallbenv.DeleteMetalLbCRAndWait(tsparams.DefaultTimeout)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterAll(func() {
+		By("Restoring baseline MetalLB deployment for subsequent test cases")
+
+		err := metallbenv.CreateNewMetalLbDaemonSetAndWaitUntilItsRunning(
+			tsparams.DefaultTimeout, NetConfig.WorkerLabelMap)
+		Expect(err).ToNot(HaveOccurred(), "Failed to restore baseline MetalLB deployment")
+	})
+
+	It("Create deployment with all parameters set", reportxml.ID("54131"), func() {
+		By("Creating MetalLB with controller and speaker configuration")
+
+		configureMetalLb(true)
+
+		By("Verifying MetalLB controller and speaker deployments")
+		verifyMetalLbDeploymentsEventually()
+	})
+
+	It("Update deployment parameters with baseline deployment", reportxml.ID("54132"), func() {
+		By("Creating a new instance of MetalLB Speakers on workers")
+
+		err := metallbenv.CreateNewMetalLbDaemonSetAndWaitUntilItsRunning(
+			tsparams.DefaultTimeout, NetConfig.WorkerLabelMap)
+		Expect(err).ToNot(HaveOccurred(), "Failed to create baseline MetalLB deployment")
+
+		By("Updating MetalLB controller and speaker configuration")
+
+		configureMetalLb(false)
+
+		By("Verifying MetalLB controller and speaker deployments")
+		verifyMetalLbDeploymentsEventually()
+	})
+})
+
+func configureMetalLb(createNew bool) {
+	var (
+		metalLbBuilder *metallb.Builder
+		err            error
+	)
+
+	if createNew {
+		metalLbBuilder = metallb.NewBuilder(
+			APIClient, tsparams.MetalLbIo, NetConfig.MlbOperatorNamespace, NetConfig.WorkerLabelMap)
+		defineMetalLbConfig(metalLbBuilder)
+		_, err = metalLbBuilder.Create()
+	} else {
+		metalLbBuilder, err = metallb.Pull(APIClient, tsparams.MetalLbIo, NetConfig.MlbOperatorNamespace)
+		Expect(err).ToNot(HaveOccurred(), "Failed to pull MetalLB CR")
+		defineMetalLbConfig(metalLbBuilder)
+		_, err = metalLbBuilder.Update(false)
+	}
+
+	Expect(err).ToNot(HaveOccurred(), "Failed to persist MetalLB CR")
+}
+
+func defineMetalLbConfig(metalLbBuilder *metallb.Builder) {
+	metallbCR := metalLbBuilder.Definition
+
+	metallbCR.Spec.ControllerConfig = &mlboperator.Config{
+		PriorityClassName: controllerPriorityClass,
+		RuntimeClassName:  runtimeClassName,
+		Annotations: map[string]string{
+			controllerAnnotationKey: controllerAnnotationValue,
+		},
+		Affinity: defineMetalLbPodAffinity(controllerAffinityLabel),
+	}
+
+	metallbCR.Spec.ControllerTolerations = []corev1.Toleration{expectedMetalLbToleration()}
+
+	metallbCR.Spec.SpeakerConfig = &mlboperator.Config{
+		PriorityClassName: speakerPriorityClass,
+		RuntimeClassName:  runtimeClassName,
+		Annotations: map[string]string{
+			speakerAnnotationKey: speakerAnnotationValue,
+		},
+		Affinity: defineMetalLbPodAffinity(speakerAffinityLabel),
+	}
+
+	metallbCR.Spec.SpeakerTolerations = []corev1.Toleration{expectedMetalLbToleration()}
+}
+
+func expectedMetalLbToleration() corev1.Toleration {
+	return corev1.Toleration{
+		Key:      tolerationKeyExample,
+		Operator: corev1.TolerationOpExists,
+		Effect:   corev1.TaintEffectNoExecute,
+	}
+}
+
+func defineMetalLbPodAffinity(component string) *corev1.Affinity {
+	return &corev1.Affinity{PodAffinity: &corev1.PodAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+			{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"component": component},
+				},
+				TopologyKey: corev1.LabelHostname,
+			},
+		},
+	}}
+}
+
+func verifyMetalLbDeploymentsEventually() {
+	GinkgoHelper()
+
+	Eventually(func(gomega Gomega) {
+		controlDep, err := deployment.Pull(
+			APIClient, tsparams.MetalLbControllerName, NetConfig.MlbOperatorNamespace)
+		gomega.Expect(err).NotTo(HaveOccurred(), "Unable to get MetalLB controller deployment")
+		verifyMetalLbPodTemplateSpec(controlDep.Object.Spec.Template,
+			controllerPriorityClass, controllerAnnotationKey, controllerAnnotationValue, controllerAffinityLabel)(gomega)
+
+		speakerDs, err := daemonset.Pull(APIClient, tsparams.MetalLbDsName, NetConfig.MlbOperatorNamespace)
+		gomega.Expect(err).NotTo(HaveOccurred(), "Unable to get MetalLB speaker daemonSet")
+		verifyMetalLbPodTemplateSpec(speakerDs.Object.Spec.Template,
+			speakerPriorityClass, speakerAnnotationKey, speakerAnnotationValue, speakerAffinityLabel)(gomega)
+	}).WithTimeout(tsparams.DefaultTimeout).WithPolling(tsparams.DefaultRetryInterval).Should(Succeed(),
+		"MetalLB deployment parameters were not applied to controller and speaker")
+}
+
+func verifyMetalLbPodTemplateSpec(
+	podTemplate corev1.PodTemplateSpec,
+	priorityClass, annotationKey, annotationValue, affinityLabel string,
+) func(Gomega) {
+	return func(gomega Gomega) {
+		podSpec := podTemplate.Spec
+
+		gomega.Expect(podSpec.PriorityClassName).To(Equal(priorityClass))
+		gomega.Expect(podSpec.RuntimeClassName).NotTo(BeNil())
+		gomega.Expect(*podSpec.RuntimeClassName).To(Equal(runtimeClassName))
+		gomega.Expect(podTemplate.Annotations).To(HaveKeyWithValue(annotationKey, annotationValue))
+		gomega.Expect(podSpec.Affinity).NotTo(BeNil())
+		gomega.Expect(podSpec.Affinity.PodAffinity).NotTo(BeNil())
+		gomega.Expect(podSpec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution).NotTo(BeEmpty())
+		term := podSpec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution[0]
+		gomega.Expect(term.LabelSelector).NotTo(BeNil())
+		gomega.Expect(term.LabelSelector.MatchLabels).To(HaveKeyWithValue("component", affinityLabel))
+		verifyMetalLbToleration(podSpec.Tolerations)(gomega)
+	}
+}
+
+func verifyMetalLbToleration(tolerations []corev1.Toleration) func(Gomega) {
+	return func(gomega Gomega) {
+		expected := expectedMetalLbToleration()
+		matched := false
+
+		for _, toleration := range tolerations {
+			if toleration.Key == expected.Key &&
+				toleration.Operator == expected.Operator &&
+				toleration.Effect == expected.Effect {
+				matched = true
+
+				break
+			}
+		}
+
+		gomega.Expect(matched).To(BeTrue(), "expected MetalLB toleration was not found in pod spec")
+	}
+}


### PR DESCRIPTION
- Add a new metallb-deployment test suite that validates MetalLB controller and speaker configuration can be created from scratch and updated from an existing baseline deployment.
- Verify the MetalLB operator applies controller and speaker pod settings including priorityClassName, runtimeClassName, annotations, affinity, and tolerations.
- Harden the MetalLB test environment helpers by deleting the MetalLB CR and waiting for both the controller deployment and speaker daemonset to be fully removed before recreating resources, which avoids reconcile races during the new tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved MetalLB custom resource cleanup procedures in test infrastructure, ensuring complete removal of controller deployments and speaker daemons before fresh instances are created
  * Added comprehensive test suite validating MetalLB controller and speaker scheduling configurations, including priority classes, runtime classes, pod affinity requirements, tolerations, and annotation handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->