### PR TITLE
system-tests: fix Whereabouts ConfigMap loss after cluster reboot

### DIFF
--- a/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-deployment.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-deployment.go
@@ -553,6 +553,9 @@ func CreateWhereaboutsDeployment(ctx SpecContext, config WhereaboutsDeploymentCo
 
 	By(fmt.Sprintf("Setting up deployment with %s", config.Description))
 
+	// Configure whereabouts reconciler to run every 3 minutes
+	ConfigureWhereaboutsIPReconciler()
+
 	cleanupDeployment(config.Name, RDSCoreConfig.WhereaboutNS, config.Label)
 
 	waBuilder := createDeploymentBuilder(config)

--- a/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-statefulset.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-statefulset.go
@@ -1639,6 +1639,9 @@ func CreateWhereaboutsStatefulset(ctx SpecContext, config StatefulsetConfig) {
 	Expect(config.NAD).ToNot(BeEmpty(),
 		"NetworkAttachmentDefinition must be set for statefulset %q", config.Name)
 
+	// Configure whereabouts reconciler to run every 3 minutes
+	ConfigureWhereaboutsIPReconciler()
+
 	// Cleanup existing statefulset FIRST (before deleting service)
 	// This ensures pods fully terminate and release their endpoints
 	// before the service and its EndpointSlices are deleted
@@ -1673,6 +1676,77 @@ func CreateWhereaboutsStatefulset(ctx SpecContext, config StatefulsetConfig) {
 	VerifyPodConnectivity(config.Label, RDSCoreConfig.WhereaboutNS, interfaceName, parsedPort)
 }
 
+// ConfigureWhereaboutsIPReconciler configures whereabouts IP reconciler to run every 3 minutes.
+func ConfigureWhereaboutsIPReconciler() {
+	By(fmt.Sprintf("Checking if configmap %q exists in %q namespace",
+		WhereaboutsReconcilerCMName, WhereaboutsReconcilerNamespace))
+
+	var ctx SpecContext
+
+	cmWhereabouts, err := configmap.Pull(APIClient, WhereaboutsReconcilerCMName, WhereaboutsReconcilerNamespace)
+	if err == nil {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Configmap %q exists in %q namespace, updating it",
+			WhereaboutsReconcilerCMName, WhereaboutsReconcilerNamespace)
+
+		if oldSchedule, ok := cmWhereabouts.Object.Data[WhereaboutsReconcilerKey]; ok {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Key %q already exists in configmap %q in %q namespace, updating it",
+				WhereaboutsReconcilerKey, WhereaboutsReconcilerCMName, WhereaboutsReconcilerNamespace)
+
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Old schedule: %q", oldSchedule)
+		} else {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Key %q does not exist in configmap %q in %q namespace, adding it",
+				WhereaboutsReconcilerKey, WhereaboutsReconcilerCMName, WhereaboutsReconcilerNamespace)
+		}
+
+		// Initialize Data map if nil before writing
+		if cmWhereabouts.Object.Data == nil {
+			cmWhereabouts.Object.Data = make(map[string]string)
+		}
+
+		cmWhereabouts.Object.Data[WhereaboutsReconcilerKey] = WhereaboutsReconcilerSchedule
+
+		By(fmt.Sprintf("Updating configmap %q in %q namespace",
+			WhereaboutsReconcilerCMName, WhereaboutsReconcilerNamespace))
+
+		Eventually(func() error {
+			_, updateErr := cmWhereabouts.Update()
+			if updateErr != nil {
+				klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+					"Failed to update ConfigMap, retrying: %v", updateErr)
+
+				// Re-pull ConfigMap to get latest resourceVersion
+				freshCM, pullErr := configmap.Pull(APIClient, WhereaboutsReconcilerCMName, WhereaboutsReconcilerNamespace)
+				if pullErr != nil {
+					return pullErr
+				}
+
+				// Re-apply the schedule to the fresh ConfigMap
+				if freshCM.Object.Data == nil {
+					freshCM.Object.Data = make(map[string]string)
+				}
+
+				freshCM.Object.Data[WhereaboutsReconcilerKey] = WhereaboutsReconcilerSchedule
+				cmWhereabouts = freshCM
+
+				return updateErr
+			}
+
+			return nil
+		}).WithContext(ctx).WithPolling(15*time.Second).WithTimeout(1*time.Minute).Should(Succeed(),
+			"Failed to update configmap %q in %q namespace", WhereaboutsReconcilerCMName, WhereaboutsReconcilerNamespace)
+	} else {
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Configmap %q does not exist in %q namespace, creating it",
+			WhereaboutsReconcilerCMName, WhereaboutsReconcilerNamespace)
+
+		By(fmt.Sprintf("Configuring whereabouts reconciler with configmap %q in %q namespace",
+			WhereaboutsReconcilerCMName, WhereaboutsReconcilerNamespace))
+
+		createConfigMap(WhereaboutsReconcilerCMName, WhereaboutsReconcilerNamespace, map[string]string{
+			WhereaboutsReconcilerKey: WhereaboutsReconcilerSchedule,
+		})
+	}
+}
+
 // ReconcilerConfigState holds the original state of the reconciler configuration.
 type ReconcilerConfigState struct {
 	OriginalSchedule   string
@@ -1682,6 +1756,11 @@ type ReconcilerConfigState struct {
 
 // ConfigureWhereaboutsReconciler configures the Whereabouts reconciler to run every 3 minutes
 // and returns the original configuration state for later restoration.
+//
+// NOTE: Currently unused - configureWhereaboutsIPReconciler() is used instead.
+// This function was part of the restoration-based approach that had issues with
+// sync.Once across reboot contexts (ConfigMap lost after reboot but sync.Once prevented
+// reconfiguration). Kept for reference.
 //
 //nolint:funlen
 func ConfigureWhereaboutsReconciler() (*ReconcilerConfigState, error) {
@@ -1790,6 +1869,8 @@ func ConfigureWhereaboutsReconciler() (*ReconcilerConfigState, error) {
 }
 
 // RestoreWhereaboutsReconciler restores the Whereabouts reconciler configuration to its original state.
+//
+// NOTE: Currently unused - kept for reference. See ConfigureWhereaboutsReconciler comment for details.
 //
 //nolint:funlen
 func RestoreWhereaboutsReconciler(state *ReconcilerConfigState) error {

--- a/tests/system-tests/rdscore/tests/00_validate_top_level.go
+++ b/tests/system-tests/rdscore/tests/00_validate_top_level.go
@@ -2,7 +2,6 @@ package rds_core_system_test
 
 import (
 	"fmt"
-	"sync"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -19,65 +18,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 )
-
-// Package-level variables for Whereabouts reconciler configuration.
-var (
-	reconcilerConfigState    *rdscorecommon.ReconcilerConfigState
-	reconcilerConfigureOnce  sync.Once
-	reconcilerRestoreOnce    sync.Once
-	errReconcilerConfigure   error
-	reconcilerConfigStateMux sync.Mutex
-)
-
-// configureWhereaboutsReconcilerOnce configures the Whereabouts reconciler once across all contexts.
-func configureWhereaboutsReconcilerOnce() {
-	reconcilerConfigureOnce.Do(func() {
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
-			"Configuring Whereabouts reconciler (first Whereabouts context)")
-
-		state, err := rdscorecommon.ConfigureWhereaboutsReconciler()
-		if err != nil {
-			klog.Errorf("Failed to configure Whereabouts reconciler: %v", err)
-			errReconcilerConfigure = err
-
-			return
-		}
-
-		reconcilerConfigStateMux.Lock()
-		reconcilerConfigState = state
-		reconcilerConfigStateMux.Unlock()
-
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
-			"Whereabouts reconciler configured successfully")
-	})
-}
-
-// restoreWhereaboutsReconcilerOnce restores the Whereabouts reconciler once after all contexts complete.
-func restoreWhereaboutsReconcilerOnce() {
-	reconcilerRestoreOnce.Do(func() {
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
-			"Restoring Whereabouts reconciler configuration")
-
-		reconcilerConfigStateMux.Lock()
-		state := reconcilerConfigState
-		reconcilerConfigStateMux.Unlock()
-
-		if state == nil {
-			klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
-				"No reconciler state to restore")
-
-			return
-		}
-
-		err := rdscorecommon.RestoreWhereaboutsReconciler(state)
-		if err != nil {
-			klog.Errorf("Failed to restore Whereabouts reconciler: %v", err)
-		} else {
-			klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
-				"Whereabouts reconciler configuration restored successfully")
-		}
-	})
-}
 
 var _ = Describe(
 	"RDS Core Top Level Suite",
@@ -354,16 +294,9 @@ var _ = Describe(
 
 			Context("Whereabouts IPAM Validation", Ordered, Label("whereabouts"), func() {
 				BeforeAll(func(ctx SpecContext) {
-					By("Configuring Whereabouts reconciler (once across all Whereabouts contexts)")
+					By("Configuring Whereabouts reconciler")
 
-					configureWhereaboutsReconcilerOnce()
-					Expect(errReconcilerConfigure).ToNot(HaveOccurred(),
-						"Failed to configure Whereabouts reconciler")
-
-					// Schedule restoration to run after all Whereabouts contexts complete
-					DeferCleanup(func() {
-						restoreWhereaboutsReconcilerOnce()
-					})
+					rdscorecommon.ConfigureWhereaboutsIPReconciler()
 
 					By("Verifying Whereabouts reconciler health")
 
@@ -804,16 +737,9 @@ var _ = Describe(
 
 			Context("Whereabouts Post-Reboot Validation", Ordered, Label("whereabouts"), func() {
 				BeforeAll(func(ctx SpecContext) {
-					By("Configuring Whereabouts reconciler (once across all Whereabouts contexts)")
+					By("Configuring Whereabouts reconciler after reboot")
 
-					configureWhereaboutsReconcilerOnce()
-					Expect(errReconcilerConfigure).ToNot(HaveOccurred(),
-						"Failed to configure Whereabouts reconciler")
-
-					// Schedule restoration to run after all Whereabouts contexts complete
-					DeferCleanup(func() {
-						restoreWhereaboutsReconcilerOnce()
-					})
+					rdscorecommon.ConfigureWhereaboutsIPReconciler()
 
 					By("Verifying Whereabouts reconciler health after reboot")
 
@@ -1169,16 +1095,9 @@ var _ = Describe(
 
 			Context("Whereabouts Post-Reboot Validation", Ordered, Label("whereabouts"), func() {
 				BeforeAll(func(ctx SpecContext) {
-					By("Configuring Whereabouts reconciler (once across all Whereabouts contexts)")
+					By("Configuring Whereabouts reconciler after reboot")
 
-					configureWhereaboutsReconcilerOnce()
-					Expect(errReconcilerConfigure).ToNot(HaveOccurred(),
-						"Failed to configure Whereabouts reconciler")
-
-					// Schedule restoration to run after all Whereabouts contexts complete
-					DeferCleanup(func() {
-						restoreWhereaboutsReconcilerOnce()
-					})
+					rdscorecommon.ConfigureWhereaboutsIPReconciler()
 
 					By("Verifying Whereabouts reconciler health after reboot")
 


### PR DESCRIPTION
Fix regression introduced in commit 6005b9b5 where Whereabouts reconciler ConfigMap was not recreated after cluster reboots, causing post-reboot tests to fail with "configmaps 'whereabouts-config' not found".

Root cause:
- sync.Once pattern prevented ConfigMap reconfiguration after cluster reboots
- First context (before reboot): sync.Once fires → ConfigMap created
- Cluster reboots → ConfigMap lost (ephemeral test resource)
- Second context (after reboot): sync.Once skips → ConfigMap NOT recreated
- VerifyWhereaboutsReconcilerHealth() fails with ConfigMap not found

Solution:
Restore the original simple behavior from before commit 6005b9b5:
- Add configureWhereaboutsIPReconciler() function
- Call it inside CreateWhereaboutsStatefulset() on every invocation
- Remove broken sync.Once coordination logic from test contexts
- ConfigMap now recreated after every reboot automatically

Changes:
- whereabouts-statefulset.go:
  * Added creWhereaboutsIPReconciler() (simple config, no state tracking)
  * Added call in CreateWhereaboutsStatefulset() after NAD validation
  * Marked ConfigureWhereaboutsReconciler/RestoreWhereaboutsReconciler as unused

- 00_validate_top_level.go:
  * Removed sync.Once package-level variables and helper functions
  * Removed configuration/restoration logic from 3 Whereabouts contexts
  * Simplified BeforeAll hooks to only verify reconciler health

Trade-off:
- Lost: ConfigMap restoration to original state after tests
- Gained: Reliable behavior across cluster reboots, simpler code

The ConfigMap modification is non-destructive (sets schedule to */3 * * * *) and test environments don't require pristine cluster state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved Whereabouts IP reconciler system-test setup to ensure the reconciler ConfigMap exists and uses a standardized `*/3 * * * *` cron schedule (with safe retry on update failures).
  * Updated deployment/statefulset preparation to configure the reconciler before any cleanup/create steps, then proceed with reconciler health/cycle checks and IPAM validation.
* **Chores**
  * Removed the unused “configure once / restore once” reconciler helpers and updated validation contexts to set up the reconciler directly without any deferred restore step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->