### PR TITLE
cnf ran oran: update pre-provision tests for hwMgmtDefaults

### DIFF
--- a/tests/cnf/ran/oran/internal/helper/helper.go
+++ b/tests/cnf/ran/oran/internal/helper/helper.go
@@ -42,10 +42,13 @@ func NewProvisioningRequest(client runtimeclient.Client, templateVersion string)
 	return prBuilder
 }
 
-// NewNoTemplatePR creates a ProvisioningRequest builder with templateVersion, following the schema for no
-// HardwareTemplate. All required parameters and the affix are set from RANConfig. The BMC and network data are
-// incorrect so that a ClusterInstance is generated but will not actually provision.
-func NewNoTemplatePR(client runtimeclient.Client, templateVersion string) *oran.ProvisioningRequestBuilder {
+// NewInlineBMCPR creates a ProvisioningRequest builder for ClusterTemplates that omit hwMgmtDefaults and rely on inline
+// BMC details in clusterInstanceParameters. All required parameters and the affix are set from RANConfig. The BMC and
+// network data are incorrect so that a ClusterInstance is generated but will not provision.
+//
+// Note that there is a similar scenario where the ProvisioningRequest includes hwMgmtParameters instead of the
+// ClusterTemplate's hwMgmtDefaults. This function is not for that scenario.
+func NewInlineBMCPR(client runtimeclient.Client, templateVersion string) *oran.ProvisioningRequestBuilder {
 	versionWithAffix := RANConfig.ClusterTemplateAffix + "-" + templateVersion
 	prBuilder := oran.NewPRBuilder(client, tsparams.TestPRName, tsparams.ClusterTemplateName, versionWithAffix).
 		WithTemplateParameter("nodeClusterName", RANConfig.Spoke1Name).

--- a/tests/cnf/ran/oran/internal/tsparams/consts.go
+++ b/tests/cnf/ran/oran/internal/tsparams/consts.go
@@ -58,10 +58,10 @@ const (
 	TemplateAddNew = "v10"
 	// TemplateUpdateSchema is the ClusterTemplate version for the policyTemplateParameters schema update test.
 	TemplateUpdateSchema = "v11"
-	// TemplateMissingSchema is the ClusterTemplate version for the missing schema without HardwareTemplate test.
-	TemplateMissingSchema = "v12"
-	// TemplateNoHWTemplate is the ClusterTemplate version for the successful no HardwareTemplate test.
-	TemplateNoHWTemplate = "v13"
+	// TemplateInlineBMCMissingSchema is the ClusterTemplate version for the missing inline BMC schema test (78245).
+	TemplateInlineBMCMissingSchema = "v12"
+	// TemplateInlineBMC is the ClusterTemplate version for the successful inline BMC provisioning test (78246).
+	TemplateInlineBMC = "v13"
 )
 
 const (

--- a/tests/cnf/ran/oran/internal/tsparams/oranvars.go
+++ b/tests/cnf/ran/oran/internal/tsparams/oranvars.go
@@ -77,8 +77,9 @@ var (
 		Status: metav1.ConditionTrue,
 	}
 
-	// CTInvalidSchemaCondition is the ClusterTemplate condition where the validation failed due to invalid schema.
-	CTInvalidSchemaCondition = metav1.Condition{
+	// CTInvalidInlineBMCSchemaCondition is the ClusterTemplate condition where validation failed because
+	// clusterInstanceParameters is missing the inline BMC fields required when hwMgmtDefaults is omitted.
+	CTInvalidInlineBMCSchemaCondition = metav1.Condition{
 		Type:    string(provisioningv1alpha1.CTconditionTypes.Validated),
 		Reason:  string(provisioningv1alpha1.CTconditionReasons.Failed),
 		Status:  metav1.ConditionFalse,

--- a/tests/cnf/ran/oran/tests/oran-pre-provision.go
+++ b/tests/cnf/ran/oran/tests/oran-pre-provision.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	provisioningv1alpha1 "github.com/openshift-kni/oran-o2ims/api/provisioning/v1alpha1"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/oran"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
 	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/ran/internal/raninittools"
@@ -39,20 +40,30 @@ var _ = Describe("ORAN Pre-provision Tests", Label(tsparams.LabelPreProvision), 
 		Expect(err).To(HaveOccurred(), "Creating a ProvisioningRequest with an invalid ClusterTemplate should fail")
 	})
 
-	// 78245 - Missing schema while provisioning without hardware template
-	It("fails to provision without a HardwareTemplate when required schema is missing", reportxml.ID("78245"), func() {
-		By("verifying the ClusterTemplate validation failed with invalid schema message")
+	// 78245 - ClusterTemplate validation fails when inline BMC schema is missing without hwMgmtDefaults
+	It("fails ClusterTemplate validation when inline BMC schema is missing without hwMgmtDefaults",
+		reportxml.ID("78245"), func() {
+			clusterTemplateName := fmt.Sprintf("%s.%s-%s",
+				tsparams.ClusterTemplateName, RANConfig.ClusterTemplateAffix, tsparams.TemplateInlineBMCMissingSchema)
+			clusterTemplateNamespace := tsparams.ClusterTemplateName + "-" + RANConfig.ClusterTemplateAffix
 
-		clusterTemplateName := fmt.Sprintf("%s.%s-%s",
-			tsparams.ClusterTemplateName, RANConfig.ClusterTemplateAffix, tsparams.TemplateMissingSchema)
-		clusterTemplateNamespace := tsparams.ClusterTemplateName + "-" + RANConfig.ClusterTemplateAffix
+			By("pulling the ClusterTemplate that omits hwMgmtDefaults and inline BMC schema")
 
-		clusterTemplate, err := oran.PullClusterTemplate(HubAPIClient, clusterTemplateName, clusterTemplateNamespace)
-		Expect(err).ToNot(HaveOccurred(), "Failed to pull ClusterTemplate with missing schema")
+			clusterTemplate, err := oran.PullClusterTemplate(HubAPIClient, clusterTemplateName, clusterTemplateNamespace)
+			Expect(err).ToNot(HaveOccurred(), "Failed to pull ClusterTemplate with missing inline BMC schema")
 
-		_, err = clusterTemplate.WaitForCondition(tsparams.CTInvalidSchemaCondition, time.Minute)
-		Expect(err).ToNot(HaveOccurred(), "Failed to verify the ClusterTemplate validation failed due to invalid schema")
-	})
+			By("verifying the ClusterTemplate omits hwMgmtDefaults and hwMgmtParameters")
+			Expect(clusterTemplate.Definition.Spec.TemplateDefaults.HwMgmtDefaults.NodeGroupData).To(BeEmpty(),
+				"ClusterTemplate defines hwMgmtDefaults nodeGroupData when it should not")
+			Expect(provisioningv1alpha1.SchemaDefinesHwMgmtParameters(clusterTemplate.Definition)).To(BeFalse(),
+				"ClusterTemplate defines hwMgmtParameters in its schema when it should not")
+
+			By("waiting for ClusterTemplate validation to fail due to missing inline BMC fields in the schema")
+
+			_, err = clusterTemplate.WaitForCondition(tsparams.CTInvalidInlineBMCSchemaCondition, time.Minute)
+			Expect(err).ToNot(HaveOccurred(),
+				"Failed to verify the ClusterTemplate validation failed due to missing inline BMC schema")
+		})
 
 	When("a ProvisioningRequest is created", func() {
 		AfterEach(func() {
@@ -65,18 +76,34 @@ var _ = Describe("ORAN Pre-provision Tests", Label(tsparams.LabelPreProvision), 
 			}
 		})
 
-		// 78246 - Successful provisioning without hardware template
-		It("successfully generates ClusterInstance provisioning without HardwareTemplate", reportxml.ID("78246"), func() {
-			By("creating a ProvisioningRequest")
+		// 78246 - Successful ClusterInstance generation with inline BMC without hwMgmtDefaults
+		It("successfully generates ClusterInstance with inline BMC without hwMgmtDefaults", reportxml.ID("78246"), func() {
+			clusterTemplateName := fmt.Sprintf("%s.%s-%s",
+				tsparams.ClusterTemplateName, RANConfig.ClusterTemplateAffix, tsparams.TemplateInlineBMC)
+			clusterTemplateNamespace := tsparams.ClusterTemplateName + "-" + RANConfig.ClusterTemplateAffix
 
-			prBuilder := helper.NewNoTemplatePR(o2imsAPIClient, tsparams.TemplateNoHWTemplate)
-			_, err := prBuilder.Create()
+			By("pulling the ClusterTemplate that defines inline BMC schema without hwMgmtDefaults")
+
+			clusterTemplate, err := oran.PullClusterTemplate(HubAPIClient, clusterTemplateName, clusterTemplateNamespace)
+			Expect(err).ToNot(HaveOccurred(), "Failed to pull ClusterTemplate with inline BMC schema")
+
+			By("verifying the ClusterTemplate omits hwMgmtDefaults and hwMgmtParameters")
+			Expect(clusterTemplate.Definition.Spec.TemplateDefaults.HwMgmtDefaults.NodeGroupData).To(BeEmpty(),
+				"ClusterTemplate defines hwMgmtDefaults nodeGroupData when it should not")
+			Expect(provisioningv1alpha1.SchemaDefinesHwMgmtParameters(clusterTemplate.Definition)).To(BeFalse(),
+				"ClusterTemplate defines hwMgmtParameters in its schema when it should not")
+
+			By("creating a ProvisioningRequest with inline BMC details in clusterInstanceParameters")
+
+			prBuilder := helper.NewInlineBMCPR(o2imsAPIClient, tsparams.TemplateInlineBMC)
+			_, err = prBuilder.Create()
 			Expect(err).ToNot(HaveOccurred(), "Failed to create a ProvisioningRequest")
 
 			By("waiting for its ClusterInstance to be created and validated")
 
 			err = helper.WaitForValidPRClusterInstance(HubAPIClient, 3*time.Minute)
-			Expect(err).ToNot(HaveOccurred(), "Failed to wait for ClusterInstance to be created and have its templates applied")
+			Expect(err).ToNot(HaveOccurred(),
+				"Failed to wait for ClusterInstance to be created and have its templates applied")
 		})
 	})
 })


### PR DESCRIPTION
Version 4.22 of the oran-o2ims operator transitioned from the
HardwareTemplate CR to the concept of hwMgmtDefaults and
hwMgmtParameters. This affects the two pre-provisioning test cases 78245
and 78246.

While the tests remain largely the same, the specific
terminology has been updated to be in line with the new fields.
Additionally, a few checks have been implemented to ensure in the tests
that the versions of the ClusterTemplates are structured as expected.

The titles of the tests have similarly changed.

Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated validation coverage for cluster templates that use inline BMC details, including clearer handling when required fields are missing.
  * Added scenarios that verify provisioning requests behave correctly with inline BMC data and fail validation when configuration is incomplete.

* **Tests**
  * Expanded end-to-end test coverage for pre-provision flows to reflect the latest inline BMC template variants and expected validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->