### PR TITLE
Add env var documentation check script

### DIFF
--- a/.github/workflows/check-envvar-docs.yml
+++ b/.github/workflows/check-envvar-docs.yml
@@ -1,0 +1,20 @@
+name: Check env var documentation
+
+on:
+  workflow_dispatch:
+
+  push:
+
+  pull_request:
+    branches:
+      - main
+      - 'release-*'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check ECO_* env vars are documented in READMEs
+        run: bash scripts/check-envvar-docs.sh

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ reports
 
 tests/hw-accel/nfd/**/*.md
 tests/hw-accel/nfd/*.md
+!tests/hw-accel/nfd/README.md
 
 # Claude
 .claude/settings.local.json

--- a/scripts/check-envvar-docs.sh
+++ b/scripts/check-envvar-docs.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# Verify that every ECO_* environment variable declared in Go source code
+# is mentioned in the corresponding README.md, and vice versa.
+#
+# Exit codes:
+#   0  all vars documented and no stale references
+#   1  undocumented or stale vars found
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TESTS_DIR="$REPO_ROOT/tests"
+errors=0
+
+declare -A GLOBAL_VARS
+while IFS= read -r v; do
+    [[ -n "$v" ]] && GLOBAL_VARS["$v"]=1
+done < <({
+    grep -ohP 'ECO_[A-Z0-9_]+' "$REPO_ROOT/scripts/test-runner.sh" 2>/dev/null || true
+    grep -ohP 'envconfig:"ECO_[A-Z0-9_]+"' "$TESTS_DIR/internal/config/config.go" 2>/dev/null \
+        | sed 's/envconfig:"//;s/"//' || true
+} | sort -u)
+
+readme_for_config() {
+    local config_file="$1"
+    echo "${config_file%/internal/*}/README.md"
+}
+
+vars_from_code() {
+    local file="$1"
+    {
+        grep -ohP 'envconfig:"ECO_[A-Z0-9_]+"' "$file" 2>/dev/null \
+            | sed 's/envconfig:"//;s/"//' || true
+        grep -ohP 'os\.Getenv\("ECO_[A-Z0-9_]+"\)' "$file" 2>/dev/null \
+            | sed 's/os\.Getenv("//;s/")//' || true
+    } | sort -u
+}
+
+vars_from_readme() {
+    local file="$1"
+    if [[ ! -f "$file" ]]; then
+        return
+    fi
+    grep -ohP 'ECO_[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+(?![_*A-Z0-9])' "$file" | sort -u
+}
+
+config_files=$(grep -rl 'envconfig:"ECO_\|os\.Getenv("ECO_' "$TESTS_DIR" --include="*.go" \
+    | grep -E '(config|env).*\.go$' \
+    | sort -u)
+
+declare -A readme_code_vars
+
+for config_file in $config_files; do
+    readme=$(readme_for_config "$config_file")
+
+    code_vars=$(vars_from_code "$config_file")
+    if [[ -n "${readme_code_vars[$readme]:-}" ]]; then
+        readme_code_vars["$readme"]="${readme_code_vars[$readme]}"$'\n'"$code_vars"
+    else
+        readme_code_vars["$readme"]="$code_vars"
+    fi
+done
+
+for readme in "${!readme_code_vars[@]}"; do
+    rel_readme="${readme#$REPO_ROOT/}"
+
+    declare -A code_set=()
+    while IFS= read -r var; do
+        [[ -n "$var" ]] && code_set["$var"]=1
+    done < <(echo "${readme_code_vars[$readme]}" | sort -u)
+
+    declare -A doc_set=()
+    while IFS= read -r var; do
+        [[ -n "$var" ]] && doc_set["$var"]=1
+    done < <(vars_from_readme "$readme")
+
+    if [[ ! -f "$readme" ]]; then
+        echo "ERROR: $rel_readme does not exist (${#code_set[@]} vars undocumented)"
+        errors=1
+        unset code_set doc_set
+        continue
+    fi
+
+    for var in "${!code_set[@]}"; do
+        if [[ -z "${doc_set[$var]:-}" ]]; then
+            echo "UNDOCUMENTED: $var not in $rel_readme"
+            errors=1
+        fi
+    done
+
+    for var in "${!doc_set[@]}"; do
+        if [[ -z "${code_set[$var]:-}" && -z "${GLOBAL_VARS[$var]:-}" ]]; then
+            echo "STALE: $var in $rel_readme but not in code"
+            errors=1
+        fi
+    done
+
+    unset code_set doc_set
+done
+
+if [[ "$errors" -eq 0 ]]; then
+    echo "OK: all ECO_* environment variables are documented."
+fi
+
+exit "$errors"

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,23 @@
+# Test Configuration
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ECO_REPORTS_DUMP_DIR` | `/tmp/reports` | Directory path for test report output |
+| `ECO_VERBOSE_LEVEL` | `0` | Logging verbosity level |
+| `ECO_DUMP_FAILED_TESTS` | `false` | Dump logs for failed tests to the reports directory |
+| `ECO_ENABLE_REPORT` | `true` | Enable XML test report generation |
+| `ECO_DRY_RUN` | `false` | Run tests in dry-run mode without making changes |
+| `ECO_SSH_KEY_PATH` | _(empty)_ | Path to SSH private key |
+| `ECO_SSH_USER` | `core` | SSH username for node access |
+| `ECO_KUBERNETES_ROLE_PREFIX` | `node-role.kubernetes.io` | Prefix for Kubernetes node role labels |
+| `ECO_WORKER_LABEL` | `worker` | Worker node role label suffix |
+| `ECO_CONTROL_PLANE_LABEL` | `control-plane` | Control plane node role label suffix |
+| `ECO_TC_PREFIX` | `TC-` | Prefix for test case identifiers |
+| `ECO_MCO_NAMESPACE` | `openshift-machine-config-operator` | Namespace for the Machine Config Operator |
+| `ECO_LOGGING_OPERATOR_NAMESPACE` | `openshift-logging` | Namespace for the Logging operator |
+| `ECO_MCO_CONFIG_DAEMON_NAME` | `machine-config-daemon` | Name of the Machine Config Daemon DaemonSet |
+| `ECO_SRIOV_OPERATOR_NAMESPACE` | `openshift-sriov-network-operator` | Namespace for the SR-IOV Network Operator |
+| `ECO_NMSTATE_OPERATOR_NAMESPACE` | `openshift-nmstate` | Namespace for the NMState operator |
+| `ECO_SRIOV_FEC_OPERATOR_NAMESPACE` | `vran-acceleration-operators` | Namespace for the SR-IOV FEC operator |

--- a/tests/accel/README.md
+++ b/tests/accel/README.md
@@ -1,0 +1,13 @@
+# Accel
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ECO_ACCEL_PULL_SECRET` | _(empty)_ | Pull secret for accessing container registries |
+| `ECO_ACCEL_REGISTRY` | _(empty)_ | Container registry URL |
+| `ECO_ACCEL_UPGRADE_TARGET_IMAGE` | _(empty)_ | Target image for OCP upgrade |
+| `ECO_ACCEL_SPOKE_KUBECONFIG` | _(empty)_ | Path to spoke cluster kubeconfig |
+| `ECO_ACCEL_HUB_CLUSTER_NAME` | _(empty)_ | Name of the hub cluster |
+| `ECO_ACCEL_HUB_MINOR_VERSION` | _(empty)_ | Minor version of the hub cluster |
+| `ECO_ACCEL_WORKLOAD_IMAGE` | `registry.redhat.io/openshift4/ose-hello-openshift-rhel8@sha256:10dca31348f07e1bfb56ee93c324525cceefe27cb7076b23e42ac181e4d1863e` | Container image for IBU workload validation |

--- a/tests/assisted/ztp/README.md
+++ b/tests/assisted/ztp/README.md
@@ -42,6 +42,7 @@ Assisted ZTP tests are developed for the purpose of testing the infrastructure o
 ### Inputs
 - `ECO_ASSISTED_ZTP_SPOKE_KUBECONFIG`: Location of the spoke cluster kubeconfig file
 - `ECO_ASSISTED_ZTP_SPOKE_CLUSTERIMAGESET`: The clusterimageset that should be used by real/mocked spoke cluster resources
+- `ECO_ASSISTED_ZTP_HUB_PULL_SECRET_OVERRIDE_PATH`: Path to a file containing a pull secret override for the hub cluster
 
 Please refer to the project README for a list of global inputs - [How to run](../../../README.md#how-to-run)
 

--- a/tests/cnf/core/network/README.md
+++ b/tests/cnf/core/network/README.md
@@ -60,6 +60,17 @@ Environment variables to change test image locations and worker labels:
 - `ECO_CNF_CORE_NET_DPDK_TEST_CONTAINER`: controls the location of the DPDK test image.
 - `ECO_CNF_CORE_NET_FRR_IMAGE`: controls the location of the FRR test image.
 - `ECO_CNF_CORE_NET_CNF_MCP_LABEL`: variable used to identify the worker node label.
+- `ECO_CNF_CORE_NET_MLB_OPERATOR_NAMESPACE`: MetalLB operator namespace.
+- `ECO_CNF_CORE_NET_FRR_K8S_NAMESPACE`: FRR-K8s namespace.
+- `ECO_CNF_CORE_NET_PF_STATUS_RELAY_OPERATOR_NAMESPACE`: PF Status Relay operator namespace.
+- `ECO_CNF_CORE_NET_MULTUS_NAMESPACE`: Multus namespace.
+- `ECO_CNF_CORE_NET_PROMETHEUS_OPERATOR_NAMESPACE`: Prometheus operator namespace.
+- `ECO_CNF_CORE_NET_CLUSTER_VLAN`: Cluster VLAN identifier.
+- `ECO_CNF_CORE_NET_PRIMARY_SWITCH_INTERFACES`: Primary switch interfaces (comma-separated, expects 4 interfaces).
+- `ECO_CNF_CORE_NET_SWITCH_LAGS`: Switch LAG names (comma-separated, expects 2 names).
+- `ECO_CNF_CORE_NET_BMC_HOST_NAMES`: BMC host names (comma-separated).
+- `ECO_CNF_CORE_NET_BMC_HOST_USER`: BMC host username.
+- `ECO_CNF_CORE_NET_BMC_HOST_PASS`: BMC host password.
 
 Please refer to the project README for a list of global inputs - [How to run](../../../README.md#how-to-run)
 All network environmental variables can be found 'tests/cnf/core/network/internal/netconfig/config.go'

--- a/tests/cnf/ran-deployment/README.md
+++ b/tests/cnf/ran-deployment/README.md
@@ -53,6 +53,7 @@ Currently, only the TALM tests need more than the first spoke kubeconfig.
 
 * `ECO_CNF_RAN_SKIP_TLS_VERIFY`: Boolean for allowing the go-git library to skip TLS certificate validation for internal repositories.
   * Set to either `true` or `false`. Default is `false`.
+* `ECO_CNF_RAN_SPOKE1_NAME`: Name of the spoke 1 cluster.
 
 ### Running the RAN deployment test suites
 

--- a/tests/cnf/ran/README.md
+++ b/tests/cnf/ran/README.md
@@ -85,6 +85,39 @@ This input is specific to the ZTP generator tests and is optional.
 
 - `ECO_CNF_RAN_ZTP_SITE_GENERATE_IMAGE`: Container image to use for generating CRs from the site config.
 
+#### PTP inputs
+
+These inputs are all specific to the PTP test suites and are optional.
+
+* `ECO_CNF_RAN_PTP_STABILITY_DURATION`: Duration for PTP stability analysis (Go duration string).
+* `ECO_CNF_RAN_PTP_STABILITY_THRESHOLD`: Absolute offset threshold in nanoseconds for PTP stability analysis.
+* `ECO_CNF_RAN_PTP_EVENT_CONSUMER_IMAGE`: URL of the PTP event consumer image (without tag).
+* `ECO_CNF_RAN_PTP_EVENT_CONSUMER_V1_TAG`: Tag of the PTP event consumer image for v1 (include leading colon).
+* `ECO_CNF_RAN_PTP_EVENT_CONSUMER_V2_TAG`: Tag of the PTP event consumer image for v2 (include leading colon).
+* `ECO_CNF_RAN_PTP_MUST_GATHER_IMAGE`: Image to use for PTP must-gather. Falls back to CSV annotation or registry.redhat.io if unset.
+
+#### Spoke inputs
+
+* `ECO_CNF_RAN_SPOKE1_NAME`: Name of the spoke 1 cluster. Automatically updated if Spoke1Kubeconfig exists, otherwise provided as input.
+* `ECO_CNF_RAN_SPOKE1_HOSTNAME`: Hostname for the spoke 1 cluster, used as input for the O-RAN suite.
+* `ECO_CNF_RAN_SPOKE1_PASSWORD`: Path to the admin password for spoke 1, saved in the O-RAN suite.
+
+#### ACM inputs
+
+* `ECO_CNF_RAN_ACM_OPERATOR_NAMESPACE`: Namespace that the ACM operator uses.
+
+#### O-RAN inputs
+
+These inputs are specific to the O-RAN test suite.
+
+* `ECO_CNF_RAN_HUB_APPS_DOMAIN`: Subdomain for the hub cluster routes (e.g. `apps.<hub-cluster-name>.<hub-cluster-domain>`).
+* `ECO_CNF_RAN_O2IMS_CLIENT_CERT_SECRET`: Name of the secret containing the client certificate for O2IMS and OAuth APIs.
+* `ECO_CNF_RAN_O2IMS_CLIENT_CERT_SECRET_NAMESPACE`: Namespace for the O2IMS client certificate secret.
+* `ECO_CNF_RAN_O2IMS_OAUTH_CLIENT_ID`: Client ID for requesting an access token from the OAuth endpoint.
+* `ECO_CNF_RAN_O2IMS_OAUTH_CLIENT_SECRET`: Client secret for requesting an access token from the OAuth endpoint.
+* `ECO_CNF_RAN_O2IMS_TOKEN`: Token for authenticating with the O2IMS API (used when OAuth is not configured).
+* `ECO_CNF_RAN_CLUSTER_TEMPLATE_AFFIX`: Version-dependent affix for naming ClusterTemplates and O-RAN resources.
+
 ### Running the RAN test suites
 
 Except for the container namespace hiding tests, a dump of relevant CRs will be generated for failed tests only when `ECO_ENABLE_REPORT=true`.

--- a/tests/hw-accel/amdgpu/README.md
+++ b/tests/hw-accel/amdgpu/README.md
@@ -1,0 +1,10 @@
+# AMD GPU
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ECO_HWACCEL_AMD_DRIVER_VERSION` | _(empty)_ | AMD GPU driver version to test |
+| `ECO_HWACCEL_AMD_OPERATOR_VERSION` | _(empty)_ | AMD GPU operator version to test |
+| `ECO_HWACCEL_AMD_SKIP_CLEANUP` | `false` | Skip test resource cleanup after test execution |
+| `ECO_HWACCEL_AMD_SKIP_CLEANUP_ON_ERROR` | `false` | Skip test resource cleanup when a test fails |

--- a/tests/hw-accel/kmm/README.md
+++ b/tests/hw-accel/kmm/README.md
@@ -52,6 +52,7 @@ Notes:
 #### Upgrade related
 - `ECO_HWACCEL_KMM_SUBSCRIPTION_NAME`: Name of subscription used to deploy the KMM operator
 - `ECO_HWACCEL_KMM_CATALOG_SOURCE_NAME`: Name of the catalog source used for performing upgrade
+- `ECO_HWACCEL_KMM_CATALOG_SOURCE_CHANNEL`: Channel of the catalog source used for performing upgrade
 - `ECO_HWACCEL_KMM_UPGRADE_TARGET_VERSION`: Expected version of the operator after upgrade
 
 #### MCM related

--- a/tests/hw-accel/neuron/README.md
+++ b/tests/hw-accel/neuron/README.md
@@ -105,6 +105,15 @@ Notes:
 | `ECO_HWACCEL_NEURON_HF_TOKEN` | **REQUIRED for vLLM tests** - HuggingFace token for downloading gated models (e.g., Llama). Get your token from https://huggingface.co/settings/tokens |
 | `ECO_HWACCEL_NEURON_STORAGE_CLASS` | Storage class for model PVC (default: `gp3-csi`). The PVC caches downloaded models to avoid re-downloading on pod restart. |
 
+#### KServe Test Variables
+
+| Variable | Description |
+|----------|-------------|
+| `ECO_HWACCEL_NEURON_KSERVE_MODEL_NAME` | HuggingFace model for KServe inference tests (default: `TinyLlama/TinyLlama-1.1B-Chat-v1.0`) |
+| `ECO_HWACCEL_NEURON_KSERVE_VLLM_IMAGE` | vLLM Neuron image for the KServe ServingRuntime |
+| `ECO_HWACCEL_NEURON_KSERVE_NAMESPACE` | Namespace where KServe resources are deployed (default: `neuron-inference`) |
+| `ECO_HWACCEL_NEURON_KSERVE_TENSOR_PARALLEL_SIZE` | Tensor parallel size for KServe vLLM (default: `1`) |
+
 #### Upgrade Test Variables
 
 | Variable | Description |

--- a/tests/hw-accel/nfd/README.md
+++ b/tests/hw-accel/nfd/README.md
@@ -1,0 +1,13 @@
+# NFD (Node Feature Discovery)
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ECO_HWACCEL_NFD_SUBSCRIPTION_NAME` | _(empty)_ | Name of the NFD operator subscription |
+| `ECO_HWACCEL_NFD_CR_IMAGE` | _(empty)_ | Container image for the NFD custom resource |
+| `ECO_HWACCEL_NFD_CATALOG_SOURCE` | _(empty)_ | Catalog source for the NFD operator |
+| `ECO_HWACCEL_NFD_CUSTOM_NFD_CATALOG_SOURCE` | _(empty)_ | Custom catalog source for the NFD operator |
+| `ECO_HWACCEL_NFD_AWS_TESTS` | `false` | Enable AWS-specific NFD tests |
+| `ECO_HWACCEL_NFD_UPGRADE_TARGET_VERSION` | _(empty)_ | Target version for NFD operator upgrade tests |
+| `ECO_HWACCEL_NFD_CPU_FLAGS_HELPER_IMAGE` | _(empty)_ | Container image for CPU flags helper pod |

--- a/tests/hw-accel/nvidiagpu/README.md
+++ b/tests/hw-accel/nvidiagpu/README.md
@@ -56,7 +56,6 @@ Parameters for the script are controlled by the following environment variables:
 - `ECO_HWACCEL_NVIDIAGPU_INSTANCE_TYPE`: Use only when cluster is on a public cloud, and when you need to scale the cluster to add a GPU-enabled compute node. If cluster already has a GPU enabled worker node, this variable should be unset.
     - Example instance type: "g4dn.xlarge" in AWS, or "a2-highgpu-1g" in GCP, or "Standard_NC4as_T4_v3" in Azure - _required when need to scale cluster to add GPU node_
 - `ECO_HWACCEL_NVIDIAGPU_CATALOGSOURCE`: custom catalogsource to be used.  If not specified, the default "certified-operators" catalog is used - _optional_
-- `ECO_HWACCEL_NVIDIAGPU_SUBSCRIPTION_CHANNEL`: specific subscription channel to be used.  If not specified, the latest channel is used - _optional_
 - `ECO_HWACCEL_NVIDIAGPU_GPUBURN_IMAGE`: GPU burn container image specific to cluster architecture _required_
 
 It is recommended to execute the runner script through the `make run-tests` make target.
@@ -73,7 +72,6 @@ $ export ECO_TEST_LABELS='nvidiagpu,48452'
 $ export ECO_VERBOSE_LEVEL=100
 $ export ECO_HWACCEL_NVIDIAGPU_INSTANCE_TYPE="g4dn.xlarge"
 $ export ECO_HWACCEL_NVIDIAGPU_CATALOGSOURCE="certified-operators"
-$ export ECO_HWACCEL_NVIDIAGPU_SUBSCRIPTION_CHANNEL="v23.9"
 $ export ECO_HWACCEL_NVIDIAGPU_GPUBURN_IMAGE="<gpu-burn image to run, specific to cluster architecture>"
 $ make run-tests                    
 Executing eco-gotests test-runner script

--- a/tests/lca/imagebasedinstall/mgmt/README.md
+++ b/tests/lca/imagebasedinstall/mgmt/README.md
@@ -1,0 +1,17 @@
+# LCA Image Based Install - Management
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ECO_LCA_IBI_MGMT_CLUSTER_INFO` | _(empty)_ | Path to YAML file with spoke cluster network and BMC info |
+| `ECO_LCA_IBI_MGMT_SEED_IMAGE` | `quay.io/ocp-edge-qe/ib-seedimage-public:ci` | Seed image for image-based installation |
+| `ECO_LCA_IBI_MGMT_SSHKEY_PATH` | _(empty)_ | Path to public SSH key file for spoke cluster access |
+| `ECO_LCA_IBI_MGMT_STATIC_NETWORK` | `false` | Enable static networking for spoke cluster |
+| `ECO_LCA_IBI_EXTRA_MANIFESTS` | `true` | Include extra manifests during installation |
+| `ECO_LCA_IBI_CA_BUNDLE` | `true` | Include CA bundle during installation |
+| `ECO_LCA_IBI_SITECONFIG` | `true` | Use SiteConfig for installation |
+| `ECO_LCA_IBI_MGMT_EXTRA_PARTITION_NAME` | _(empty)_ | Name of extra disk partition to create |
+| `ECO_LCA_IBI_MGMT_EXTRA_PARTITION_SIZE` | `50000` | Size of extra disk partition in MiB |
+| `ECO_LCA_IBI_REINSTALL_GENERATION` | `generate1` | Reinstall generation label for reinstall tests |
+| `ECO_LCA_IBI_ADDITIONAL_NTP_SOURCES` | _(empty)_ | Additional NTP sources for the cluster |

--- a/tests/lca/imagebasedupgrade/cnf/README.md
+++ b/tests/lca/imagebasedupgrade/cnf/README.md
@@ -1,0 +1,21 @@
+# LCA Image-Based Upgrade - CNF
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ECO_LCA_IBU_CNF_WORKLOAD_IMAGE` | `registry.redhat.io/openshift4/ose-hello-openshift-rhel8@sha256:10dca31348f07e1bfb56ee93c324525cceefe27cb7076b23e42ac181e4d1863e` | Container image for IBU workload validation |
+| `ECO_LCA_IBU_CNF_KUBECONFIG_TARGET_HUB` | _(empty)_ | Path to kubeconfig for the target hub cluster |
+| `ECO_LCA_IBU_CNF_KUBECONFIG_TARGET_SNO` | _(empty)_ | Path to kubeconfig for the target SNO cluster |
+| `ECO_LCA_IBU_CNF_WORKLOAD_NS` | `test` | Namespace for IBU workload validation |
+| `ECO_LCA_IBU_CNF_WORKLOAD_PV_NS` | `test` | Namespace for IBU persistent volume workload validation |
+| `ECO_LCA_IBU_CNF_WORKLOAD_PV_POD` | `test10-0` | Pod name for persistent volume workload validation |
+| `ECO_LCA_IBU_CNF_WORKLOAD_PV_FILE` | `/data/test10-0` | File path inside the persistent volume pod to validate |
+| `ECO_LCA_IBU_CNF_KCAT_IMAGE` | `quay.io/ocp-edge-qe/kcat` | Container image for kcat (Kafka cat) validation |
+| `ECO_LCA_IBU_CNF_KCAT_BROKER` | `kafka.example.com:9092` | Kafka broker address for kcat validation |
+| `ECO_LCA_IBU_CNF_KCAT_TOPIC` | `vran-qe` | Kafka topic for kcat validation |
+| `ECO_LCA_IBGU_SEED_IMAGE` | `quay.io/ocp-edge-qe/seed-image` | Seed image for IBGU (Image Based Group Upgrade) |
+| `ECO_LCA_IBGU_SEED_IMAGE_VERSION` | `4.17.0` | Seed image version for IBGU |
+| `ECO_LCA_IBGU_ODAP_CM_NAME` | `oadp-cm` | OADP ConfigMap name for IBGU |
+| `ECO_LCA_IBGU_ODAP_CM_NAMESPACE` | `openshift-adp` | OADP ConfigMap namespace for IBGU |
+| `ECO_LCA_IBU_CNF_ACM_OPERATOR_NAMESPACE` | `rhacm` | Namespace of the ACM operator |

--- a/tests/lca/imagebasedupgrade/mgmt/README.md
+++ b/tests/lca/imagebasedupgrade/mgmt/README.md
@@ -1,0 +1,14 @@
+# LCA Image-Based Upgrade - Management
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ECO_LCA_IBU_MGMT_SEED_IMAGE` | `quay.io/ocp-edge-qe/ib-seedimage-public:ci` | Seed image for image-based upgrade |
+| `ECO_LCA_IBU_MGMT_WORKLOAD_IMAGE` | `registry.redhat.io/openshift4/ose-hello-openshift-rhel8@sha256:10dca31348f07e1bfb56ee93c324525cceefe27cb7076b23e42ac181e4d1863e` | Container image for IBU workload validation |
+| `ECO_LCA_IBU_MGMT_IDLE_POST_UPGRADE` | `false` | Set IBU to Idle after the upgrade completes |
+| `ECO_LCA_IBU_MGMT_ROLLBACK_AFTER_UPGRADE` | `false` | Perform rollback after upgrade completes |
+| `ECO_LCA_IBU_MGMT_EXTRA_MANIFESTS` | `true` | Include extra manifests during upgrade |
+| `ECO_LCA_IBU_MGMT_ADDITIONAL_NTP_SOURCES` | _(empty)_ | Additional NTP sources for the cluster |
+| `ECO_LCA_IBU_MGMT_STATE_TRANSITIONS` | `false` | Enable state transition testing before upgrade |
+| `ECO_LCA_IBU_MGMT_SECOND_UPGRADE` | `false` | Perform a second upgrade after the first completes |

--- a/tests/lca/ipchange/README.md
+++ b/tests/lca/ipchange/README.md
@@ -1,0 +1,14 @@
+# LCA IP Change
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ECO_LCA_IPC_EXPECTED_STAGE` | _(empty)_ | Expected LCA stage after IP change |
+| `ECO_LCA_IPC_EXPECTED_IPV4_ADDRESS` | _(empty)_ | Expected IPv4 address after IP change |
+| `ECO_LCA_IPC_EXPECTED_IPV4_GATEWAY` | _(empty)_ | Expected IPv4 gateway after IP change |
+| `ECO_LCA_IPC_EXPECTED_IPV4_MACHINE_NETWORK` | _(empty)_ | Expected IPv4 machine network CIDR after IP change |
+| `ECO_LCA_IPC_EXPECTED_IPV6_ADDRESS` | _(empty)_ | Expected IPv6 address after IP change |
+| `ECO_LCA_IPC_EXPECTED_IPV6_GATEWAY` | _(empty)_ | Expected IPv6 gateway after IP change |
+| `ECO_LCA_IPC_EXPECTED_IPV6_MACHINE_NETWORK` | _(empty)_ | Expected IPv6 machine network CIDR after IP change |
+| `ECO_LCA_IPC_EXPECTED_DNS_SERVERS` | _(empty)_ | Expected DNS servers after IP change |

--- a/tests/lca/seedgeneration/README.md
+++ b/tests/lca/seedgeneration/README.md
@@ -1,0 +1,8 @@
+# LCA Seed Generation
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ECO_LCA_IBU_CNF_KUBECONFIG_TARGET_SNO` | _(empty)_ | Path to kubeconfig for the target SNO cluster |
+| `ECO_LCA_IBGU_SEED_IMAGE` | _(empty)_ | Seed image for IBGU (Image Based Group Upgrade) |

--- a/tests/ocp/sriov/README.md
+++ b/tests/ocp/sriov/README.md
@@ -51,7 +51,15 @@ export ECO_OCP_SRIOV_INTERFACE_LIST="ens2f0,ens3f0"
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `ECO_OCP_SRIOV_OPERATOR_NAMESPACE` | SR-IOV operator namespace | `openshift-sriov-network-operator` |
-| `ECO_OCP_SRIOV_TEST_CONTAINER` | Container image for test workloads | — |
+| `ECO_OCP_SRIOV_TEST_CONTAINER` | Container image for test workloads | -- |
+| `ECO_OCP_SRIOV_DPDK_TEST_CONTAINER` | Container image for DPDK test workloads | -- |
+| `ECO_OCP_SRIOV_PROMETHEUS_OPERATOR_NAMESPACE` | Prometheus operator namespace | -- |
+| `ECO_OCP_SRIOV_MCP_LABEL` | Machine config pool label | -- |
+| `ECO_OCP_SRIOV_SWITCH_USER` | Switch username for switch-based tests | -- |
+| `ECO_OCP_SRIOV_SWITCH_PASS` | Switch password for switch-based tests | -- |
+| `ECO_OCP_SRIOV_SWITCH_IP` | Switch IP address for switch-based tests | -- |
+| `ECO_OCP_SRIOV_SWITCH_INTERFACES` | Switch interfaces for switch-based tests (comma-separated `name:port` pairs) | -- |
+| `ECO_OCP_SRIOV_VLAN` | VLAN ID for switch-based tests (1-4094) | -- |
 
 ## Directory Structure
 

--- a/tests/system-tests/README.md
+++ b/tests/system-tests/README.md
@@ -1,0 +1,9 @@
+# System Tests
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ECO_SYSTEM_TESTS_IPMITOOL_IMAGE` | `quay.io/ocp-edge-qe/ipmitool@sha256:e843...` | Container image for IPMI tool operations |
+| `ECO_SYSTEM_TESTS_CNF_CLIENT_IMAGE` | `quay.io/ocp-edge-qe/cnf-gotests-client:v4.15` | Container image for CNF test client |
+| `ECO_SYSTEM_TESTS_DEST_REGISTRY_URL` | _(empty)_ | Destination registry URL for image mirroring |

--- a/tests/system-tests/diskencryption/README.md
+++ b/tests/system-tests/diskencryption/README.md
@@ -1,0 +1,10 @@
+# Disk Encryption
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ECO_SYSTEM_TESTS_BMC_USERNAME` | _(empty)_ | BMC username for node power management |
+| `ECO_SYSTEM_TESTS_BMC_PASSWORD` | _(empty)_ | BMC password for node power management |
+| `ECO_SYSTEM_TESTS_BMC_HOSTS` | _(empty)_ | Comma-separated list of BMC host addresses |
+| `ECO_SYSTEM_TESTS_BMC_TIMEOUT` | `15s` | Timeout for BMC operations |

--- a/tests/system-tests/ipsec/README.md
+++ b/tests/system-tests/ipsec/README.md
@@ -90,9 +90,9 @@ to open ports for IPSec, as explained in Appendix A4.
 If the SNO cluster used for IPSec testing is changed, then most likely the IP addresses
 will have to be changed.
 
-To change the SNO cluster IP, first update the `iperf3_server_sno_ip` parameter
+To change the SNO cluster IP, first update the `iperf3_server_ocp_ips` parameter
 in the `eco-gotests/tests/system-tests/ipsec/internal/ipsecconfig/default.yaml`
-file. This parameter can be overridden in CI by setting the `ECO_IPSEC_IPERF3_SERVER_SNO_IP`
+file. This parameter can be overridden in CI by setting the `ECO_IPSEC_IPERF3_SERVER_OCP_IPS`
 environment variable.
 
 Additionally, the SNO cluster Machine Config must be created again and stored in
@@ -127,6 +127,26 @@ The test case could fail for one of the following reasons:
 3. The iperf3 image for the SNO cluster is not available. Refer to Appendix A3.
 4. One of the IPs in `eco-gotests/tests/system-tests/ipsec/internal/ipsecconfig/default.yaml`
    is incorrect.
+
+## Environment Variables
+
+The following environment variables configure the IPSec test suite. See
+`tests/system-tests/ipsec/internal/ipsecconfig/default.yaml` for default values.
+
+* `ECO_IPSEC_TESTS_IPERF3_IMAGE`: Container image for the iperf3 tool.
+* `ECO_IPSEC_SECGW_HOST_IP`: Host IP address of the Security Gateway (for SSH).
+* `ECO_IPSEC_SECGW_SERVER_IP`: IPSec tunnel IP of the Security Gateway.
+* `ECO_IPSEC_IPERF3_SERVER_OCP_IPS`: OCP cluster IP addresses for iperf3 server.
+* `ECO_IPSEC_IPERF3_CLIENT_TX_BYTES`: Number of bytes to transmit in iperf3 client tests.
+* `ECO_IPSEC_NODE_PORT`: NodePort used for iperf3 tests.
+* `ECO_IPSEC_NODE_PORT_INCREMENT`: Increment applied to the node port between tests.
+* `ECO_IPSEC_TESTWORKLOAD_NAMESPACE`: Namespace for the test workload.
+* `ECO_IPSEC_TESTWORKLOAD_CREATE_METHOD`: Method used to create the test workload.
+* `ECO_IPSEC_TESTWORKLOAD_CREATE_SHELLCMD`: Shell command to create the test workload.
+* `ECO_IPSEC_TESTWORKLOAD_DELETE_SHELLCMD`: Shell command to delete the test workload.
+* `ECO_SSH_USER`: SSH username for the Security Gateway.
+* `ECO_SSH_PRIVATE_KEY`: Path to SSH private key for the Security Gateway.
+* `ECO_SSH_PORT`: SSH port for the Security Gateway.
 
 ## Appendix
 

--- a/tests/system-tests/o-cloud/README.md
+++ b/tests/system-tests/o-cloud/README.md
@@ -1,0 +1,56 @@
+# O-Cloud
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ECO_OCLOUD_IBI_GENERATE_SEED_IMAGE` | `true` | Generate the seed image for Image Based Install |
+| `ECO_OCLOUD_IBI_BASE_IMAGE_PATH` | _(empty)_ | Local path to the IBI base image |
+| `ECO_OCLOUD_IBI_BASE_IMAGE_URL` | _(empty)_ | URL to the IBI base image |
+| `ECO_OCLOUD_VIRTUAL_MEDIA_ID` | _(empty)_ | Virtual media ID for BMC boot |
+| `ECO_OCLOUD_LOCAL_REGISTRY_AUTH` | _(empty)_ | Authentication credentials for the local registry |
+| `ECO_OCLOUD_SEED_IMAGE` | _(empty)_ | Seed container image reference |
+| `ECO_OCLOUD_SEED_VERSION` | _(empty)_ | Version of the seed image |
+| `ECO_OCLOUD_REGISTRY_5000` | _(empty)_ | URL for registry on port 5000 |
+| `ECO_OCLOUD_REGISTRY_5005` | _(empty)_ | URL for registry on port 5005 |
+| `ECO_OCLOUD_SSH_KEY` | _(empty)_ | SSH public key for cluster node access |
+| `ECO_OCLOUD_PULL_SECRET` | _(empty)_ | Pull secret for container image registries |
+| `ECO_OCLOUD_BASE_IMAGE_NAME` | _(empty)_ | Name of the base image |
+| `ECO_OCLOUD_INTERFACE_NAME` | _(empty)_ | Network interface name on the spoke nodes |
+| `ECO_OCLOUD_INTERFACE_IPV6_1` | _(empty)_ | IPv6 address of the interface for the first cluster |
+| `ECO_OCLOUD_INTERFACE_IPV6_2` | _(empty)_ | IPv6 address of the interface for the second cluster |
+| `ECO_OCLOUD_DNS_IPV6` | _(empty)_ | IPv6 address of the DNS server |
+| `ECO_OCLOUD_NEXT_HOP_IPV6` | _(empty)_ | IPv6 address of the next hop gateway |
+| `ECO_OCLOUD_NEXT_HOP_INTERFACE` | _(empty)_ | Network interface for the next hop route |
+| `ECO_OCLOUD_SPOKE1_BMC_USERNAME` | _(empty)_ | BMC username for spoke 1 |
+| `ECO_OCLOUD_SPOKE1_BMC_PASSWORD` | _(empty)_ | BMC password for spoke 1 |
+| `ECO_OCLOUD_SPOKE1_BMC_HOST` | _(empty)_ | BMC IP address for spoke 1 |
+| `ECO_OCLOUD_SPOKE1_BMC_TIMEOUT` | `15s` | BMC operation timeout for spoke 1 |
+| `ECO_OCLOUD_SPOKE2_BMC_USERNAME` | _(empty)_ | BMC username for spoke 2 |
+| `ECO_OCLOUD_SPOKE2_BMC_PASSWORD` | _(empty)_ | BMC password for spoke 2 |
+| `ECO_OCLOUD_SPOKE2_BMC_HOST` | _(empty)_ | BMC IP address for spoke 2 |
+| `ECO_OCLOUD_SPOKE2_BMC_TIMEOUT` | `15s` | BMC operation timeout for spoke 2 |
+| `ECO_OCLOUD_INVENTORY_POOL_NAMESPACE` | _(empty)_ | Namespace of the inventory pool |
+| `ECO_OCLOUD_BMH_SPOKE1` | _(empty)_ | BareMetalHost resource name for spoke 1 |
+| `ECO_OCLOUD_BMH_SPOKE2` | _(empty)_ | BareMetalHost resource name for spoke 2 |
+| `ECO_OCLOUD_TEMPLATE_NAME` | _(empty)_ | Base name of the referenced ClusterTemplate |
+| `ECO_OCLOUD_TEMPLATE_VERSION_AI_SUCCESS` | _(empty)_ | ClusterTemplate version for successful AI-based SNO provisioning |
+| `ECO_OCLOUD_TEMPLATE_VERSION_AI_FAILURE` | _(empty)_ | ClusterTemplate version for failing AI-based SNO provisioning |
+| `ECO_OCLOUD_TEMPLATE_VERSION_SIMULTANEOUS_1` | _(empty)_ | First ClusterTemplate version for multi-cluster provisioning |
+| `ECO_OCLOUD_TEMPLATE_VERSION_SIMULTANEOUS_2` | _(empty)_ | Second ClusterTemplate version for multi-cluster provisioning |
+| `ECO_OCLOUD_TEMPLATE_VERSION_IBI_SUCCESS` | _(empty)_ | ClusterTemplate version for successful IBI-based SNO provisioning |
+| `ECO_OCLOUD_TEMPLATE_VERSION_IBI_FAILURE` | _(empty)_ | ClusterTemplate version for failing IBI-based SNO provisioning |
+| `ECO_OCLOUD_TEMPLATE_VERSION_DAY2` | _(empty)_ | ClusterTemplate version for Day 2 operations |
+| `ECO_OCLOUD_TEMPLATE_VERSION_SEED` | _(empty)_ | ClusterTemplate version for IBI seed cluster provisioning |
+| `ECO_OCLOUD_NODE_CLUSTER_NAME_1` | _(empty)_ | Name of the first ORAN Node Cluster |
+| `ECO_OCLOUD_NODE_CLUSTER_NAME_2` | _(empty)_ | Name of the second ORAN Node Cluster |
+| `ECO_OCLOUD_OCLOUD_SITE_ID` | _(empty)_ | ID of the ORAN O-Cloud Site |
+| `ECO_OCLOUD_CLUSTER_NAME_1` | _(empty)_ | Name of the first cluster |
+| `ECO_OCLOUD_CLUSTER_NAME_2` | _(empty)_ | Name of the second cluster |
+| `ECO_OCLOUD_SSH_CLUSTER_2` | _(empty)_ | SSH address for the second cluster |
+| `ECO_OCLOUD_HOSTNAME_1` | _(empty)_ | Hostname of the first cluster node |
+| `ECO_OCLOUD_HOSTNAME_2` | _(empty)_ | Hostname of the second cluster node |
+| `ECO_OCLOUD_AUTHFILE_PATH` | `/kubeconfig/docker/config.json` | Path to the auth file for Skopeo commands |
+| `ECO_OCLOUD_SUBSCRIBER_URL` | _(empty)_ | URL of the O-Cloud event subscriber |
+| `ECO_OCLOUD_SUBSCRIBER_DOMAIN` | _(empty)_ | Domain of the O-Cloud event subscriber |
+| `ECO_OCLOUD_O2IMS_BASE_URL` | _(empty)_ | Base URL for the O2IMS API |

--- a/tests/system-tests/ran-du/README.md
+++ b/tests/system-tests/ran-du/README.md
@@ -83,6 +83,7 @@ The suite depends on shared helpers from `tests/system-tests/internal/`:
 |----------|---------|-------------|
 | `KUBECONFIG` | _(required)_ | Path to cluster kubeconfig |
 | `ECO_RANDU_TESTWORKLOAD_NAMESPACE` | `test` | Namespace for test workloads |
+| `ECO_RANDU_TESTWORKLOAD_CREATE_METHOD` | `shell` | Method used to create the test workload |
 | `ECO_RANDU_TESTWORKLOAD_CREATE_SHELLCMD` | `/opt/vdu-workload-emulator/add_test-deployments.sh` | Shell command to create workload |
 | `ECO_RANDU_TESTWORKLOAD_DELETE_SHELLCMD` | `/opt/vdu-workload-emulator/delete_test-deployments.sh` | Shell command to delete workload |
 

--- a/tests/system-tests/rdscore/README.md
+++ b/tests/system-tests/rdscore/README.md
@@ -2,6 +2,274 @@
 
 Documentaion of parameters to be set for running this test suite.
 
+## Environment Variables
+
+All environment variables are defined in
+`tests/system-tests/rdscore/internal/rdscoreconfig/config.go`.
+See `default.yaml` in the same directory for default values.
+
+| Variable | Description |
+|----------|-------------|
+| `ECO_RDSCORE_POLICY_NS` | Policy namespace |
+| `ECO_RDSCORE_WLKD_SRIOV_ONE_NS` | Workload SR-IOV one namespace |
+| `ECO_RDSCORE_WLKD_SRIOV_TWO_NS` | Workload SR-IOV two namespace |
+| `ECO_RDSCORE_WLKD_SRIOV_3_NS` | Workload SR-IOV 3 namespace |
+| `ECO_RDSCORE_WLKD_SRIOV_4_NS` | Workload SR-IOV 4 namespace |
+| `ECO_RDSCORE_WLKD_NROP_ONE_NS` | Workload NROP one namespace |
+| `ECO_RDSCORE_WLKD_NROP_TWO_NS` | Workload NROP two namespace |
+| `ECO_RDSCORE_MCVLAN_NS_ONE` | MAC VLAN namespace one |
+| `ECO_RDSCORE_MCVLAN_NS_TWO` | MAC VLAN namespace two |
+| `ECO_SYSTEM_RDSCORE_DEPLOY_IMG_ONE` | MAC VLAN / IP VLAN deploy image one |
+| `ECO_SYSTEM_RDSCORE_MCVLAN_NAD_ONE_NAME` | MAC VLAN NAD one name |
+| `ECO_RDSCORE_KDUMP_CP_NODE_LABEL` | Kdump control plane node label |
+| `ECO_RDSCORE_KDUMP_CNF_NODE_LABEL` | Kdump CNF MCP node label |
+| `ECO_RDSCORE_IPVLAN_NS_ONE` | IP VLAN namespace one |
+| `ECO_RDSCORE_IPVLAN_NS_TWO` | IP VLAN namespace two |
+| `ECO_SYSTEM_RDSCORE_IPVLAN_NAD_ONE_NAME` | IP VLAN NAD one name |
+| `ECO_SYSTEM_RDSCORE_IPVLAN_NAD_TWO_NAME` | IP VLAN NAD two name |
+| `ECO_SYSTEM_RDSCORE_IPVLAN_NAD_THREE_NAME` | IP VLAN NAD three name |
+| `ECO_SYSTEM_RDSCORE_IPVLAN_NAD_FOUR_NAME` | IP VLAN NAD four name |
+| `ECO_RDSCORE_GRACEFUL_RESTART_APP_LABEL` | Graceful restart app label |
+| `ECO_RDSCORE_KDUMP_WORKER_NODE_LABEL` | Kdump worker MCP node label |
+| `ECO_RDS_CORE_PERFORMANCE_PROFILE_HT_NAME` | Performance profile HT name |
+| `ECO_RDSCORE_NMI_REDFISH_CP_NODE_LABEL` | NMI Redfish control plane node label |
+| `ECO_RDSCORE_NMI_REDFISH_WORKER_NODE_LABEL` | NMI Redfish worker MCP node label |
+| `ECO_RDSCORE_NMI_REDFISH_CNF_NODE_LABEL` | NMI Redfish CNF MCP node label |
+| `ECO_RDSCORE_TOLERATIONS_LIST` | Workload toleration list |
+| `ECO_RDSCORE_NROP_TOLERATIONS_LIST` | Workload NROP toleration list |
+| `ECO_SYSTEM_RDSCORE_MCVLAN_CM_DATA_ONE` | MAC VLAN ConfigMap data one |
+| `ECO_SYSTEM_RDSCORE_IPVLAN_CM_DATA_ONE` | IP VLAN ConfigMap data one |
+| `ECO_RDSCORE_STORAGE_WLKD_IMAGE` | Storage ODF workload image |
+| `ECO_RDSCORE_NODES_CREDENTIALS_MAP` | Nodes BMC credentials map |
+| `ECO_RDSCORE_WLKD_SRIOV_ONE_IMG` | Workload SR-IOV deploy one image |
+| `ECO_RDSCORE_WLKD_SRIOV_TWO_IMG` | Workload SR-IOV deploy two image |
+| `ECO_RDSCORE_WLKD_SRIOV_3_IMG` | Workload SR-IOV deploy 3 image |
+| `ECO_RDSCORE_WLKD_SRIOV_4_IMG` | Workload SR-IOV deploy 4 image |
+| `ECO_RDSCORE_WLKD_NROP_ONE_IMG` | Workload NROP deploy one image |
+| `ECO_RDSCORE_WLKD_NROP_TWO_IMG` | Workload NROP deploy two image |
+| `ECO_RDSCORE_WLKD_SRIOV_NET_ONE` | Workload SR-IOV network one |
+| `ECO_RDSCORE_WLKD_SRIOV_NET_TWO` | Workload SR-IOV network two |
+| `ECO_RDSCORE_WLKD_SRIOV_NET_21` | Workload SR-IOV network 21 |
+| `ECO_RDSCORE_WLKD_SRIOV_NET_22` | Workload SR-IOV network 22 |
+| `ECO_RDSCORE_WLKD_SRIOV_NET_31` | Workload SR-IOV network 31 |
+| `ECO_RDSCORE_WLKD_SRIOV_NET_32` | Workload SR-IOV network 32 |
+| `ECO_RDSCORE_WLKD_SRIOV_NET_41` | Workload SR-IOV network 41 |
+| `ECO_RDSCORE_WLKD_SRIOV_NET_42` | Workload SR-IOV network 42 |
+| `ECO_RDSCORE_WLKD_SRIOV_TWO_SA` | Workload SR-IOV two service account |
+| `ECO_RDSCORE_NROP_SCHEDULER_NAME` | NROP scheduler name |
+| `ECO_RDSCORE_METALLB_FRR_TEST_URL_IPV4` | MetalLB FRR test URL IPv4 |
+| `ECO_RDSCORE_METALLB_FRR_NAMESPACE` | MetalLB FRR namespace |
+| `ECO_RDSCORE_METALLB_FRR_ONE_IPV4` | MetalLB FRR one IPv4 |
+| `ECO_RDSCORE_METALLB_FRR_ONEIPV6` | MetalLB FRR one IPv6 |
+| `ECO_RDSCORE_METALLB_FRR_TWO_IPV4` | MetalLB FRR two IPv4 |
+| `ECO_RDSCORE_METALLB_FRR_TWO_IPV6` | MetalLB FRR two IPv6 |
+| `ECO_RDSCORE_METALLB_FRR_TEST_URL_IPV6` | MetalLB FRR test URL IPv6 |
+| `ECO_RDSCORE_METALLB_TRAFFIC_SEGREGATION_TARGET_PORT` | MetalLB traffic segregation target port |
+| `ECO_RDSCORE_METALLB_TRAFFIC_SEG_TARGET_ONE_IPV4` | MetalLB traffic segregation target one IPv4 |
+| `ECO_RDSCORE_METALLB_TRAFFIC_SEG_TARGET_ONE_IPV6` | MetalLB traffic segregation target one IPv6 |
+| `ECO_RDSCORE_METALLB_TRAFFIC_SEG_TARGET_TWO_IPV4` | MetalLB traffic segregation target two IPv4 |
+| `ECO_RDSCORE_METALLB_TRAFFIC_SEG_TARGET_TWO_IPV6` | MetalLB traffic segregation target two IPv6 |
+| `ECO_RDSCORE_METALLB_LB_ONE_NAMESPACE` | MetalLB load balancer one namespace |
+| `ECO_RDSCORE_METALLB_LB_TWO_NAMESPACE` | MetalLB load balancer two namespace |
+| `ECO_RDSCORE_METALLB_SUPPORT_TOOLS_IMAGE` | MetalLB support tools image |
+| `ECO_RDSCORE_METALLB_TRAFFIC_SEG_TCPDUMP_INT_ONE` | MetalLB traffic segregation tcpdump interface one |
+| `ECO_RDSCORE_METALLB_TRAFFIC_SEG_TCPDUMP_INT_TWO` | MetalLB traffic segregation tcpdump interface two |
+| `ECO_RDSCORE_METALLB_FRR_CONTAINER_NAME_ONE` | MetalLB FRR container name one |
+| `ECO_RDSCORE_METALLB_FRR_CONTAINER_NAME_TWO` | MetalLB FRR container name two |
+| `ECO_RDSCORE_METALLB_LB_ONE_IPV4` | MetalLB load balancer one IPv4 |
+| `ECO_RDSCORE_METALLB_LB_ONE_IPV6` | MetalLB load balancer one IPv6 |
+| `ECO_RDSCORE_METALLB_LB_TWO_IPV4` | MetalLB load balancer two IPv4 |
+| `ECO_RDSCORE_METALLB_LB_TWO_IPV6` | MetalLB load balancer two IPv6 |
+| `ECO_SYSTEM_TEST_HYPERVISOR_HOST` | Hypervisor host |
+| `ECO_SYSTEM_TEST_HYPERVISOR_USER` | Hypervisor user |
+| `ECO_SYSTEM_TEST_HYPERVISOR_PASS` | Hypervisor password |
+| `ECO_RDSCORE_SRIOV_CM_DATA_ONE` | Workload SR-IOV ConfigMap data one |
+| `ECO_RDSCORE_SRIOV_CM_DATA_TWO` | Workload SR-IOV ConfigMap data two |
+| `ECO_RDSCORE_SRIOV_CM_DATA_3` | Workload SR-IOV ConfigMap data 3 |
+| `ECO_RDSCORE_SRIOV_CM_DATA_4` | Workload SR-IOV ConfigMap data 4 |
+| `ECO_RDSCORE_WLKD_ODF_ONE_SELECTOR` | Storage ODF deploy one selector |
+| `ECO_RDSCORE_WLKD_ODF_TWO_SELECTOR` | Storage ODF deploy two selector |
+| `ECO_RDSCORE_WLKD_NROP_ONE_SELECTOR` | Workload NROP deploy one selector |
+| `ECO_RDSCORE_WLKD_SRIOV_ONE_SELECTOR` | Workload SR-IOV deploy one selector |
+| `ECO_RDSCORE_WLKD_SRIOV_TWO_SELECTOR` | Workload SR-IOV deploy two selector |
+| `ECO_RDSCORE_WLKD_SRIOV_3_0_SELECTOR` | Workload SR-IOV deploy 3 one selector |
+| `ECO_RDSCORE_WLKD_SRIOV_4_0_SELECTOR` | Workload SR-IOV deploy 4 one selector |
+| `ECO_RDSCORE_WLKD_SRIOV_4_1_SELECTOR` | Workload SR-IOV deploy 4 two selector |
+| `ECO_RDSCORE_WLKD_SRIOV_3_1_SELECTOR` | Workload SR-IOV deploy 3 two selector |
+| `ECO_RDSCORE_WLKD_NROP_ONE_RES_REQUESTS` | Workload NROP deploy one resource requests |
+| `ECO_RDSCORE_WLKD_SRIOV_ONE_RES_REQUESTS` | Workload SR-IOV deploy one resource requests |
+| `ECO_RDSCORE_WLKD_SRIOV_TWO_RES_REQUESTS` | Workload SR-IOV deploy two resource requests |
+| `ECO_RDSCORE_WLKD_SRIOV_3_0_RES_REQUESTS` | Workload SR-IOV deploy 3 one resource requests |
+| `ECO_RDSCORE_WLKD_SRIOV_3_1_RES_REQUESTS` | Workload SR-IOV deploy 3 two resource requests |
+| `ECO_RDSCORE_WLKD_SRIOV_4_0_RES_REQUESTS` | Workload SR-IOV deploy 4 one resource requests |
+| `ECO_RDSCORE_WLKD_SRIOV_4_1_RES_REQUESTS` | Workload SR-IOV deploy 4 two resource requests |
+| `ECO_RDSCORE_WLKD_NROP_ONE_RES_LIMITS` | Workload NROP deploy one resource limits |
+| `ECO_RDSCORE_WLKD_SRIOV_ONE_RES_LIMITS` | Workload SR-IOV deploy one resource limits |
+| `ECO_RDSCORE_WLKD_SRIOV_TWO_RES_LIMITS` | Workload SR-IOV deploy two resource limits |
+| `ECO_RDSCORE_WLKD_SRIOV_3_0_RES_LIMITS` | Workload SR-IOV deploy 3 one resource limits |
+| `ECO_RDSCORE_WLKD_SRIOV_3_1_RES_LIMITS` | Workload SR-IOV deploy 3 two resource limits |
+| `ECO_RDSCORE_WLKD_SRIOV_4_0_RES_LIMITS` | Workload SR-IOV deploy 4 one resource limits |
+| `ECO_RDSCORE_WLKD_SRIOV_4_1_RES_LIMITS` | Workload SR-IOV deploy 4 two resource limits |
+| `ECO_RDSCORE_NODE_SELECTOR_HT_NODES` | Node selector for HT nodes |
+| `ECO_RDSCORE_SRIOV_WLKD_DEPLOY_ONE_TARGET` | Workload SR-IOV deploy one target address |
+| `ECO_RDSCORE_SRIOV_WLKD_DEPLOY_ONE_TARGET_IPV6` | Workload SR-IOV deploy one target address IPv6 |
+| `ECO_RDSCORE_SRIOV_WLKD_DEPLOY_3_ONE_TARGET` | Workload SR-IOV deploy 3 one target address |
+| `ECO_RDSCORE_SRIOV_WLKD_DEPLOY_3_ONE_TARGET_IPV6` | Workload SR-IOV deploy 3 one target address IPv6 |
+| `ECO_RDSCORE_SRIOV_WLKD_DEPLOY_4_ONE_TARGET` | Workload SR-IOV deploy 4 one target address |
+| `ECO_RDSCORE_SRIOV_WLKD_DEPLOY_4_ONE_TARGET_IPV6` | Workload SR-IOV deploy 4 one target address IPv6 |
+| `ECO_RDSCORE_SRIOV_WLKD_DEPLOY_TWO_TARGET` | Workload SR-IOV deploy two target address |
+| `ECO_RDSCORE_SRIOV_WLKD_DEPLOY_TWO_TARGET_IPV6` | Workload SR-IOV deploy two target address IPv6 |
+| `ECO_RDSCORE_SRIOV_WLKD_3_DEPLOY_TWO_TARGET` | Workload SR-IOV deploy 3 two target address |
+| `ECO_RDSCORE_SRIOV_WLKD_3_DEPLOY_TWO_TARGET_IPV6` | Workload SR-IOV deploy 3 two target address IPv6 |
+| `ECO_RDSCORE_SRIOV_WLKD_4_DEPLOY_TWO_TARGET` | Workload SR-IOV deploy 4 two target address |
+| `ECO_RDSCORE_SRIOV_WLKD_4_DEPLOY_TWO_TARGET_IPV6` | Workload SR-IOV deploy 4 two target address IPv6 |
+| `ECO_RDSCORE_SRIOV_WLKD2_DEPLOY_ONE_TARGET` | Workload SR-IOV deploy 2 one target address |
+| `ECO_RDSCORE_SRIOV_WLKD2_DEPLOY_ONE_TARGET_IPV6` | Workload SR-IOV deploy 2 one target address IPv6 |
+| `ECO_RDSCORE_SRIOV_WLKD2_DEPLOY_TWO_TARGET` | Workload SR-IOV deploy 2 two target address |
+| `ECO_RDSCORE_SRIOV_WLKD2_DEPLOY_TWO_TARGET_IPV6` | Workload SR-IOV deploy 2 two target address IPv6 |
+| `ECO_SYSTEM_RDSCORE_MCVLAN_1_NODE_SELECTOR` | MAC VLAN deploy node selector one |
+| `ECO_SYSTEM_RDSCORE_MCVLAN_2_NODE_SELECTOR` | MAC VLAN deploy node selector two |
+| `ECO_SYSTEM_RDSCORE_MACVLAN_DEPLOY_ONE_TARGET` | MAC VLAN deploy 1 target address |
+| `ECO_SYSTEM_RDSCORE_MACVLAN_DEPLOY_ONE_TARGET_IPV6` | MAC VLAN deploy 1 target address IPv6 |
+| `ECO_SYSTEM_RDSCORE_MACVLAN_DEPLOY_TWO_TARGET` | MAC VLAN deploy 2 target address |
+| `ECO_SYSTEM_RDSCORE_MACVLAN_DEPLOY_TWO_TARGET_IPV6` | MAC VLAN deploy 2 target address IPv6 |
+| `ECO_SYSTEM_RDSCORE_MACVLAN_DEPLOY_3_TARGET` | MAC VLAN deploy 3 target address |
+| `ECO_SYSTEM_RDSCORE_MACVLAN_DEPLOY_3_TARGET_IPV6` | MAC VLAN deploy 3 target address IPv6 |
+| `ECO_SYSTEM_RDSCORE_MACVLAN_DEPLOY_4_TARGET` | MAC VLAN deploy 4 target address |
+| `ECO_SYSTEM_RDSCORE_MACVLAN_DEPLOY_4_TARGET_IPV6` | MAC VLAN deploy 4 target address IPv6 |
+| `ECO_SYSTEM_RDSCORE_IPVLAN_1_NODE_SELECTOR` | IP VLAN deploy node selector one |
+| `ECO_SYSTEM_RDSCORE_IPVLAN_2_NODE_SELECTOR` | IP VLAN deploy node selector two |
+| `ECO_SYSTEM_RDSCORE_IPVLAN_DEPLOY_ONE_TARGET` | IP VLAN deploy 1 target address |
+| `ECO_SYSTEM_RDSCORE_IPVLAN_DEPLOY_ONE_TARGET_IPV6` | IP VLAN deploy 1 target address IPv6 |
+| `ECO_SYSTEM_RDSCORE_IPVLAN_DEPLOY_TWO_TARGET` | IP VLAN deploy 2 target address |
+| `ECO_SYSTEM_RDSCORE_IPVLAN_DEPLOY_TWO_TARGET_IPV6` | IP VLAN deploy 2 target address IPv6 |
+| `ECO_SYSTEM_RDSCORE_IPVLAN_DEPLOY_3_TARGET` | IP VLAN deploy 3 target address |
+| `ECO_SYSTEM_RDSCORE_IPVLAN_DEPLOY_3_TARGET_IPV6` | IP VLAN deploy 3 target address IPv6 |
+| `ECO_SYSTEM_RDSCORE_IPVLAN_DEPLOY_4_TARGET` | IP VLAN deploy 4 target address |
+| `ECO_SYSTEM_RDSCORE_IPVLAN_DEPLOY_4_TARGET_IPV6` | IP VLAN deploy 4 target address IPv6 |
+| `ECO_RDSCORE_WLKD_NROP_ONE_CMD` | Workload NROP deploy one command |
+| `ECO_RDSCORE_WLKD_SRIOV_ONE_CMD` | Workload SR-IOV deploy one command |
+| `ECO_RDSCORE_WLKD_SRIOV_TWO_CMD` | Workload SR-IOV deploy two command |
+| `ECO_RDSCORE_WLKD_SRIOV_2_ONE_CMD` | Workload SR-IOV deploy 2 one command |
+| `ECO_RDSCORE_WLKD_SRIOV_2_TWO_CMD` | Workload SR-IOV deploy 2 two command |
+| `ECO_RDSCORE_WLKD_SRIOV_3_ONE_CMD` | Workload SR-IOV deploy 3 one command |
+| `ECO_RDSCORE_WLKD_SRIOV_3_TWO_CMD` | Workload SR-IOV deploy 3 two command |
+| `ECO_RDSCORE_WLKD_SRIOV_4_ONE_CMD` | Workload SR-IOV deploy 4 one command |
+| `ECO_RDSCORE_WLKD_SRIOV_4_TWO_CMD` | Workload SR-IOV deploy 4 two command |
+| `ECO_SYSTEM_RDSCORE_MCVLAN_DEPLOY_1_CMD` | MAC VLAN deploy one command |
+| `ECO_SYSTEM_RDSCORE_MCVLAN_DEPLOY_2_CMD` | MAC VLAN deploy two command |
+| `ECO_SYSTEM_RDSCORE_MCVLAN_DEPLOY_3_CMD` | MAC VLAN deploy 3 command |
+| `ECO_SYSTEM_RDSCORE_MCVLAN_DEPLOY_4_CMD` | MAC VLAN deploy 4 command |
+| `ECO_SYSTEM_RDSCORE_IPVLAN_DEPLOY_1_CMD` | IP VLAN deploy one command |
+| `ECO_SYSTEM_RDSCORE_IPVLAN_DEPLOY_2_CMD` | IP VLAN deploy two command |
+| `ECO_SYSTEM_RDSCORE_IPVLAN_DEPLOY_3_CMD` | IP VLAN deploy 3 command |
+| `ECO_SYSTEM_RDSCORE_IPVLAN_DEPLOY_4_CMD` | IP VLAN deploy 4 command |
+| `ECO_RDSCORE_SC_CEPHFS_NAME` | Storage CephFS storage class name |
+| `ECO_RDSCORE_SC_CEPHRBD_NAME` | Storage CephRBD storage class name |
+| `ECO_RDSCORE_EGRESS_SERVICE_NS` | Egress service namespace |
+| `ECO_RDSCORE_GRACEFUL_RESTART_SERVICE_NS` | Graceful restart service namespace |
+| `ECO_RDSCORE_GRACEFUL_RESTART_SERVICE_NAME` | Graceful restart service name |
+| `ECO_RDSCORE_GRACEFUL_RESTART_SERVICE_PORT` | Graceful restart app service port |
+| `ECO_RDSCORE_EGRESS_SERVICE_REMOTE_IP` | Egress service remote IP |
+| `ECO_RDSCORE_EGRESS_SERVICE_REMOTE_IPV6` | Egress service remote IPv6 |
+| `ECO_RDSCORE_EGRESS_SERVICE_REMOTE_PORT` | Egress service remote port |
+| `ECO_RDSCORE_EGRESS_SERVICE_DEPLOY_1_CMD` | Egress service deploy 1 command |
+| `ECO_RDSCORE_EGRESS_SVC_DEPLOY_1_IMG` | Egress service deploy 1 image |
+| `ECO_RDSCORE_EGRESS_SVC_VRF_1_NET` | Egress service VRF 1 network |
+| `ECO_RDSCORE_EGRESS_SVC_DEPLOY_1_IPADDR_POOL` | Egress service deploy 1 IP address pool |
+| `ECO_RDSCORE_EGRESS_SVC_1_NODE_SELECTOR` | Egress service deploy 1 node selector |
+| `ECO_RDSCORE_EGRESS_SERVICE_DEPLOY_2_CMD` | Egress service deploy 2 command |
+| `ECO_RDSCORE_EGRESS_SVC_DEPLOY_2_IMG` | Egress service deploy 2 image |
+| `ECO_RDSCORE_EGRESS_SVC_VRF_2_NET` | Egress service VRF 2 network |
+| `ECO_RDSCORE_EGRESS_SVC_2_NODE_SELECTOR` | Egress service deploy 2 node selector |
+| `ECO_RDSCORE_EGRESS_SVC_DEPLOY_2_IPADDR_POOL` | Egress service deploy 2 IP address pool |
+| `ECO_RDSCORE_EGRESS_SERVICE_DEPLOY_3_CMD` | Egress service deploy 3 command |
+| `ECO_RDSCORE_EGRESS_SVC_DEPLOY_3_IMG` | Egress service deploy 3 image |
+| `ECO_RDSCORE_EGRESS_SVC_VRF_3_NET` | Egress service VRF 3 network |
+| `ECO_RDSCORE_EGRESS_SVC_DEPLOY_3_IPADDR_POOL` | Egress service deploy 3 IP address pool |
+| `ECO_RDSCORE_EGRESS_SVC_3_NODE_SELECTOR` | Egress service deploy 3 node selector |
+| `ECO_RDSCORE_EGRESS_SERVICE_DEPLOY_4_CMD` | Egress service deploy 4 command |
+| `ECO_RDSCORE_EGRESS_SVC_DEPLOY_4_IMG` | Egress service deploy 4 image |
+| `ECO_RDSCORE_EGRESS_SVC_VRF_4_NET` | Egress service VRF 4 network |
+| `ECO_RDSCORE_EGRESS_SVC_DEPLOY_4_IPADDR_POOL` | Egress service deploy 4 IP address pool |
+| `ECO_RDSCORE_EGRESS_SVC_4_NODE_SELECTOR` | Egress service deploy 4 node selector |
+| `ECO_RDSCORE_EGRESS_SVC_NETWORK_EXPECTED_IPS` | Egress service network expected IPs |
+| `ECO_RDSCORE_EGRESSIP_NAME` | Egress IP name |
+| `ECO_RDSCORE_EGRESSIP_DEPLOY_IMG` | Egress IP deployment image |
+| `ECO_SYSTEM_RDSCORE_EGRESSIP_NODE_ONE` | Egress IP node one |
+| `ECO_SYSTEM_RDSCORE_EGRESSIP_NODE_TWO` | Egress IP node two |
+| `ECO_SYSTEM_RDSCORE_EGRESSIP_NODE_THREE` | Egress IP node three |
+| `ECO_RDSCORE_EGRESSIP_TCP_PORT_NUMBER` | Egress IP TCP port |
+| `ECO_SYSTEM_RDSCORE_NON_EGRESSIP_NODE` | Non egress IP node |
+| `ECO_RDSCORE_EGRESSIP_NS_LABEL` | Egress IP namespace label |
+| `ECO_RDSCORE_EGRESSIP_POD_LABEL` | Egress IP pod label |
+| `ECO_RDSCORE_EGRESSIP_NS_ONE` | Egress IP namespace one |
+| `ECO_RDSCORE_EGRESSIP_NS_TWO` | Egress IP namespace two |
+| `ECO_RDSCORE_EGRESSIP_IPV4` | Egress IPv4 address |
+| `ECO_RDSCORE_EGRESSIP_IPV6` | Egress IPv6 address |
+| `ECO_RDSCORE_EGRESSIP_REMOTE_IPV4` | Egress IP remote IPv4 |
+| `ECO_RDSCORE_EGRESSIP_REMOTE_IPV6` | Egress IP remote IPv6 |
+| `ECO_RDSCORE_POD_LEVEL_BOND_PORT` | Pod level bond port |
+| `ECO_RDSCORE_POD_LEVEL_BOND_NS` | Pod level bond namespace |
+| `ECO_RDSCORE_POD_LEVEL_BOND_IMG` | Pod level bond deploy image |
+| `ECO_RDSCORE_POD_LEVEL_BOND_ONE_NAME` | Pod level bond deployment one name |
+| `ECO_RDSCORE_POD_LEVEL_BOND_TWO_NAME` | Pod level bond deployment two name |
+| `ECO_RDSCORE_POD_LEVEL_BOND_ONE_IPV4` | Pod level bond deployment one IPv4 |
+| `ECO_RDSCORE_POD_LEVEL_BOND_ONE_IPV6` | Pod level bond deployment one IPv6 |
+| `ECO_RDSCORE_POD_LEVEL_BOND_TWO_IPV4` | Pod level bond deployment two IPv4 |
+| `ECO_RDSCORE_POD_LEVEL_BOND_TWO_IPV6` | Pod level bond deployment two IPv6 |
+| `ECO_RDSCORE_POD_LEVEL_BOND_POD_ONE_NODE` | Pod level bond pod one schedule on host |
+| `ECO_RDSCORE_POD_LEVEL_BOND_POD_TWO_NODE` | Pod level bond pod two schedule on host |
+| `ECO_RDSCORE_POD_LEVEL_BOND_SRIOV_NET_ONE` | Pod level bond SR-IOV network one |
+| `ECO_RDSCORE_POD_LEVEL_BOND_SRIOV_NET_TWO` | Pod level bond SR-IOV network two |
+| `ECO_RDSCORE_POD_LEVEL_BOND_POD_SUBNET_MASK_IPV4` | Pod level bond pod subnet mask IPv4 |
+| `ECO_RDSCORE_POD_LEVEL_BOND_POD_SUBNET_MASK_IPV6` | Pod level bond pod subnet mask IPv6 |
+| `ECO_RDSCORE_POD_LEVEL_BOND_POD_MAC_ADDR` | Pod level bond pod MAC address |
+| `ECO_RDSCORE_FRR_EXPECTED_NODES` | FRR expected nodes |
+| `ECO_RDSCORE_ROOTLESS_DPDK_NS` | Rootless DPDK namespace |
+| `ECO_RDSCORE_ROOTLESS_DPDK_CLIENT_DEPLOYMENT_NAME` | Rootless DPDK client deployment name |
+| `ECO_RDSCORE_ROOTLESS_DPDK_NETWORK_ONE` | Rootless DPDK network one |
+| `ECO_RDSCORE_ROOTLESS_DPDK_NETWORK_TWO` | Rootless DPDK network two |
+| `ECO_RDSCORE_ROOTLESS_DPDK_VLAN_ID` | Rootless DPDK VLAN ID |
+| `ECO_RDSCORE_ROOTLESS_DPDK_DUMMY_VLAN_ID` | Rootless DPDK dummy VLAN ID |
+| `ECO_RDSCORE_ROOTLESS_DPDK_NODE_ONE` | Rootless DPDK node one |
+| `ECO_RDSCORE_ROOTLESS_DPDK_NODE_TWO` | Rootless DPDK node two |
+| `ECO_RDSCORE_ROOTLESS_DPDK_DEPLOYMENT_SA` | Rootless DPDK deployment service account |
+| `ECO_RDSCORE_ROOTLESS_DPDK_POLICY_TWO` | Rootless DPDK policy two |
+| `ECO_RDSCORE_ROOTLESS_DPDK_CLIENT_VLAN_MAC` | Rootless DPDK client VLAN MAC |
+| `ECO_RDSCORE_ROOTLESS_DPDK_CLIENT_MACVLAN_MAC` | Rootless DPDK client MAC VLAN MAC |
+| `ECO_RDSCORE_ROOTLESS_DPDK_CLIENT_IPVLAN_MAC` | Rootless DPDK client IP VLAN MAC |
+| `ECO_RDSCORE_ROOTLESS_DPDK_CLIENT_IPVLAN_IPV4` | Rootless DPDK client IP VLAN IPv4 |
+| `ECO_RDSCORE_ROOTLESS_DPDK_CLIENT_IPVLAN_IPV4_DUMMY` | Rootless DPDK client IP VLAN IPv4 dummy |
+| `ECO_RDSCORE_DPDK_TEST_CONTAINER` | DPDK test container |
+| `ECO_RDSCORE_KAFKA_LOGS_LABEL` | Kafka logs label |
+| `ECO_RDSCORE_WHEREABOUT_NS` | Whereabout namespace |
+| `ECO_RDSCORE_WHEREABOUTS_ST_IMAGE_ONE` | Whereabouts statefulset image one |
+| `ECO_RDSCORE_WHEREABOUTS_ST_IMAGE_TWO` | Whereabouts statefulset image two |
+| `ECO_RDSCORE_WHEREABOUTS_ST_ONE_CMD` | Whereabouts statefulset one command |
+| `ECO_RDSCORE_WHEREABOUTS_ST_TWO_CMD` | Whereabouts statefulset two command |
+| `ECO_RDSCORE_WHEREABOUTS_ST_ONE_PORT` | Whereabouts statefulset one port |
+| `ECO_RDSCORE_WHEREABOUTS_ST_TWO_PORT` | Whereabouts statefulset two port |
+| `ECO_RDSCORE_WHEREABOUTS_ST_ONE_NAD` | Whereabouts statefulset one NAD |
+| `ECO_RDSCORE_WHEREABOUTS_ST_TWO_NAD` | Whereabouts statefulset two NAD |
+| `ECO_RDSCORE_WHEREABOUTS_DEPLOY_IMAGE_ONE` | Whereabouts deploy image one |
+| `ECO_RDSCORE_WHEREABOUTS_DEPLOY_IMAGE_TWO` | Whereabouts deploy image two |
+| `ECO_RDSCORE_WHEREABOUTS_DEPLOY_ONE_CMD` | Whereabouts deploy one command |
+| `ECO_RDSCORE_WHEREABOUTS_DEPLOY_TWO_CMD` | Whereabouts deploy two command |
+| `ECO_RDSCORE_WHEREABOUTS_DEPLOY_ONE_PORT` | Whereabouts deploy one port |
+| `ECO_RDSCORE_WHEREABOUTS_DEPLOY_TWO_PORT` | Whereabouts deploy two port |
+| `ECO_RDSCORE_WHEREABOUTS_DEPLOY_ONE_NAD` | Whereabouts deploy one NAD |
+| `ECO_RDSCORE_WHEREABOUTS_DEPLOY_TWO_NAD` | Whereabouts deploy two NAD |
+| `ECO_RDSCORE_WHEREABOUTS_DEPLOY_IMAGE_3` | Whereabouts deploy image 3 |
+| `ECO_RDSCORE_WHEREABOUTS_DEPLOY_IMAGE_4` | Whereabouts deploy image 4 |
+| `ECO_RDSCORE_WHEREABOUTS_DEPLOY_3_CMD` | Whereabouts deploy 3 command |
+| `ECO_RDSCORE_WHEREABOUTS_DEPLOY_4_CMD` | Whereabouts deploy 4 command |
+| `ECO_RDSCORE_WHEREABOUTS_DEPLOY_3_PORT` | Whereabouts deploy 3 port |
+| `ECO_RDSCORE_WHEREABOUTS_DEPLOY_4_PORT` | Whereabouts deploy 4 port |
+| `ECO_RDSCORE_WHEREABOUTS_DEPLOY_3_NAD` | Whereabouts deploy 3 NAD |
+| `ECO_RDSCORE_WHEREABOUTS_DEPLOY_4_NAD` | Whereabouts deploy 4 NAD |
+| `ECO_RDSCORE_PYTHON_HTTP_SERVER_IMAGE` | Python HTTP server image |
+
 ### _VerifySRIOVWorkloadsOnSameNodeDifferentNet_
 
 This test verifies connectivity between pods that use different SR-IOV networks and are scheduled
@@ -313,3 +581,4 @@ and firewall traffic or probes sufficient to produce journal lines**
 ### _VerifyNMStateInstanceExists_
 
 Verifies that _NMState_ instance `nmstate` exists
+

--- a/tests/system-tests/spk/README.md
+++ b/tests/system-tests/spk/README.md
@@ -1,0 +1,27 @@
+# SPK
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ECO_SYSTEM_SPK_WORKLOAD_NS` | `spk-test` | Namespace for SPK workload deployment |
+| `ECO_SYSTEM_SPK_INGRESS_TCP_IPV4_URL` | _(empty)_ | IPv4 URL for TCP ingress testing |
+| `ECO_SYSTEM_SPK_INGRESS_UDP_IPV4_URL` | _(empty)_ | IPv4 URL for UDP ingress testing |
+| `ECO_SYSTEM_SPK_INGRESS_TCP_IPV6_URL` | _(empty)_ | IPv6 URL for TCP ingress testing |
+| `ECO_SYSTEM_SPK_INGRESS_UDP_IPV6_URL` | _(empty)_ | IPv6 URL for UDP ingress testing |
+| `ECO_SYSTEM_SPK_WORKLOAD_DCI_DEPLOYEMNT_NAME` | _(empty)_ | Name of the DCI workload deployment |
+| `ECO_SYSTEM_SPK_NODES_CREDENTIALS_MAP` | _(empty)_ | BMC credentials map per node (format: `node,user,pass,bmc;...`) |
+| `ECO_SYSTEM_SPK_WORKLOAD_DEPLOYMENT_IMAGE` | _(empty)_ | Container image for the SPK workload deployment |
+| `ECO_SYSTEM_SPK_BACKEND_DEPLOYMENT_IMAGE` | _(empty)_ | Container image for the SPK backend deployment |
+| `ECO_SYSTEM_SPK_WORKLOAD_DEPLOYMENT_NAME` | _(empty)_ | Name of the SPK workload deployment |
+| `ECO_SYSTEM_SPK_WORKLOAD_TEST_URL` | _(empty)_ | URL used for workload connectivity tests |
+| `ECO_SYSTEM_SPK_WORKLOAD_TEST_PORT` | _(empty)_ | Port used for workload connectivity tests |
+| `ECO_SYSTEM_SPK_DATA_NS` | _(empty)_ | Namespace for SPK data plane components |
+| `ECO_SYSTEM_SPK_DNS_NS` | _(empty)_ | Namespace for SPK DNS components |
+| `ECO_SYSTEM_SPK_UTILITIES_NS` | _(empty)_ | Namespace for SPK utilities |
+| `ECO_SYSTEM_COREDNS_NS` | _(empty)_ | Namespace for CoreDNS |
+| `ECO_SYSTEM_SPK_DATA_TMM_DEPLOY_NAME` | _(empty)_ | Deployment name for data plane TMM |
+| `ECO_SYSTEM_SPK_DNS_TMM_DEPLOY_NAME` | _(empty)_ | Deployment name for DNS TMM |
+| `ECO_SYSTEM_SPK_DATA_INGRESS_DEPLOY_NAME` | _(empty)_ | Deployment name for data plane ingress controller |
+| `ECO_SYSTEM_SPK_DNS_INGRESS_DEPLOY_NAME` | _(empty)_ | Deployment name for DNS ingress controller |
+| `ECO_SYSTEM_SPK_BACKEND_UDP_DEPLOYMENT_IMAGE` | _(empty)_ | Container image for the SPK UDP backend deployment |

--- a/tests/system-tests/vcore/README.md
+++ b/tests/system-tests/vcore/README.md
@@ -1,0 +1,21 @@
+# vCore
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ECO_SYSTEM_VCORE_NS` | `vcore-test` | Default namespace for vCore tests |
+| `ECO_SYSTEM_VCORE_ODF_MCP` | `odf` | MachineConfigPool name for ODF nodes |
+| `ECO_SYSTEM_VCORE_PP_MCP` | `user-plane-worker` | MachineConfigPool name for user plane worker nodes |
+| `ECO_SYSTEM_VCORE_CP_MCP` | `control-plane-worker` | MachineConfigPool name for control plane worker nodes |
+| `ECO_SYSTEM_VCORE_HOST` | _(empty)_ | Hostname or IP of the target host |
+| `ECO_SYSTEM_VCORE_USER` | `kni` | SSH username for the target host |
+| `ECO_SYSTEM_VCORE_PASS` | _(empty)_ | SSH password for the target host |
+| `ECO_SYSTEM_VCORE_MIRROR_REGISTRY_USER` | `ocp-edge` | Username for the mirror registry |
+| `ECO_SYSTEM_VCORE_MIRROR_REGISTRY_PASSWORD` | `ocp-edge-pass` | Password for the mirror registry |
+| `ECO_SYSTEM_VCORE_COMBINED_PULL_SECRET` | `combined-secret.json` | Filename for the combined pull secret |
+| `ECO_SYSTEM_VCORE_PRIVATE_KEY` | `.ssh/id_rsa` | Path to the SSH private key |
+| `ECO_SYSTEM_VCORE_REGISTRY_REPOSITORY` | `openshift` | Repository name in the mirror registry |
+| `ECO_SYSTEM_VCORE_CPU_ISOLATED` | `2-27,30-55` | CPU cores reserved for isolated workloads |
+| `ECO_SYSTEM_VCORE_CPU_RESERVED` | `0-1,28-29` | CPU cores reserved for system use |
+| `ECO_SYSTEM_VCORE_KUBECONFIG` | `/home/kni/clusterconfigs/auth/kubeconfig` | Path to the kubeconfig file |


### PR DESCRIPTION
- Implement a CI workflow to check that all ECO_* environment
  variables in the Go source code are documented in the relevant
  README files.
- Introduce a bash script to automate validation of environment
  variables against the README documentation, ensuring no
  undocumented or stale references exist.
- Update several README files across various test suites with
  missing ECO_* environment variable documentation to maintain
  consistency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded environment variable documentation across multiple test suites, including accel (AMD GPU, Neuron, KMM, NVIDIA GPU), CNF (RAN deployment/network), LCA (image-based install/upgrade, IP change, seed generation), OCP (SR-IOV), and system tests (disk encryption, IPsec, O-Cloud, RAN DU, RDScore, SPK, vCore).
  * Added new suite READMEs and updated existing tables for defaults, required inputs, and optional settings.

* **Chores**
  * Added automated checks to keep environment variable documentation in sync, including a new CI workflow and validation script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->