### PR TITLE
neuron: add in-cluster build support and test suite

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -277,7 +277,7 @@ require (
 )
 
 require (
-	github.com/rh-ecosystem-edge/eco-goinfra v0.0.0-20260618190922-866a3518ded5
+	github.com/rh-ecosystem-edge/eco-goinfra v0.0.0-20260619181221-bf7069adc99d
 	k8s.io/apiextensions-apiserver v0.35.5
 )
 

--- a/go.sum
+++ b/go.sum
@@ -705,8 +705,8 @@ github.com/red-hat-storage/odf-operator v0.0.0-20260226164309-08c71191d483 h1:I8
 github.com/red-hat-storage/odf-operator v0.0.0-20260226164309-08c71191d483/go.mod h1:ezzeJZeZyinngGE5Ox4wAZg6w+Bdu7/9PtdQeV3fXUk=
 github.com/redhat-cne/sdk-go v1.23.6 h1:L+Rs12UihwDBJc/tj1eEMc4Otf7Lxf0bkFjdsg7FPGA=
 github.com/redhat-cne/sdk-go v1.23.6/go.mod h1:5hK1sILdB33pdMsNYTyBKV/v5GjjibmQZcyRtVrVfvs=
-github.com/rh-ecosystem-edge/eco-goinfra v0.0.0-20260618190922-866a3518ded5 h1:jqTqOOHhBiLwdWboBoX2nksFp7kvXou32hVtLpgyz+w=
-github.com/rh-ecosystem-edge/eco-goinfra v0.0.0-20260618190922-866a3518ded5/go.mod h1:lJ1JIy4Y6PSN2k7xYrNR7kuBcFf7k8QXB/ZYMG/sY/4=
+github.com/rh-ecosystem-edge/eco-goinfra v0.0.0-20260619181221-bf7069adc99d h1:Vu2czjXpvh0AnygaDgiSLFM/NdQEH/+y91iTNiRJxV4=
+github.com/rh-ecosystem-edge/eco-goinfra v0.0.0-20260619181221-bf7069adc99d/go.mod h1:lJ1JIy4Y6PSN2k7xYrNR7kuBcFf7k8QXB/ZYMG/sY/4=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=

