### PR TITLE
Dockerfile: update ginkgo to match go.mod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ FROM registry.access.redhat.com/ubi9/ubi:latest
 COPY --from=fetcher /usr/local/go /usr/local/go
 
 ARG GO_VER=go1.26.0
-ARG GINKGO_VER=ginkgo@v2.28.1
+ARG GINKGO_VER=ginkgo@v2.29.0
 ARG CONTAINERUSER=testuser
 
 LABEL description="eco-gotests development image"


### PR DESCRIPTION
This commit updates the Dockerfile to use a Ginkgo version that matches
the go.mod after it was updated in #1424. The warning should not cause
any issues though.