### PR TITLE
cnf network: fix nmstate race condition

### DIFF
--- a/tests/cnf/core/network/nmstate/tests/altnames.go
+++ b/tests/cnf/core/network/nmstate/tests/altnames.go
@@ -213,12 +213,9 @@ var _ = Describe("NMState Altnames:", Ordered, Label(tsparams.LabelAltnames), Co
 
 			By("Verifying physical interface removed")
 
-			nnstates, err = getNodeNetworkStates(worker0LabelMap)
-			Expect(err).ToNot(HaveOccurred(), "Failed to get NodeNetwork states")
-
-			for _, nnstate := range nnstates {
-				validateAltnamesFromNodeNetworkState(nnstate, sriovIf0, altnames1, true)(Default)
-			}
+			Eventually(validateAltnamesOnNode(
+				workerNodes[0].Object.Name, sriovIf0, altnames1, true)).
+				WithTimeout(netparam.DefaultTimeout).WithPolling(5 * time.Second).Should(Succeed())
 
 			By("Restoring the physical interface to up state")
 
@@ -305,15 +302,9 @@ var _ = Describe("NMState Altnames:", Ordered, Label(tsparams.LabelAltnames), Co
 
 			By("Verifying altnames for SR-IOV VFs that are configured via NMState")
 
-			nnstates, err := getNodeNetworkStates(worker0LabelMap)
-			Expect(err).ToNot(HaveOccurred(), "Failed to get NodeNetwork states")
-
-			for _, nnstate := range nnstates {
-				vfName, err := netnmstate.SrIovVfNetdevFromNodeNetworkState(
-					nnstate, sriovIf0, 0)
-				Expect(err).ToNot(HaveOccurred(), "Failed to resolve VF0 netdev on node %s", nnstate.Object.Name)
-				validateAltnamesFromNodeNetworkState(nnstate, vfName, altnames1, false)(Default)
-			}
+			Eventually(validateAltnamesOnNode(
+				workerNodes[0].Object.Name, firstVFNetdev, altnames1, false)).
+				WithTimeout(netparam.DefaultTimeout).WithPolling(5 * time.Second).Should(Succeed())
 
 			By("Delete Existing NNCP and Create a new one with altnames removed")
 
@@ -328,15 +319,9 @@ var _ = Describe("NMState Altnames:", Ordered, Label(tsparams.LabelAltnames), Co
 
 			By("Verifying altnames removed")
 
-			nnstates, err = getNodeNetworkStates(worker0LabelMap)
-			Expect(err).ToNot(HaveOccurred(), "Failed to get NodeNetwork states")
-
-			for _, nnstate := range nnstates {
-				vfName, err := netnmstate.SrIovVfNetdevFromNodeNetworkState(
-					nnstate, sriovIf0, 0)
-				Expect(err).ToNot(HaveOccurred(), "Failed to resolve VF0 netdev on node %s", nnstate.Object.Name)
-				validateAltnamesFromNodeNetworkState(nnstate, vfName, altnames1, true)(Default)
-			}
+			Eventually(validateAltnamesOnNode(
+				workerNodes[0].Object.Name, firstVFNetdev, altnames1, true)).
+				WithTimeout(netparam.DefaultTimeout).WithPolling(5 * time.Second).Should(Succeed())
 		})
 	})
 
@@ -551,8 +536,14 @@ var _ = Describe("NMState Altnames:", Ordered, Label(tsparams.LabelAltnames), Co
 				}
 
 				for _, nic := range nics {
-					if nic.Name == altnames1[0] {
-						return nil
+					if nic.Name != sriovIf0 {
+						continue
+					}
+
+					for _, altname := range nic.AltNames {
+						if altname == altnames1[0] {
+							return nil
+						}
 					}
 				}
 


### PR DESCRIPTION
Fixing race condition failure with `Eventually`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Reworked NMState alternative-name tests to use asynchronous validation with timeout and polling for more reliable propagation.
  * Added checks verifying altname presence for SR‑IOV VFs after creation and absence after removal.
  * Fixed validation to correctly confirm an interface’s altname by inspecting the specific VF interface’s altname list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->