--- a/tests/hw-accel/neuron/3upgrade/tests/upgrade-test.go
+++ b/tests/hw-accel/neuron/3upgrade/tests/upgrade-test.go
@@ -110,7 +110,8 @@ var _ = Describe("Neuron Rolling Upgrade Tests", Ordered, Label(params.Label), L
 
 				isStale := false
 				if neuronConfig.IsInClusterBuild() {
-					isStale = existingDC.Definition.Spec.DriverVersion != neuronConfig.DriverVersion
+					isStale = existingDC.Definition.Spec.DriverVersion != neuronConfig.DriverVersion ||
+						existingDC.Definition.Spec.DriversImage != ""
 				} else {
 					isStale = existingDC.Definition.Spec.DriversImage != neuronConfig.DriversImage
 				}

--- a/tests/hw-accel/neuron/3upgrade/tests/upgrade-test.go
+++ b/tests/hw-accel/neuron/3upgrade/tests/upgrade-test.go
@@ -42,8 +42,8 @@ var _ = Describe("Neuron Rolling Upgrade Tests", Ordered, Label(params.Label), L
 
 			if !neuronConfig.IsUpgradeConfigured() {
 				Skip("Upgrade configuration is not set - " +
-					"ECO_HWACCEL_NEURON_UPGRADE_TARGET_VERSION and " +
-					"ECO_HWACCEL_NEURON_UPGRADE_TARGET_DRIVERS_IMAGE are required")
+					"ECO_HWACCEL_NEURON_UPGRADE_TARGET_VERSION is required " +
+					"(ECO_HWACCEL_NEURON_UPGRADE_TARGET_DRIVERS_IMAGE also required in pre-built image mode)")
 			}
 
 			By("Verifying all required operators are ready")
@@ -100,34 +100,25 @@ var _ = Describe("Neuron Rolling Upgrade Tests", Ordered, Label(params.Label), L
 
 			By("Creating initial DeviceConfig with driver version")
 
-			builder := neuron.NewBuilder(
-				APIClient,
-				params.DefaultDeviceConfigName,
-				params.NeuronNamespace,
-				neuronConfig.DriversImage,
-				neuronConfig.DriverVersion,
-				neuronConfig.DevicePluginImage,
-			).WithSelector(map[string]string{
-				params.NeuronNFDLabelKey: params.NeuronNFDLabelValue,
-			}).WithNodeMetricsImage(neuronConfig.NodeMetricsImage)
-
-			if neuronConfig.SchedulerImage != "" && neuronConfig.SchedulerExtensionImage != "" {
-				builder = builder.WithScheduler(neuronConfig.SchedulerImage, neuronConfig.SchedulerExtensionImage)
-			}
-
-			if neuronConfig.ImageRepoSecretName != "" {
-				builder = builder.WithImageRepoSecret(neuronConfig.ImageRepoSecretName)
-			}
+			builder := neuronhelpers.NewDeviceConfigBuilder(APIClient, neuronConfig)
+			Expect(builder).ToNot(BeNil(), "Failed to create DeviceConfig builder")
 
 			if builder.Exists() {
 				existingDC, pullErr := neuron.Pull(
 					APIClient, params.DefaultDeviceConfigName, params.NeuronNamespace)
 				Expect(pullErr).ToNot(HaveOccurred(), "Failed to pull existing DeviceConfig")
 
-				if existingDC.Definition.Spec.DriversImage != neuronConfig.DriversImage {
+				isStale := false
+				if neuronConfig.IsInClusterBuild() {
+					isStale = existingDC.Definition.Spec.DriverVersion != neuronConfig.DriverVersion
+				} else {
+					isStale = existingDC.Definition.Spec.DriversImage != neuronConfig.DriversImage
+				}
+
+				if isStale {
 					klog.V(params.NeuronLogLevel).Infof(
-						"DeviceConfig has stale image %s, recreating with initial version %s",
-						existingDC.Definition.Spec.DriversImage, neuronConfig.DriversImage)
+						"DeviceConfig is stale, recreating with initial version %s",
+						neuronConfig.DriverVersion)
 
 					_, deleteErr := existingDC.Delete()
 					Expect(deleteErr).ToNot(HaveOccurred(), "Failed to delete stale DeviceConfig")
@@ -274,8 +265,11 @@ var _ = Describe("Neuron Rolling Upgrade Tests", Ordered, Label(params.Label), L
 					APIClient, params.DefaultDeviceConfigName, params.NeuronNamespace)
 				Expect(err).ToNot(HaveOccurred(), "Failed to pull DeviceConfig")
 
-				deviceConfigBuilder.Definition.Spec.DriversImage = neuronConfig.UpgradeTargetDriversImage
 				deviceConfigBuilder.Definition.Spec.DriverVersion = neuronConfig.UpgradeTargetVersion
+
+				if !neuronConfig.IsInClusterBuild() {
+					deviceConfigBuilder.Definition.Spec.DriversImage = neuronConfig.UpgradeTargetDriversImage
+				}
 
 				if neuronConfig.SchedulerImage != "" && neuronConfig.SchedulerExtensionImage != "" {
 					deviceConfigBuilder = deviceConfigBuilder.WithScheduler(
@@ -427,10 +421,17 @@ var _ = Describe("Neuron Rolling Upgrade Tests", Ordered, Label(params.Label), L
 					APIClient, params.DefaultDeviceConfigName, params.NeuronNamespace)
 				Expect(err).ToNot(HaveOccurred(), "Failed to get DeviceConfig")
 
-				driversImage := deviceConfigBuilder.Definition.Spec.DriversImage
-				klog.V(params.NeuronLogLevel).Infof("DeviceConfig driversImage: %s", driversImage)
-				Expect(driversImage).To(Equal(neuronConfig.UpgradeTargetDriversImage),
-					"DeviceConfig should have the new drivers image")
+				driverVersion := deviceConfigBuilder.Definition.Spec.DriverVersion
+				klog.V(params.NeuronLogLevel).Infof("DeviceConfig driverVersion: %s", driverVersion)
+				Expect(driverVersion).To(Equal(neuronConfig.UpgradeTargetVersion),
+					"DeviceConfig should have the new driver version")
+
+				if !neuronConfig.IsInClusterBuild() {
+					driversImage := deviceConfigBuilder.Definition.Spec.DriversImage
+					klog.V(params.NeuronLogLevel).Infof("DeviceConfig driversImage: %s", driversImage)
+					Expect(driversImage).To(Equal(neuronConfig.UpgradeTargetDriversImage),
+						"DeviceConfig should have the new drivers image")
+				}
 
 				By("Verifying new device plugin pods are running")
 

--- a/tests/hw-accel/neuron/inclusterbuild/inclusterbuild_suite_test.go
+++ b/tests/hw-accel/neuron/inclusterbuild/inclusterbuild_suite_test.go
@@ -1,0 +1,34 @@
+package inclusterbuild
+
+import (
+	"runtime"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	_ "github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/inclusterbuild/tests"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/internal/inittools"
+)
+
+var _, currentFile, _, _ = runtime.Caller(0)
+
+func TestInclusterbuild(t *testing.T) {
+	_, reporterConfig := GinkgoConfiguration()
+	reporterConfig.JUnitReport = GeneralConfig.GetJunitReportPath(currentFile)
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Neuron InClusterBuild Suite", reporterConfig)
+}
+
+var _ = BeforeSuite(func() {
+	By("Setting up Neuron InClusterBuild test suite")
+})
+
+var _ = AfterSuite(func() {
+	By("Tearing down Neuron InClusterBuild test suite")
+})
+
+var _ = ReportAfterSuite("", func(report Report) {
+	reportxml.Create(report, GeneralConfig.GetReportPath(), GeneralConfig.TCPrefix)
+})

--- a/tests/hw-accel/neuron/inclusterbuild/internal/tsparams/consts.go
+++ b/tests/hw-accel/neuron/inclusterbuild/internal/tsparams/consts.go
@@ -1,0 +1,18 @@
+package tsparams
+
+import "time"
+
+const (
+	// LabelSuite represents in-cluster build test suite label.
+	LabelSuite = "inclusterbuild"
+
+	// InClusterBuildTestNamespace represents the namespace for in-cluster build tests.
+	InClusterBuildTestNamespace = "neuron-inclusterbuild-test"
+
+	// BuildConfigMapTimeout represents the timeout for the Dockerfile ConfigMap to be created.
+	BuildConfigMapTimeout = 5 * time.Minute
+	// DevicePluginReadyTimeout represents the timeout for device plugin readiness.
+	DevicePluginReadyTimeout = 15 * time.Minute
+	// OperatorDeployTimeout represents the timeout for operator deployment.
+	OperatorDeployTimeout = 10 * time.Minute
+)

--- a/tests/hw-accel/neuron/inclusterbuild/tests/inclusterbuild-test.go
+++ b/tests/hw-accel/neuron/inclusterbuild/tests/inclusterbuild-test.go
@@ -1,0 +1,167 @@
+package tests
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/deployment"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/namespace"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/neuron"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/inclusterbuild/internal/tsparams"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/internal/await"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/internal/check"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/internal/neuronconfig"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/internal/neuronhelpers"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/params"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/internal/inittools"
+	"k8s.io/klog/v2"
+)
+
+var _ = Describe("Neuron In-Cluster Build Tests", Ordered,
+	Label(params.Label, params.LabelSuite, params.InClusterBuildLabel), func() {
+		Context("Module with in-cluster build", Label(tsparams.LabelSuite), func() {
+			neuronConfig := neuronconfig.NewNeuronConfig()
+
+			BeforeAll(func() {
+				By("Verifying in-cluster build configuration")
+
+				if !neuronConfig.IsValid() {
+					Skip("Neuron configuration is not valid - DriverVersion and DevicePluginImage are required")
+				}
+
+				if !neuronConfig.IsInClusterBuild() {
+					Skip("Not configured for in-cluster build - DriversImage is set, skipping in-cluster build tests")
+				}
+
+				By("Verifying NFD operator is ready")
+				nfdDeploy, err := deployment.Pull(APIClient, "nfd-controller-manager", "openshift-nfd")
+				Expect(err).ToNot(HaveOccurred(), "NFD operator deployment not found")
+				Expect(nfdDeploy.IsReady(30 * time.Second)).To(BeTrue(), "NFD operator must be ready")
+
+				By("Verifying KMM operator is ready")
+				kmmDeploy, err := deployment.Pull(APIClient, "kmm-operator-controller", "openshift-kmm")
+				Expect(err).ToNot(HaveOccurred(), "KMM operator deployment not found")
+				Expect(kmmDeploy.IsReady(30 * time.Second)).To(BeTrue(), "KMM operator must be ready")
+
+				By("Verifying Neuron operator is ready")
+				neuronDeploy, err := deployment.Pull(
+					APIClient, "awslabs-gpu-operator-controller-manager", params.NeuronNamespace)
+				Expect(err).ToNot(HaveOccurred(), "Neuron operator deployment not found")
+				Expect(neuronDeploy.IsReady(30 * time.Second)).To(BeTrue(), "Neuron operator must be ready")
+
+				By("Creating DeviceConfig with in-cluster build (no DriversImage)")
+
+				builder := neuron.NewBuilderWithInClusterBuild(
+					APIClient,
+					params.DefaultDeviceConfigName,
+					params.NeuronNamespace,
+					neuronConfig.DriverVersion,
+					neuronConfig.DevicePluginImage,
+				).WithSelector(map[string]string{
+					params.NeuronNFDLabelKey: params.NeuronNFDLabelValue,
+				}).WithNodeMetricsImage(neuronConfig.NodeMetricsImage)
+
+				if neuronConfig.SchedulerImage != "" && neuronConfig.SchedulerExtensionImage != "" {
+					builder = builder.WithScheduler(neuronConfig.SchedulerImage, neuronConfig.SchedulerExtensionImage)
+				}
+
+				if neuronConfig.ImageRepoSecretName != "" {
+					builder = builder.WithImageRepoSecret(neuronConfig.ImageRepoSecretName)
+				}
+
+				if !builder.Exists() {
+					_, err := builder.Create()
+					Expect(err).ToNot(HaveOccurred(), "Failed to create DeviceConfig for in-cluster build")
+				}
+
+				By("Waiting for cluster stability after DeviceConfig")
+
+				err = neuronhelpers.WaitForClusterStabilityAfterDeviceConfig(APIClient)
+				Expect(err).ToNot(HaveOccurred(), "Cluster not stable after DeviceConfig")
+
+				By("Waiting for Neuron nodes to be labeled")
+
+				err = await.NeuronNodesLabeled(APIClient, tsparams.OperatorDeployTimeout)
+				Expect(err).ToNot(HaveOccurred(), "No Neuron-labeled nodes found")
+			})
+
+			AfterAll(func() {
+				By("Cleaning up in-cluster build test resources")
+
+				nsBuilder := namespace.NewBuilder(APIClient, tsparams.InClusterBuildTestNamespace)
+				if nsBuilder.Exists() {
+					err := nsBuilder.Delete()
+					if err != nil {
+						klog.V(params.NeuronLogLevel).Infof("Failed to delete test namespace: %v", err)
+					}
+				}
+			})
+
+			It("should create the Dockerfile ConfigMap", reportxml.ID("88201"), func() {
+				By("Waiting for the build ConfigMap to be created by the operator")
+
+				err := await.BuildConfigMapCreated(
+					APIClient,
+					params.NeuronNamespace,
+					params.DefaultDeviceConfigName,
+					tsparams.BuildConfigMapTimeout,
+				)
+				Expect(err).ToNot(HaveOccurred(), "Dockerfile ConfigMap was not created")
+
+				By("Verifying the ConfigMap exists")
+
+				exists, err := check.BuildConfigMapExists(
+					APIClient,
+					params.NeuronNamespace,
+					params.DefaultDeviceConfigName,
+				)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(exists).To(BeTrue(), "Dockerfile ConfigMap should exist")
+			})
+
+			It("should deploy device plugin via in-cluster built driver",
+				reportxml.ID("88202"), func() {
+					By("Waiting for device plugin deployment to be ready")
+
+					err := await.DevicePluginDeployment(
+						APIClient,
+						params.NeuronNamespace,
+						tsparams.DevicePluginReadyTimeout,
+					)
+					Expect(err).ToNot(HaveOccurred(), "Device plugin deployment failed with in-cluster build")
+
+					By("Verifying device plugin pods are running on all Neuron nodes")
+
+					running, err := check.DevicePluginPodsRunning(APIClient)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(running).To(BeTrue(), "Device plugin pods should be running on all Neuron nodes")
+				})
+
+			It("should have Neuron device capacity on nodes",
+				reportxml.ID("88203"), func() {
+					By("Waiting for Neuron resources to be available on all nodes")
+
+					err := await.AllNeuronNodesResourceAvailable(APIClient, tsparams.DevicePluginReadyTimeout)
+					Expect(err).ToNot(HaveOccurred(), "Neuron resources not available on nodes")
+
+					By("Verifying Neuron device capacity on each node")
+
+					neuronNodes, err := check.GetNeuronNodes(APIClient)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(neuronNodes).ToNot(BeEmpty(), "Should have at least one Neuron node")
+
+					for _, node := range neuronNodes {
+						devices, cores, err := check.GetNeuronCapacity(APIClient, node.Object.Name)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(devices).To(BeNumerically(">", 0),
+							"Node %s should have Neuron device capacity", node.Object.Name)
+
+						klog.V(params.NeuronLogLevel).Infof(
+							"Node %s: %d Neuron devices, %d NeuronCores",
+							node.Object.Name, devices, cores)
+					}
+				})
+		})
+	})

--- a/tests/hw-accel/neuron/inclusterbuild/tests/inclusterbuild-test.go
+++ b/tests/hw-accel/neuron/inclusterbuild/tests/inclusterbuild-test.go
@@ -5,7 +5,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/deployment"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/namespace"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/neuron"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
@@ -35,24 +34,17 @@ var _ = Describe("Neuron In-Cluster Build Tests", Ordered,
 					Skip("Not configured for in-cluster build - DriversImage is set, skipping in-cluster build tests")
 				}
 
-				By("Verifying NFD operator is ready")
+				By("Verifying all required operators are ready")
 
-				nfdDeploy, err := deployment.Pull(APIClient, "nfd-controller-manager", "openshift-nfd")
-				Expect(err).ToNot(HaveOccurred(), "NFD operator deployment not found")
-				Expect(nfdDeploy.IsReady(30*time.Second)).To(BeTrue(), "NFD operator must be ready")
+				var options *neuronhelpers.NeuronInstallConfigOptions
+				if neuronConfig.CatalogSource != "" {
+					options = &neuronhelpers.NeuronInstallConfigOptions{
+						CatalogSource: neuronhelpers.StringPtr(neuronConfig.CatalogSource),
+					}
+				}
 
-				By("Verifying KMM operator is ready")
-
-				kmmDeploy, err := deployment.Pull(APIClient, "kmm-operator-controller", "openshift-kmm")
-				Expect(err).ToNot(HaveOccurred(), "KMM operator deployment not found")
-				Expect(kmmDeploy.IsReady(30*time.Second)).To(BeTrue(), "KMM operator must be ready")
-
-				By("Verifying Neuron operator is ready")
-
-				neuronDeploy, err := deployment.Pull(
-					APIClient, "awslabs-gpu-operator-controller-manager", params.NeuronNamespace)
-				Expect(err).ToNot(HaveOccurred(), "Neuron operator deployment not found")
-				Expect(neuronDeploy.IsReady(30*time.Second)).To(BeTrue(), "Neuron operator must be ready")
+				Expect(neuronhelpers.AreAllOperatorsReady(APIClient, options)).To(BeTrue(),
+					"All operators (NFD, KMM, Neuron) must be pre-installed and ready")
 
 				By("Creating DeviceConfig with in-cluster build (no DriversImage)")
 
@@ -74,14 +66,37 @@ var _ = Describe("Neuron In-Cluster Build Tests", Ordered,
 					builder = builder.WithImageRepoSecret(neuronConfig.ImageRepoSecretName)
 				}
 
-				if !builder.Exists() {
+				if builder.Exists() {
+					existingDC, pullErr := neuron.Pull(
+						APIClient, params.DefaultDeviceConfigName, params.NeuronNamespace)
+					Expect(pullErr).ToNot(HaveOccurred(), "Failed to pull existing DeviceConfig")
+
+					if existingDC.Definition.Spec.DriversImage != "" {
+						klog.V(params.NeuronLogLevel).Infof(
+							"Existing DeviceConfig has DriversImage set, recreating for in-cluster build")
+
+						_, deleteErr := existingDC.Delete()
+						Expect(deleteErr).ToNot(HaveOccurred(), "Failed to delete existing DeviceConfig")
+
+						Eventually(func() bool {
+							_, checkErr := neuron.Pull(
+								APIClient, params.DefaultDeviceConfigName, params.NeuronNamespace)
+
+							return checkErr != nil
+						}, 5*time.Minute, 5*time.Second).Should(BeTrue(),
+							"DeviceConfig should be fully deleted")
+
+						_, createErr := builder.Create()
+						Expect(createErr).ToNot(HaveOccurred(), "Failed to create DeviceConfig for in-cluster build")
+					}
+				} else {
 					_, err := builder.Create()
 					Expect(err).ToNot(HaveOccurred(), "Failed to create DeviceConfig for in-cluster build")
 				}
 
 				By("Waiting for cluster stability after DeviceConfig")
 
-				err = neuronhelpers.WaitForClusterStabilityAfterDeviceConfig(APIClient)
+				err := neuronhelpers.WaitForClusterStabilityAfterDeviceConfig(APIClient)
 				Expect(err).ToNot(HaveOccurred(), "Cluster not stable after DeviceConfig")
 
 				By("Waiting for Neuron nodes to be labeled")

--- a/tests/hw-accel/neuron/inclusterbuild/tests/inclusterbuild-test.go
+++ b/tests/hw-accel/neuron/inclusterbuild/tests/inclusterbuild-test.go
@@ -36,20 +36,23 @@ var _ = Describe("Neuron In-Cluster Build Tests", Ordered,
 				}
 
 				By("Verifying NFD operator is ready")
+
 				nfdDeploy, err := deployment.Pull(APIClient, "nfd-controller-manager", "openshift-nfd")
 				Expect(err).ToNot(HaveOccurred(), "NFD operator deployment not found")
-				Expect(nfdDeploy.IsReady(30 * time.Second)).To(BeTrue(), "NFD operator must be ready")
+				Expect(nfdDeploy.IsReady(30*time.Second)).To(BeTrue(), "NFD operator must be ready")
 
 				By("Verifying KMM operator is ready")
+
 				kmmDeploy, err := deployment.Pull(APIClient, "kmm-operator-controller", "openshift-kmm")
 				Expect(err).ToNot(HaveOccurred(), "KMM operator deployment not found")
-				Expect(kmmDeploy.IsReady(30 * time.Second)).To(BeTrue(), "KMM operator must be ready")
+				Expect(kmmDeploy.IsReady(30*time.Second)).To(BeTrue(), "KMM operator must be ready")
 
 				By("Verifying Neuron operator is ready")
+
 				neuronDeploy, err := deployment.Pull(
 					APIClient, "awslabs-gpu-operator-controller-manager", params.NeuronNamespace)
 				Expect(err).ToNot(HaveOccurred(), "Neuron operator deployment not found")
-				Expect(neuronDeploy.IsReady(30 * time.Second)).To(BeTrue(), "Neuron operator must be ready")
+				Expect(neuronDeploy.IsReady(30*time.Second)).To(BeTrue(), "Neuron operator must be ready")
 
 				By("Creating DeviceConfig with in-cluster build (no DriversImage)")
 

--- a/tests/hw-accel/neuron/internal/await/await.go
+++ b/tests/hw-accel/neuron/internal/await/await.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/internal/neuronparams"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/params"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -339,9 +340,13 @@ func BuildConfigMapCreated(apiClient *clients.Settings, namespace, deviceConfigN
 			_, err := apiClient.K8sClient.CoreV1().ConfigMaps(namespace).Get(
 				ctx, cmName, metav1.GetOptions{})
 			if err != nil {
-				klog.V(params.NeuronLogLevel).Infof("ConfigMap %s not found yet: %v", cmName, err)
+				if apierrors.IsNotFound(err) {
+					klog.V(params.NeuronLogLevel).Infof("ConfigMap %s not found yet", cmName)
 
-				return false, nil
+					return false, nil
+				}
+
+				return false, err
 			}
 
 			klog.V(params.NeuronLogLevel).Infof("ConfigMap %s exists", cmName)

--- a/tests/hw-accel/neuron/internal/await/await.go
+++ b/tests/hw-accel/neuron/internal/await/await.go
@@ -325,6 +325,31 @@ func AllNeuronNodesResourceAvailable(apiClient *clients.Settings, timeout time.D
 		})
 }
 
+// BuildConfigMapCreated waits for the Dockerfile ConfigMap to be created by the operator.
+func BuildConfigMapCreated(apiClient *clients.Settings, namespace, deviceConfigName string,
+	timeout time.Duration) error {
+	cmName := params.BuildConfigMapPrefix + deviceConfigName
+
+	klog.V(params.NeuronLogLevel).Infof(
+		"Waiting for build ConfigMap %s in namespace %s", cmName, namespace)
+
+	return wait.PollUntilContextTimeout(
+		context.TODO(), 10*time.Second, timeout, true,
+		func(ctx context.Context) (bool, error) {
+			_, err := apiClient.K8sClient.CoreV1().ConfigMaps(namespace).Get(
+				ctx, cmName, metav1.GetOptions{})
+			if err != nil {
+				klog.V(params.NeuronLogLevel).Infof("ConfigMap %s not found yet: %v", cmName, err)
+
+				return false, nil
+			}
+
+			klog.V(params.NeuronLogLevel).Infof("ConfigMap %s exists", cmName)
+
+			return true, nil
+		})
+}
+
 // DevicePluginRunningOnNode waits for the device plugin pod to be running on a specific node.
 func DevicePluginRunningOnNode(apiClient *clients.Settings, nodeName string,
 	timeout time.Duration) error {

--- a/tests/hw-accel/neuron/internal/check/check.go
+++ b/tests/hw-accel/neuron/internal/check/check.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/params"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog/v2"
@@ -277,7 +278,11 @@ func BuildConfigMapExists(apiClient *clients.Settings, namespace, deviceConfigNa
 	_, err := apiClient.K8sClient.CoreV1().ConfigMaps(namespace).Get(
 		context.TODO(), cmName, metav1.GetOptions{})
 	if err != nil {
-		return false, nil
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+
+		return false, err
 	}
 
 	return true, nil

--- a/tests/hw-accel/neuron/internal/check/check.go
+++ b/tests/hw-accel/neuron/internal/check/check.go
@@ -1,6 +1,7 @@
 package check
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -267,6 +268,19 @@ func NeuronWorkloadsOnNode(apiClient *clients.Settings, nodeName, namespace stri
 	}
 
 	return count, nil
+}
+
+// BuildConfigMapExists checks if the Dockerfile ConfigMap created by the operator exists.
+func BuildConfigMapExists(apiClient *clients.Settings, namespace, deviceConfigName string) (bool, error) {
+	cmName := params.BuildConfigMapPrefix + deviceConfigName
+
+	_, err := apiClient.K8sClient.CoreV1().ConfigMaps(namespace).Get(
+		context.TODO(), cmName, metav1.GetOptions{})
+	if err != nil {
+		return false, nil
+	}
+
+	return true, nil
 }
 
 // IsDevicePluginPod checks if a pod is a device plugin pod by comparing its name prefix.

--- a/tests/hw-accel/neuron/internal/neuronconfig/config.go
+++ b/tests/hw-accel/neuron/internal/neuronconfig/config.go
@@ -120,8 +120,17 @@ func NewNeuronConfig() *NeuronConfig {
 }
 
 // IsValid checks if the minimum required configuration is present.
+// Supports both pre-compiled image mode (DriversImage set) and in-cluster build mode (only DriverVersion set).
 func (c *NeuronConfig) IsValid() bool {
-	return c.DriversImage != "" && c.DriverVersion != "" && c.DevicePluginImage != "" && c.NodeMetricsImage != ""
+	hasDriverSource := c.DriversImage != "" || c.DriverVersion != ""
+
+	return hasDriverSource && c.DevicePluginImage != "" && c.NodeMetricsImage != ""
+}
+
+// IsInClusterBuild returns true when the configuration targets in-cluster build mode
+// (DriversImage is empty but DriverVersion is set).
+func (c *NeuronConfig) IsInClusterBuild() bool {
+	return c.DriversImage == "" && c.DriverVersion != ""
 }
 
 // IsVLLMConfigured checks if vLLM testing configuration is present.
@@ -130,8 +139,18 @@ func (c *NeuronConfig) IsVLLMConfigured() bool {
 }
 
 // IsUpgradeConfigured checks if upgrade testing configuration is present.
+// In pre-built image mode, both UpgradeTargetVersion and UpgradeTargetDriversImage are required.
+// In in-cluster build mode, only UpgradeTargetVersion is required.
 func (c *NeuronConfig) IsUpgradeConfigured() bool {
-	return c.UpgradeTargetVersion != "" && c.UpgradeTargetDriversImage != ""
+	if c.UpgradeTargetVersion == "" {
+		return false
+	}
+
+	if c.IsInClusterBuild() {
+		return true
+	}
+
+	return c.UpgradeTargetDriversImage != ""
 }
 
 // IsKServeConfigured checks if KServe testing configuration is present.

--- a/tests/hw-accel/neuron/internal/neuronhelpers/config.go
+++ b/tests/hw-accel/neuron/internal/neuronhelpers/config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/neuron"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nfd"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/internal/neuronconfig"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/params"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -216,19 +217,32 @@ func NFDRuleExists(apiClient *clients.Settings, namespace string) bool {
 }
 
 // CreateDeviceConfigFromEnv creates a DeviceConfig from environment configuration.
+// When driversImage is empty, uses in-cluster build mode (only driverVersion required).
 func CreateDeviceConfigFromEnv(
 	apiClient *clients.Settings,
 	driversImage, driverVersion, devicePluginImage, nodeMetricsImage,
 	schedulerImage, schedulerExtensionImage, imageRepoSecretName string,
 ) error {
-	builder := neuron.NewBuilder(
-		apiClient,
-		params.DefaultDeviceConfigName,
-		params.NeuronNamespace,
-		driversImage,
-		driverVersion,
-		devicePluginImage,
-	)
+	var builder *neuron.Builder
+
+	if driversImage != "" {
+		builder = neuron.NewBuilder(
+			apiClient,
+			params.DefaultDeviceConfigName,
+			params.NeuronNamespace,
+			driversImage,
+			driverVersion,
+			devicePluginImage,
+		)
+	} else {
+		builder = neuron.NewBuilderWithInClusterBuild(
+			apiClient,
+			params.DefaultDeviceConfigName,
+			params.NeuronNamespace,
+			driverVersion,
+			devicePluginImage,
+		)
+	}
 
 	if builder == nil {
 		return fmt.Errorf("failed to create neuron DeviceConfig builder: invalid parameters")
@@ -249,4 +263,49 @@ func CreateDeviceConfigFromEnv(
 	_, err := builder.Create()
 
 	return err
+}
+
+// NewDeviceConfigBuilder creates a DeviceConfig builder from NeuronConfig.
+// Handles both pre-built image and in-cluster build modes.
+// Returns the builder ready for further customization or creation.
+func NewDeviceConfigBuilder(apiClient *clients.Settings,
+	config *neuronconfig.NeuronConfig) *neuron.Builder {
+	var builder *neuron.Builder
+
+	if config.DriversImage != "" {
+		builder = neuron.NewBuilder(
+			apiClient,
+			params.DefaultDeviceConfigName,
+			params.NeuronNamespace,
+			config.DriversImage,
+			config.DriverVersion,
+			config.DevicePluginImage,
+		)
+	} else {
+		builder = neuron.NewBuilderWithInClusterBuild(
+			apiClient,
+			params.DefaultDeviceConfigName,
+			params.NeuronNamespace,
+			config.DriverVersion,
+			config.DevicePluginImage,
+		)
+	}
+
+	if builder == nil {
+		return nil
+	}
+
+	builder = builder.WithSelector(map[string]string{
+		params.NeuronNFDLabelKey: params.NeuronNFDLabelValue,
+	}).WithNodeMetricsImage(config.NodeMetricsImage)
+
+	if config.SchedulerImage != "" && config.SchedulerExtensionImage != "" {
+		builder = builder.WithScheduler(config.SchedulerImage, config.SchedulerExtensionImage)
+	}
+
+	if config.ImageRepoSecretName != "" {
+		builder = builder.WithImageRepoSecret(config.ImageRepoSecretName)
+	}
+
+	return builder
 }

--- a/tests/hw-accel/neuron/internal/neuronhelpers/deploy.go
+++ b/tests/hw-accel/neuron/internal/neuronhelpers/deploy.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/deployment"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/internal/deploy"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/params"
 	"k8s.io/klog/v2"
@@ -153,15 +154,22 @@ func AreAllOperatorsReady(apiClient *clients.Settings, neuronOptions *NeuronInst
 
 	klog.V(params.NeuronLogLevel).Info("KMM operator is already ready")
 
-	// Check Neuron
+	// Check Neuron — try OLM first, fall back to direct deployment check
 	neuronInstallConfig := GetDefaultNeuronInstallConfig(apiClient, neuronOptions)
 	neuronInstaller := deploy.NewOperatorInstaller(neuronInstallConfig)
 	neuronReady, err := neuronInstaller.IsReady(OperatorReadinessCheckTimeout)
 
 	if err != nil || !neuronReady {
-		klog.V(params.NeuronLogLevel).Infof("Neuron operator not ready: %v", err)
+		klog.V(params.NeuronLogLevel).Infof(
+			"Neuron operator not ready via OLM check, trying direct deployment check: %v", err)
 
-		return false
+		neuronDeploy, deployErr := deployment.Pull(
+			apiClient, "awslabs-gpu-operator-controller-manager", params.NeuronNamespace)
+		if deployErr != nil || !neuronDeploy.IsReady(OperatorReadinessCheckTimeout) {
+			klog.V(params.NeuronLogLevel).Infof("Neuron operator not ready: %v", deployErr)
+
+			return false
+		}
 	}
 
 	klog.V(params.NeuronLogLevel).Info("Neuron operator is already ready")

--- a/tests/hw-accel/neuron/metrics/tests/metrics-test.go
+++ b/tests/hw-accel/neuron/metrics/tests/metrics-test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/namespace"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/neuron"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/internal/await"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/internal/check"
@@ -69,37 +68,19 @@ var _ = Describe("Neuron Metrics Tests", Ordered, Label(params.Label), Label(par
 			Expect(neuronhelpers.AreAllOperatorsReady(APIClient, options)).To(BeTrue(),
 				"All operators (NFD, KMM, Neuron) must be pre-installed and ready")
 
-			var err error
-
 			By("Creating DeviceConfig")
 
-			builder := neuron.NewBuilder(
-				APIClient,
-				params.DefaultDeviceConfigName,
-				params.NeuronNamespace,
-				neuronConfig.DriversImage,
-				neuronConfig.DriverVersion,
-				neuronConfig.DevicePluginImage,
-			).WithSelector(map[string]string{
-				params.NeuronNFDLabelKey: params.NeuronNFDLabelValue,
-			}).WithNodeMetricsImage(neuronConfig.NodeMetricsImage)
-
-			if neuronConfig.SchedulerImage != "" && neuronConfig.SchedulerExtensionImage != "" {
-				builder = builder.WithScheduler(neuronConfig.SchedulerImage, neuronConfig.SchedulerExtensionImage)
-			}
-
-			if neuronConfig.ImageRepoSecretName != "" {
-				builder = builder.WithImageRepoSecret(neuronConfig.ImageRepoSecretName)
-			}
+			builder := neuronhelpers.NewDeviceConfigBuilder(APIClient, neuronConfig)
+			Expect(builder).ToNot(BeNil(), "Failed to create DeviceConfig builder")
 
 			if !builder.Exists() {
-				_, err = builder.Create()
+				_, err := builder.Create()
 				Expect(err).ToNot(HaveOccurred(), "Failed to create DeviceConfig")
 			}
 
 			By("Waiting for cluster stability after DeviceConfig")
 
-			err = neuronhelpers.WaitForClusterStabilityAfterDeviceConfig(APIClient)
+			err := neuronhelpers.WaitForClusterStabilityAfterDeviceConfig(APIClient)
 			Expect(err).ToNot(HaveOccurred(), "Cluster not stable after DeviceConfig")
 
 			By("Waiting for Neuron nodes to be labeled")

--- a/tests/hw-accel/neuron/params/consts.go
+++ b/tests/hw-accel/neuron/params/consts.go
@@ -40,6 +40,12 @@ const (
 	// MetricsDaemonSetPrefix represents the prefix for the metrics DaemonSet name.
 	MetricsDaemonSetPrefix = "neuron-node-metrics"
 
+	// InClusterBuildLabel represents the label for in-cluster build test cases.
+	InClusterBuildLabel = "in-cluster-build"
+
+	// BuildConfigMapPrefix represents the prefix for the Dockerfile ConfigMap created by the operator.
+	BuildConfigMapPrefix = "dockerfile-"
+
 	// DevicePluginDaemonSetPrefix represents the prefix for the device plugin DaemonSet name.
 	DevicePluginDaemonSetPrefix = "neuron-device-plugin"
 

--- a/tests/hw-accel/neuron/vllm/tests/vllm-inference-test.go
+++ b/tests/hw-accel/neuron/vllm/tests/vllm-inference-test.go
@@ -9,7 +9,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/deployment"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/namespace"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/neuron"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/internal/await"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/hw-accel/neuron/internal/do"
@@ -50,37 +49,19 @@ var _ = Describe("Neuron vLLM Inference Tests", Ordered, Label(params.Label), La
 			Expect(neuronhelpers.AreAllOperatorsReady(APIClient, options)).To(BeTrue(),
 				"All operators (NFD, KMM, Neuron) must be pre-installed and ready")
 
-			var err error
-
 			By("Creating DeviceConfig")
 
-			builder := neuron.NewBuilder(
-				APIClient,
-				params.DefaultDeviceConfigName,
-				params.NeuronNamespace,
-				neuronConfig.DriversImage,
-				neuronConfig.DriverVersion,
-				neuronConfig.DevicePluginImage,
-			).WithSelector(map[string]string{
-				params.NeuronNFDLabelKey: params.NeuronNFDLabelValue,
-			}).WithNodeMetricsImage(neuronConfig.NodeMetricsImage)
-
-			if neuronConfig.SchedulerImage != "" && neuronConfig.SchedulerExtensionImage != "" {
-				builder = builder.WithScheduler(neuronConfig.SchedulerImage, neuronConfig.SchedulerExtensionImage)
-			}
-
-			if neuronConfig.ImageRepoSecretName != "" {
-				builder = builder.WithImageRepoSecret(neuronConfig.ImageRepoSecretName)
-			}
+			builder := neuronhelpers.NewDeviceConfigBuilder(APIClient, neuronConfig)
+			Expect(builder).ToNot(BeNil(), "Failed to create DeviceConfig builder")
 
 			if !builder.Exists() {
-				_, err = builder.Create()
+				_, err := builder.Create()
 				Expect(err).ToNot(HaveOccurred(), "Failed to create DeviceConfig")
 			}
 
 			By("Waiting for cluster stability after DeviceConfig")
 
-			err = neuronhelpers.WaitForClusterStabilityAfterDeviceConfig(APIClient)
+			err := neuronhelpers.WaitForClusterStabilityAfterDeviceConfig(APIClient)
 			Expect(err).ToNot(HaveOccurred(), "Cluster not stable after DeviceConfig")
 
 			By("Waiting for Neuron nodes to be labeled")

--- a/vendor/github.com/rh-ecosystem-edge/eco-goinfra/pkg/neuron/deviceconfig.go
+++ b/vendor/github.com/rh-ecosystem-edge/eco-goinfra/pkg/neuron/deviceconfig.go
@@ -109,6 +109,79 @@ func NewBuilder(
 	return builder
 }
 
+// NewBuilderWithInClusterBuild creates a new instance of Builder for in-cluster build mode.
+// In this mode, DriversImage is left empty and the operator triggers KMM in-cluster builds
+// using a Dockerfile ConfigMap. Only driverVersion and devicePluginImage are required.
+func NewBuilderWithInClusterBuild(
+	apiClient *clients.Settings,
+	name, namespace string,
+	driverVersion, devicePluginImage string) *Builder {
+	klog.V(100).Infof(
+		"Initializing new DeviceConfig (in-cluster build) with name: %s, namespace: %s",
+		name, namespace)
+
+	if apiClient == nil {
+		klog.V(100).Infof("The apiClient is empty")
+
+		return nil
+	}
+
+	err := apiClient.AttachScheme(neuronv1beta1.AddToScheme)
+	if err != nil {
+		klog.V(100).Infof("Failed to add neuron v1beta1 scheme to client schemes")
+
+		return nil
+	}
+
+	builder := &Builder{
+		apiClient: apiClient,
+		Definition: &neuronv1beta1.DeviceConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: neuronv1beta1.DeviceConfigSpec{
+				DriverVersion:     driverVersion,
+				DevicePluginImage: devicePluginImage,
+			},
+		},
+	}
+
+	if name == "" {
+		klog.V(100).Infof("The name of the DeviceConfig is empty")
+
+		builder.errorMsg = "DeviceConfig 'name' cannot be empty"
+
+		return builder
+	}
+
+	if namespace == "" {
+		klog.V(100).Infof("The namespace of the DeviceConfig is empty")
+
+		builder.errorMsg = "DeviceConfig 'namespace' cannot be empty"
+
+		return builder
+	}
+
+	if driverVersion == "" {
+		klog.V(100).Infof("The driverVersion of the DeviceConfig is empty")
+
+		builder.errorMsg = "DeviceConfig 'driverVersion' cannot be empty"
+
+		return builder
+	}
+
+	if devicePluginImage == "" {
+		klog.V(100).Infof("The devicePluginImage of the DeviceConfig is empty")
+
+		builder.errorMsg = "DeviceConfig 'devicePluginImage' cannot be empty"
+
+		return builder
+	}
+
+	return builder
+}
+
 // WithSelector sets the node selector for the DeviceConfig.
 func (builder *Builder) WithSelector(selector map[string]string) *Builder {
 	if valid, _ := builder.validate(); !valid {

--- a/vendor/github.com/rh-ecosystem-edge/eco-goinfra/pkg/neuron/deviceconfig.go
+++ b/vendor/github.com/rh-ecosystem-edge/eco-goinfra/pkg/neuron/deviceconfig.go
@@ -29,6 +29,11 @@ type Builder struct {
 // AdditionalOptions additional options for DeviceConfig object.
 type AdditionalOptions func(builder *Builder) (*Builder, error)
 
+const (
+	errDriverVersionEmpty     = "DeviceConfig 'driverVersion' cannot be empty"
+	errDevicePluginImageEmpty = "DeviceConfig 'devicePluginImage' cannot be empty"
+)
+
 // NewBuilder creates a new instance of Builder.
 func NewBuilder(
 	apiClient *clients.Settings,
@@ -93,7 +98,7 @@ func NewBuilder(
 	if driverVersion == "" {
 		klog.V(100).Infof("The driverVersion of the DeviceConfig is empty")
 
-		builder.errorMsg = "DeviceConfig 'driverVersion' cannot be empty"
+		builder.errorMsg = errDriverVersionEmpty
 
 		return builder
 	}
@@ -101,7 +106,7 @@ func NewBuilder(
 	if devicePluginImage == "" {
 		klog.V(100).Infof("The devicePluginImage of the DeviceConfig is empty")
 
-		builder.errorMsg = "DeviceConfig 'devicePluginImage' cannot be empty"
+		builder.errorMsg = errDevicePluginImageEmpty
 
 		return builder
 	}
@@ -166,7 +171,7 @@ func NewBuilderWithInClusterBuild(
 	if driverVersion == "" {
 		klog.V(100).Infof("The driverVersion of the DeviceConfig is empty")
 
-		builder.errorMsg = "DeviceConfig 'driverVersion' cannot be empty"
+		builder.errorMsg = errDriverVersionEmpty
 
 		return builder
 	}
@@ -174,7 +179,7 @@ func NewBuilderWithInClusterBuild(
 	if devicePluginImage == "" {
 		klog.V(100).Infof("The devicePluginImage of the DeviceConfig is empty")
 
-		builder.errorMsg = "DeviceConfig 'devicePluginImage' cannot be empty"
+		builder.errorMsg = errDevicePluginImageEmpty
 
 		return builder
 	}
@@ -274,9 +279,9 @@ func (builder *Builder) WithDriverVersion(version string) *Builder {
 		builder.Definition.Name, builder.Definition.Namespace, version)
 
 	if version == "" {
-		klog.V(100).Infof("DeviceConfig 'driverVersion' cannot be empty")
+		klog.V(100).Infof(errDriverVersionEmpty)
 
-		builder.errorMsg = "DeviceConfig 'driverVersion' cannot be empty"
+		builder.errorMsg = errDriverVersionEmpty
 
 		return builder
 	}

--- a/vendor/github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/neuron/v1beta1/deviceconfig_types.go
+++ b/vendor/github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/neuron/v1beta1/deviceconfig_types.go
@@ -30,7 +30,9 @@ type DeviceConfigSpec struct {
 	// if the in-tree driver should be used instead of OOT drivers
 	UseInTreeDrivers bool `json:"useInTreeDrivers,omitempty"`
 
-	// defines image that includes drivers
+	// defines image that includes drivers. When empty, the operator triggers
+	// KMM in-cluster builds using a Dockerfile ConfigMap.
+	// +optional
 	DriversImage string `json:"driversImage,omitempty"`
 
 	// defines the Version of the neuron drivers. used for rolling upgrade

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -962,7 +962,7 @@ github.com/redhat-cne/sdk-go/pkg/event/ptp
 github.com/redhat-cne/sdk-go/pkg/event/redfish
 github.com/redhat-cne/sdk-go/pkg/pubsub
 github.com/redhat-cne/sdk-go/pkg/types
-# github.com/rh-ecosystem-edge/eco-goinfra v0.0.0-20260618190922-866a3518ded5
+# github.com/rh-ecosystem-edge/eco-goinfra v0.0.0-20260619181221-bf7069adc99d
 ## explicit; go 1.26
 github.com/rh-ecosystem-edge/eco-goinfra/pkg/amdgpu
 github.com/rh-ecosystem-edge/eco-goinfra/pkg/apiservers


### PR DESCRIPTION
## Summary
- Add `inclusterbuild` test suite (3 tests) for validating KMM in-cluster builds when `DriversImage` is empty
- Update all existing neuron suites (vllm, metrics, upgrade) to use shared `NewDeviceConfigBuilder` helper that branches on `DriversImage` presence
- Update upgrade test to support in-cluster build mode (only `UpgradeTargetVersion` required, no `UpgradeTargetDriversImage`)
- Add `AreAllOperatorsReady` fallback for non-OLM Neuron deployments
- Vendor updated eco-goinfra with `NewBuilderWithInClusterBuild` and optional `DriversImage`
- Fix KMM webhook test to register v1beta1 scheme before direct Module creation

## Test plan
- [x] `inclusterbuild` suite: 3/3 passed (ConfigMap creation, device plugin deployment, Neuron capacity)
- [x] `vllm` suite: 1/1 passed (full inference with TinyLlama on NeuronCores)
- [x] `metrics` suite: 7/7 passed (DaemonSet, ServiceMonitor, Prometheus scraping, hardware info, utilization, memory, per-node)
- [x] `upgrade` suite: 6/6 passed (rolling upgrade from 2.27.4.0 to 2.26.5.0 via in-cluster build)
- [x] All suites tested on ROSA HCP 4.21 with OLM-installed operators (NFD, KMM v2.6.0, Neuron v1.2.0)

🤖 Co-Authored-By: [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for in-cluster build mode for Neuron drivers as an alternative to pre-built images.
  * New integration test suite for in-cluster build functionality.

* **Tests**
  * Updated existing tests to validate both in-cluster build and pre-built image deployment modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->