### PR TITLE
system-tests: configure DPDK testpmd for huge CPU count

### DIFF
--- a/tests/system-tests/rdscore/internal/rdscorecommon/sriov-rootless-dpdk.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/sriov-rootless-dpdk.go
@@ -49,6 +49,15 @@ const (
 	dpdkTestpmdTimeout = 20 * time.Second
 	clientRxCmdTimeout = dpdkTestpmdTimeout + 10*time.Second
 	getLinkRxTimeout   = 3 * time.Second
+
+	// SR-IOV interface MTU matches policy configuration (9000 bytes jumbo frames).
+	sriovInterfaceMTU = 9000
+	// Maximum packet length includes MTU plus Ethernet headers.
+	// MTU (9000) + Ethernet header (14) + CRC (4) + VLAN tag (4) = 9022.
+	maxPktLen = sriovInterfaceMTU + 22
+	// Mbuf size must be large enough to hold maximum packet plus headroom.
+	// Using 10240 bytes (10KB) for single-segment jumbo frame support.
+	mbufSize = 10240
 )
 
 var (
@@ -745,7 +754,10 @@ func getNumberOfPackets(line, firstFieldSubstr string) int {
 }
 
 func defineTestServerPmdCmd(ethPeer, pciAddress, txIPs string) []string {
-	baseCmd := fmt.Sprintf("dpdk-testpmd -a %s -- --forward-mode txonly --eth-peer=0,%s", pciAddress, ethPeer)
+	baseCmd := fmt.Sprintf("dpdk-testpmd -R -a %s -- "+
+		"--mbuf-size=%d "+
+		"--forward-mode txonly --eth-peer=0,%s --max-pkt-len=%d",
+		pciAddress, mbufSize, ethPeer, maxPktLen)
 	if txIPs != "" {
 		baseCmd += fmt.Sprintf(" --tx-ip=%s", txIPs)
 	}
@@ -757,8 +769,14 @@ func defineTestServerPmdCmd(ethPeer, pciAddress, txIPs string) []string {
 
 func defineTestPmdCmd(interfaceName string, pciAddress string) string {
 	return fmt.Sprintf("timeout -s SIGKILL %d dpdk-testpmd "+
+		"-R "+
 		"--vdev=virtio_user0,path=/dev/vhost-net,queues=2,queue_size=1024,iface=%s "+
-		"-a %s -- --stats-period 5", int(dpdkTestpmdTimeout.Seconds()), interfaceName, pciAddress)
+		"-a %s "+
+		"-- "+
+		"--mbuf-size=%d "+
+		"--max-pkt-len=%d "+
+		"--stats-period 5",
+		int(dpdkTestpmdTimeout.Seconds()), interfaceName, pciAddress, mbufSize, maxPktLen)
 }
 
 func checkRxOutputRateForInterfaces(


### PR DESCRIPTION
Added `-R` option to handle SRIOV(_RTE_MAX_LCORE_) automapping.

DPDK rootless tests were failing on clusters with SR-IOV MTU 9000 (jumbo frames) because dpdk-testpmd defaulted to MTU 1500. The Mellanox mlx5 PMD in bifurcated mode requires kernel and DPDK MTU to match.

Added `--mbuf-size=10240` and `--max-pkt-len=9022` parameters to both client and server dpdk-testpmd commands. This configures DPDK to handle jumbo frames matching the SR-IOV VF MTU, allowing port configuration to succeed.

Fixes test failures on Mellanox NICs with MTU 9000:
- test_id:77195 (rootless DPDK same node, multiple VLANs)
- test_id:81388 (rootless DPDK different nodes, multiple VLANs)
- test_id:77488 (rootless DPDK different nodes, multiple MACVLANs)
- test_id:77490 (rootless DPDK different nodes, multiple IP-VLANs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced DPDK SR-IOV rootless system tests with improved packet buffer and frame size configuration for better test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->