### PR TITLE
Add sriov bond ipam

### DIFF
--- a/tests/cnf/core/network/sriov/internal/sriovenv/bond.go
+++ b/tests/cnf/core/network/sriov/internal/sriovenv/bond.go
@@ -40,6 +40,58 @@ func CreateBondNAD(
 	mtu,
 	slaveCount int,
 ) (*nad.Builder, error) {
+	return createBondNAD(nadName, mode, mtu, slaveCount, &nad.IPAM{Type: ipamType})
+}
+
+// CreateBondNADWithWhereabouts builds a Bond CNI NAD with Whereabouts IPAM on the bond interface.
+// The caller is responsible for calling .Create() on the returned builder.
+func CreateBondNADWithWhereabouts(
+	nadName,
+	mode string,
+	mtu,
+	slaveCount int,
+	ipRange,
+	gateway string,
+) (*nad.Builder, error) {
+	ipam, err := bondWhereaboutsIPAM(ipRange, gateway)
+	if err != nil {
+		return nil, err
+	}
+
+	return createBondNAD(nadName, mode, mtu, slaveCount, ipam)
+}
+
+// bondWhereaboutsIPAM builds Whereabouts IPAM with an explicit alloc pool so the gateway is not
+// assigned to pods (same range_start/range_end pattern as SR-IOV Whereabouts NADs).
+func bondWhereaboutsIPAM(ipRange, gateway string) (*nad.IPAM, error) {
+	if ipRange == "" || gateway == "" {
+		return nil, fmt.Errorf("invalid whereabouts IPAM range %q gateway %q", ipRange, gateway)
+	}
+
+	rangeStart := tsparams.WhereaboutsIPv6AllocStart
+	rangeEnd := tsparams.WhereaboutsIPv6AllocEnd
+
+	if ipRange == tsparams.WhereaboutsIPv6Range2 {
+		rangeStart = tsparams.WhereaboutsIPv6AllocStart2
+		rangeEnd = tsparams.WhereaboutsIPv6AllocEnd2
+	}
+
+	return &nad.IPAM{
+		Type:       "whereabouts",
+		AddrRange:  ipRange,
+		RangeStart: rangeStart,
+		RangeEnd:   rangeEnd,
+		Gateway:    gateway,
+	}, nil
+}
+
+func createBondNAD(
+	nadName,
+	mode string,
+	mtu,
+	slaveCount int,
+	ipam *nad.IPAM,
+) (*nad.Builder, error) {
 	if slaveCount < 2 {
 		return nil, fmt.Errorf("slaveCount must be >= 2, got %d", slaveCount)
 	}
@@ -56,7 +108,7 @@ func CreateBondNAD(
 		WithMiimon(100).
 		WithLinks(links).
 		WithCapabilities(&nad.Capability{IPs: true}).
-		WithIPAM(&nad.IPAM{Type: ipamType})
+		WithIPAM(ipam)
 
 	masterPlugin, err := plugin.GetMasterPluginConfig()
 	if err != nil {

--- a/tests/cnf/core/network/sriov/internal/sriovenv/sriovenv.go
+++ b/tests/cnf/core/network/sriov/internal/sriovenv/sriovenv.go
@@ -425,34 +425,6 @@ func CreateSriovBondNetwork(name, resourceName string) error {
 	return WaitForNADCreation(name, tsparams.TestNamespaceName, tsparams.NADWaitTimeout)
 }
 
-// CreateSriovBondNetworkWithWhereaboutsIPAM creates a bond slave SriovNetwork with Whereabouts IPAM
-// and bond VF settings (Trust on, SpoofChk off, LinkState auto).
-func CreateSriovBondNetworkWithWhereaboutsIPAM(
-	name,
-	resourceName,
-	ipRange,
-	gateway,
-	networkName,
-	ipv6Range string,
-) error {
-	klog.V(90).Infof("Creating bond slave SR-IOV network %s with whereabouts IPAM, range %s, gateway %s",
-		name, ipRange, gateway)
-
-	networkBuilder := sriov.NewNetworkBuilder(
-		APIClient, name, NetConfig.SriovOperatorNamespace,
-		tsparams.TestNamespaceName, resourceName)
-
-	networkBuilder = applyBondSlaveVFSettings(networkBuilder)
-
-	if ipv6Range != "" {
-		networkBuilder.Definition.Spec.IPAM = whereaboutsDualStackIPAMJSON(ipRange, ipv6Range, networkName)
-	} else {
-		networkBuilder = networkBuilder.WithWhereaboutsIPAM(ipRange, gateway, "", networkName)
-	}
-
-	return CreateSriovNetworkAndWaitForNADCreation(networkBuilder, tsparams.NADWaitTimeout)
-}
-
 // CreateSriovNetworkWithVLANAndWhereabouts creates an SR-IOV network with Whereabouts IPAM and VLAN tagging.
 // Dual-stack uses ipRanges without gateway (ipv6Gateway is ignored, same as CreateSriovNetworkWithWhereaboutsIPAM).
 func CreateSriovNetworkWithVLANAndWhereabouts(
@@ -805,17 +777,23 @@ func getIPv4MulticastConfig(mtu int) (group, mac string) {
 
 // buildTestcmdListeners returns the shell commands to start all testcmd listeners.
 // serverIP and mcastGroup can be shell variables (e.g., $SERVER_IP, $MCAST_GROUP) or literal values.
-func buildTestcmdListeners(interfaceName, serverIP, mcastGroup string, packetSize int) string {
-	return fmt.Sprintf(
+// When holdOpen is true, sleep infinity keeps the container alive (pod entrypoint use).
+func buildTestcmdListeners(interfaceName, serverIP, mcastGroup string, packetSize int, holdOpen bool) string {
+	listeners := fmt.Sprintf(
 		"testcmd -listen -protocol tcp -port 5001 -interface %s -mtu %d & "+
 			"testcmd -listen -protocol udp -port 5002 -interface %s -mtu %d & "+
 			"testcmd -listen -protocol sctp -port 5003 -interface %s -server %s -mtu %d & "+
-			"testcmd -listen -multicast -protocol udp -port 5004 -interface %s -server %s -mtu %d & "+
-			"sleep infinity",
+			"testcmd -listen -multicast -protocol udp -port 5004 -interface %s -server %s -mtu %d & ",
 		interfaceName, packetSize,
 		interfaceName, packetSize,
 		interfaceName, serverIP, packetSize,
 		interfaceName, mcastGroup, packetSize)
+
+	if holdOpen {
+		return listeners + "sleep infinity"
+	}
+
+	return listeners
 }
 
 // buildMulticastSetup returns the shell command to configure multicast and the multicast group address.
@@ -842,10 +820,9 @@ func BuildMulticastSetup(isIPv6 bool, interfaceName string, mtu int) (setupCmd, 
 	return buildMulticastSetup(isIPv6, interfaceName, mtu)
 }
 
-// buildDynamicIPServerCommand builds the server command for Whereabouts IPAM
-// where the IP is discovered at runtime inside the pod.
-func buildDynamicIPServerCommand(interfaceName string, mtu, packetSize int) []string {
-	// Step 1: Discover server IP (try IPv4 first, then IPv6).
+// buildDynamicServerStartScript returns a shell script that discovers the interface IP,
+// configures multicast, and starts testcmd listeners in the background.
+func buildDynamicServerStartScript(interfaceName string, mtu, packetSize int) string {
 	discoverIP := fmt.Sprintf(
 		"for _ in $(seq 1 10); do "+
 			"SERVER_IP=$(ip -4 -o addr show %s 2>/dev/null | awk '{print $4}' | cut -d'/' -f1 | head -1); "+
@@ -857,7 +834,6 @@ func buildDynamicIPServerCommand(interfaceName string, mtu, packetSize int) []st
 			"echo \"Discovered server IP: $SERVER_IP\"; ",
 		interfaceName, interfaceName)
 
-	// Step 2: Configure multicast based on discovered IP version (determined at runtime).
 	ipv6Setup, ipv6Group := buildMulticastSetup(true, interfaceName, mtu)
 	ipv4Setup, ipv4Group := buildMulticastSetup(false, interfaceName, mtu)
 
@@ -870,10 +846,17 @@ func buildDynamicIPServerCommand(interfaceName string, mtu, packetSize int) []st
 		ipv6Group, ipv6Setup,
 		ipv4Group, ipv4Setup)
 
-	// Step 3: Start listeners using shell variables set above.
-	listeners := buildTestcmdListeners(interfaceName, "$SERVER_IP", "$MCAST_GROUP", packetSize)
+	listeners := buildTestcmdListeners(interfaceName, "$SERVER_IP", "$MCAST_GROUP", packetSize, false)
 
-	return []string{"bash", "-c", discoverIP + setupMulticast + listeners}
+	return discoverIP + setupMulticast + listeners
+}
+
+// buildDynamicIPServerCommand builds the server command for Whereabouts IPAM
+// where the IP is discovered at runtime inside the pod.
+func buildDynamicIPServerCommand(interfaceName string, mtu, packetSize int) []string {
+	script := buildDynamicServerStartScript(interfaceName, mtu, packetSize)
+
+	return []string{"bash", "-c", script + "sleep infinity"}
 }
 
 // buildStaticIPServerCommand builds the server command when the IP is known at pod creation time.
@@ -881,7 +864,7 @@ func buildStaticIPServerCommand(serverBindIP, interfaceName string, mtu, packetS
 	isIPv6 := strings.Contains(serverBindIP, ":")
 	multicastSetup, multicastGroup := buildMulticastSetup(isIPv6, interfaceName, mtu)
 
-	listeners := buildTestcmdListeners(interfaceName, serverBindIP, multicastGroup, packetSize)
+	listeners := buildTestcmdListeners(interfaceName, serverBindIP, multicastGroup, packetSize, true)
 
 	return []string{"bash", "-c", multicastSetup + "sleep 5; " + listeners}
 }

--- a/tests/cnf/core/network/sriov/tests/sriov-bond-mode.go
+++ b/tests/cnf/core/network/sriov/tests/sriov-bond-mode.go
@@ -23,6 +23,7 @@ import (
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/sriov/internal/tsparams"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/cluster"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/sriovoperator"
+	multus "gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/types"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -211,10 +212,12 @@ var _ = Describe(
 				runBondScenario(
 					sriovenv.BondModeActiveBackup,
 					mtu1280, mtu9000,
-					tsparams.ServerIPv4IPAddress, tsparams.ClientIPv4IPAddress,
-					tsparams.ServerIPv4IPAddress2, tsparams.ClientIPv4IPAddress2,
 					workerNodeList[0].Definition.Name, workerNodeList[1].Definition.Name,
 					bondNetworksV4DiffPFSmall, bondNetworksV4DiffPFJumbo,
+					staticBondIPs(
+						tsparams.ServerIPv4IPAddress, tsparams.ClientIPv4IPAddress,
+						tsparams.ServerIPv4IPAddress2, tsparams.ClientIPv4IPAddress2,
+					),
 				)
 			})
 
@@ -226,10 +229,12 @@ var _ = Describe(
 				runBondScenario(
 					sriovenv.BondModeActiveBackup,
 					mtu1280, mtu9000,
-					tsparams.ServerIPv4IPAddress, tsparams.ClientIPv4IPAddress,
-					tsparams.ServerIPv4IPAddress2, tsparams.ClientIPv4IPAddress2,
 					workerNodeList[0].Definition.Name, workerNodeList[1].Definition.Name,
 					bondNetworksV4SamePFSmall, bondNetworksV4SamePFJumbo,
+					staticBondIPs(
+						tsparams.ServerIPv4IPAddress, tsparams.ClientIPv4IPAddress,
+						tsparams.ServerIPv4IPAddress2, tsparams.ClientIPv4IPAddress2,
+					),
 				)
 			})
 
@@ -241,10 +246,12 @@ var _ = Describe(
 				runBondScenario(
 					sriovenv.BondModeActiveBackup,
 					mtu1280, mtu9000,
-					tsparams.ServerIPv6IPAddress, tsparams.ClientIPv6IPAddress,
-					tsparams.ServerIPv6IPAddress2, tsparams.ClientIPv6IPAddress2,
 					workerNodeList[0].Definition.Name, workerNodeList[1].Definition.Name,
 					bondNetworksV6DiffPFSmall, bondNetworksV6DiffPFJumbo,
+					staticBondIPs(
+						tsparams.ServerIPv6IPAddress, tsparams.ClientIPv6IPAddress,
+						tsparams.ServerIPv6IPAddress2, tsparams.ClientIPv6IPAddress2,
+					),
 				)
 			})
 
@@ -256,10 +263,40 @@ var _ = Describe(
 				runBondScenario(
 					sriovenv.BondModeActiveBackup,
 					mtu1280, mtu9000,
-					tsparams.ServerIPv6IPAddress, tsparams.ClientIPv6IPAddress,
-					tsparams.ServerIPv6IPAddress2, tsparams.ClientIPv6IPAddress2,
 					workerNodeList[0].Definition.Name, workerNodeList[1].Definition.Name,
 					bondNetworksV6SamePFSmall, bondNetworksV6SamePFJumbo,
+					staticBondIPs(
+						tsparams.ServerIPv6IPAddress, tsparams.ClientIPv6IPAddress,
+						tsparams.ServerIPv6IPAddress2, tsparams.ClientIPv6IPAddress2,
+					),
+				)
+			})
+
+			It("DiffNodeDiffPF IPv6 IPAM", reportxml.ID("89681"), func() {
+				if !netenv.ClusterSupportsIPv6(clusterIPFamily) {
+					Skip("Cluster does not support IPv6 - skipping SR-IOV bond whereabouts IPAM tests")
+				}
+
+				runBondScenario(
+					sriovenv.BondModeActiveBackup,
+					mtu1280, mtu9000,
+					workerNodeList[0].Definition.Name, workerNodeList[1].Definition.Name,
+					bondNetworksV6DiffPFSmall, bondNetworksV6DiffPFJumbo,
+					whereaboutsBondIPs(),
+				)
+			})
+
+			It("DiffNodeSamePF IPv6 IPAM", reportxml.ID("89682"), func() {
+				if !netenv.ClusterSupportsIPv6(clusterIPFamily) {
+					Skip("Cluster does not support IPv6 - skipping SR-IOV bond whereabouts IPAM tests")
+				}
+
+				runBondScenario(
+					sriovenv.BondModeActiveBackup,
+					mtu1280, mtu9000,
+					workerNodeList[0].Definition.Name, workerNodeList[1].Definition.Name,
+					bondNetworksV6SamePFSmall, bondNetworksV6SamePFJumbo,
+					whereaboutsBondIPs(),
 				)
 			})
 		})
@@ -285,10 +322,12 @@ var _ = Describe(
 				runBondScenario(
 					sriovenv.BondModeBalanceRR,
 					mtu1280, mtu9000,
-					tsparams.ServerIPv4IPAddress, tsparams.ClientIPv4IPAddress,
-					tsparams.ServerIPv4IPAddress2, tsparams.ClientIPv4IPAddress2,
 					workerNodeList[0].Definition.Name, workerNodeList[1].Definition.Name,
 					bondNetworksV4DiffPFSmall, bondNetworksV4DiffPFJumbo,
+					staticBondIPs(
+						tsparams.ServerIPv4IPAddress, tsparams.ClientIPv4IPAddress,
+						tsparams.ServerIPv4IPAddress2, tsparams.ClientIPv4IPAddress2,
+					),
 				)
 			})
 
@@ -300,10 +339,12 @@ var _ = Describe(
 				runBondScenario(
 					sriovenv.BondModeBalanceXOR,
 					mtu1280, mtu9000,
-					tsparams.ServerIPv4IPAddress, tsparams.ClientIPv4IPAddress,
-					tsparams.ServerIPv4IPAddress2, tsparams.ClientIPv4IPAddress2,
 					workerNodeList[0].Definition.Name, workerNodeList[1].Definition.Name,
 					bondNetworksV4DiffPFSmall, bondNetworksV4DiffPFJumbo,
+					staticBondIPs(
+						tsparams.ServerIPv4IPAddress, tsparams.ClientIPv4IPAddress,
+						tsparams.ServerIPv4IPAddress2, tsparams.ClientIPv4IPAddress2,
+					),
 				)
 			})
 
@@ -315,10 +356,12 @@ var _ = Describe(
 				runBondScenario(
 					sriovenv.BondModeBalanceRR,
 					mtu1280, mtu9000,
-					tsparams.ServerIPv6IPAddress, tsparams.ClientIPv6IPAddress,
-					tsparams.ServerIPv6IPAddress2, tsparams.ClientIPv6IPAddress2,
 					workerNodeList[0].Definition.Name, workerNodeList[1].Definition.Name,
 					bondNetworksV6DiffPFSmall, bondNetworksV6DiffPFJumbo,
+					staticBondIPs(
+						tsparams.ServerIPv6IPAddress, tsparams.ClientIPv6IPAddress,
+						tsparams.ServerIPv6IPAddress2, tsparams.ClientIPv6IPAddress2,
+					),
 				)
 			})
 
@@ -330,10 +373,12 @@ var _ = Describe(
 				runBondScenario(
 					sriovenv.BondModeBalanceXOR,
 					mtu1280, mtu9000,
-					tsparams.ServerIPv6IPAddress, tsparams.ClientIPv6IPAddress,
-					tsparams.ServerIPv6IPAddress2, tsparams.ClientIPv6IPAddress2,
 					workerNodeList[0].Definition.Name, workerNodeList[1].Definition.Name,
 					bondNetworksV6DiffPFSmall, bondNetworksV6DiffPFJumbo,
+					staticBondIPs(
+						tsparams.ServerIPv6IPAddress, tsparams.ClientIPv6IPAddress,
+						tsparams.ServerIPv6IPAddress2, tsparams.ClientIPv6IPAddress2,
+					),
 				)
 			})
 		})
@@ -525,63 +570,131 @@ var (
 	bondNetworksV6SamePFJumbo = []string{"sriov-bond-v6-samepf-jumbo-a", "sriov-bond-v6-samepf-jumbo-b"}
 )
 
+// bondScenarioIPSetup selects static pod IPs or Whereabouts IPAM for a bond scenario run.
+type bondScenarioIPSetup struct {
+	whereabouts   bool
+	serverIPSmall string
+	clientIPSmall string
+	serverIPLarge string
+	clientIPLarge string
+}
+
+func staticBondIPs(serverIPSmall, clientIPSmall, serverIPLarge, clientIPLarge string) bondScenarioIPSetup {
+	return bondScenarioIPSetup{
+		serverIPSmall: serverIPSmall,
+		clientIPSmall: clientIPSmall,
+		serverIPLarge: serverIPLarge,
+		clientIPLarge: clientIPLarge,
+	}
+}
+
+func whereaboutsBondIPs() bondScenarioIPSetup {
+	return bondScenarioIPSetup{whereabouts: true}
+}
+
+func createBondScenarioNAD(nadName, bondMode string, mtu int, whereabouts bool) {
+	deleteBondNADBestEffort(nadName)
+
+	var (
+		bondBuilder *nad.Builder
+		err         error
+	)
+
+	if whereabouts {
+		ipRange, gateway := bondWhereaboutsIPAMForMTU(mtu)
+		bondBuilder, err = sriovenv.CreateBondNADWithWhereabouts(
+			nadName, bondMode, mtu, 2, ipRange, gateway)
+		Expect(err).ToNot(HaveOccurred(), "Failed to build whereabouts bond NAD %s", nadName)
+	} else {
+		bondBuilder, err = sriovenv.CreateBondNAD(nadName, bondMode, "static", mtu, 2)
+		Expect(err).ToNot(HaveOccurred(), "Failed to build bond NAD %s", nadName)
+	}
+
+	_, err = bondBuilder.Create()
+	Expect(err).ToNot(HaveOccurred(), "Failed to create bond NAD %s", nadName)
+}
+
+func bondScenarioPodNames(whereabouts bool, modeSuffix string, mtu int) (serverName, clientName string) {
+	prefix := "bond"
+	if whereabouts {
+		prefix = "bond-wb"
+	}
+
+	serverName = fmt.Sprintf("%s-server-%s-mtu%d", prefix, modeSuffix, mtu)
+	clientName = fmt.Sprintf("%s-client-%s-mtu%d", prefix, modeSuffix, mtu)
+
+	return serverName, clientName
+}
+
+func createBondScenarioPodsPair(
+	nadName, serverName, clientName, serverNode, clientNode string,
+	slaveNetworks []string,
+	mtu int,
+	serverIPWithCIDR, clientIPWithCIDR string,
+	whereabouts bool,
+) (*pod.Builder, string) {
+	if whereabouts {
+		serverPod, clientPod := createBondWhereaboutsPodsPair(
+			nadName, serverName, clientName, serverNode, clientNode, slaveNetworks, mtu)
+
+		serverIP, err := sriovenv.GetPodIPFromInterface(serverPod, sriovenv.BondInterfaceName, "ipv6")
+		Expect(err).ToNot(HaveOccurred(), "Failed to get server bond IP on %s", serverName)
+
+		return clientPod, serverIP
+	}
+
+	_, clientPod := createBondedPodsPair(
+		nadName, serverName, clientName, serverNode, clientNode,
+		slaveNetworks, serverIPWithCIDR, clientIPWithCIDR, mtu)
+
+	return clientPod, serverIPWithCIDR
+}
+
 //nolint:unparam // mtu values are fixed by the suite's MTU matrix.
 func runBondScenario(
 	bondMode string,
 	mtuSmall int,
 	mtuLarge int,
-	serverIPSmall string,
-	clientIPSmall string,
-	serverIPLarge string,
-	clientIPLarge string,
 	serverNode string,
 	clientNode string,
 	slaveNetworksSmall []string,
 	slaveNetworksLarge []string,
+	ips bondScenarioIPSetup,
 ) {
 	nadSmall := bondNADNameFor(bondMode, mtuSmall)
 	nadLarge := bondNADNameFor(bondMode, mtuLarge)
 
-	By("Creating bond NADs for both MTUs")
+	if ips.whereabouts {
+		By("Creating bond NADs with whereabouts IPAM for both MTUs")
+	} else {
+		By("Creating bond NADs for both MTUs")
+	}
 
-	deleteBondNADBestEffort(nadSmall)
-	deleteBondNADBestEffort(nadLarge)
-
-	bondSmall, err := sriovenv.CreateBondNAD(nadSmall, bondMode, "static", mtuSmall, 2)
-	Expect(err).ToNot(HaveOccurred(), "Failed to build small MTU bond NAD")
-
-	_, err = bondSmall.Create()
-	Expect(err).ToNot(HaveOccurred(), "Failed to create small MTU bond NAD")
-
+	createBondScenarioNAD(nadSmall, bondMode, mtuSmall, ips.whereabouts)
 	defer func() { deleteBondNADBestEffort(nadSmall) }()
 
-	bondLarge, err := sriovenv.CreateBondNAD(nadLarge, bondMode, "static", mtuLarge, 2)
-	Expect(err).ToNot(HaveOccurred(), "Failed to build large MTU bond NAD")
-
-	_, err = bondLarge.Create()
-	Expect(err).ToNot(HaveOccurred(), "Failed to create large MTU bond NAD")
-
+	createBondScenarioNAD(nadLarge, bondMode, mtuLarge, ips.whereabouts)
 	defer func() { deleteBondNADBestEffort(nadLarge) }()
 
 	modeSuffix := strings.ReplaceAll(bondMode, "balance-", "")
-	serverSmallName := fmt.Sprintf("bond-server-%s-mtu%d", modeSuffix, mtuSmall)
-	clientSmallName := fmt.Sprintf("bond-client-%s-mtu%d", modeSuffix, mtuSmall)
-	serverLargeName := fmt.Sprintf("bond-server-%s-mtu%d", modeSuffix, mtuLarge)
-	clientLargeName := fmt.Sprintf("bond-client-%s-mtu%d", modeSuffix, mtuLarge)
+	serverSmallName, clientSmallName := bondScenarioPodNames(ips.whereabouts, modeSuffix, mtuSmall)
+	serverLargeName, clientLargeName := bondScenarioPodNames(ips.whereabouts, modeSuffix, mtuLarge)
 
 	By("Creating server and client pods for both MTUs (4 pods total)")
 
-	_, clientSmall := createBondedPodsPair(
+	clientSmall, serverIPSmall := createBondScenarioPodsPair(
 		nadSmall,
 		serverSmallName, clientSmallName,
 		serverNode, clientNode,
-		slaveNetworksSmall, serverIPSmall, clientIPSmall, mtuSmall,
+		slaveNetworksSmall, mtuSmall,
+		ips.serverIPSmall, ips.clientIPSmall, ips.whereabouts,
 	)
-	_, clientLarge := createBondedPodsPair(
+	clientLarge, serverIPLarge := createBondScenarioPodsPair(
 		nadLarge,
 		serverLargeName, clientLargeName,
 		serverNode, clientNode,
-		slaveNetworksLarge, serverIPLarge, clientIPLarge, mtuLarge,
+		slaveNetworksLarge, mtuLarge,
+		ips.serverIPLarge, ips.clientIPLarge, ips.whereabouts,
 	)
 
 	By("Verifying traffic on bond interface for both MTUs")
@@ -1330,4 +1443,75 @@ func deleteBondNADBestEffort(name string) {
 	if err := deleteBondNADIfExists(name); err != nil {
 		klog.Warningf("best-effort bond NAD cleanup failed for %s: %v", name, err)
 	}
+}
+
+func bondWhereaboutsIPAMForMTU(mtu int) (ipRange, gateway string) {
+	ipRange = tsparams.WhereaboutsIPv6Range
+	gateway = tsparams.WhereaboutsIPv6Gateway
+
+	if mtu >= mtu9000 {
+		ipRange = tsparams.WhereaboutsIPv6Range2
+		gateway = tsparams.WhereaboutsIPv6Gateway2
+	}
+
+	return ipRange, gateway
+}
+
+func createBondWhereaboutsPodsPair(
+	nadName string,
+	serverName, clientName,
+	serverNode, clientNode string,
+	slaveNetworks []string,
+	mtu int,
+) (*pod.Builder, *pod.Builder) {
+	annotation := bondWhereaboutsPodAnnotation(nadName, slaveNetworks)
+	Expect(annotation).NotTo(BeEmpty(), "Failed to create whereabouts bond pod annotation")
+
+	serverCmd := sriovenv.BuildServerCommand("", sriovenv.BondInterfaceName, mtu)
+
+	serverContainer, err := pod.NewContainerBuilder("server", NetConfig.CnfNetTestContainer, serverCmd).GetContainerCfg()
+	Expect(err).ToNot(HaveOccurred(), "Failed to build server container config")
+
+	serverPod, err := pod.NewBuilder(APIClient, serverName, tsparams.TestNamespaceName, NetConfig.CnfNetTestContainer).
+		DefineOnNode(serverNode).
+		RedefineDefaultContainer(*serverContainer).
+		WithPrivilegedFlag().
+		WithSecondaryNetwork(annotation).
+		CreateAndWaitUntilRunning(netparam.DefaultTimeout)
+	Expect(err).ToNot(HaveOccurred(), "Failed to create server pod")
+
+	Expect(sriovenv.WaitForServerReady(serverPod, tsparams.WaitTimeout)).
+		To(Succeed(), "Server pod testcmd listeners not ready")
+
+	clientPod, err := pod.NewBuilder(APIClient, clientName, tsparams.TestNamespaceName, NetConfig.CnfNetTestContainer).
+		DefineOnNode(clientNode).
+		WithPrivilegedFlag().
+		WithSecondaryNetwork(annotation).
+		CreateAndWaitUntilRunning(netparam.DefaultTimeout)
+	Expect(err).ToNot(HaveOccurred(), "Failed to create client pod")
+
+	Expect(sriovenv.WaitForBondSlavesMIIUp(serverPod, sriovenv.BondInterfaceName)).
+		To(Succeed(), "Server bond slaves not MII up in pod %s", serverName)
+	Expect(sriovenv.WaitForBondSlavesMIIUp(clientPod, sriovenv.BondInterfaceName)).
+		To(Succeed(), "Client bond slaves not MII up in pod %s", clientName)
+
+	return serverPod, clientPod
+}
+
+func bondWhereaboutsPodAnnotation(nadName string, slaveNetworks []string) []*multus.NetworkSelectionElement {
+	var annotation []*multus.NetworkSelectionElement
+
+	for _, slaveNetwork := range slaveNetworks {
+		slave := pod.StaticAnnotation(slaveNetwork)
+		Expect(slave).NotTo(BeNil(), "Failed to build slave network annotation for %s", slaveNetwork)
+		annotation = append(annotation, slave)
+	}
+
+	annotation = append(annotation, &multus.NetworkSelectionElement{
+		Name:             nadName,
+		Namespace:        tsparams.TestNamespaceName,
+		InterfaceRequest: sriovenv.BondInterfaceName,
+	})
+
+	return annotation
 }


### PR DESCRIPTION
Summary
Adds CreateBondNADWithWhereabouts in sriovenv/bond.go to build Bond CNI NADs with Whereabouts IPAM on the bond interface (complement to the existing static-IP CreateBondNAD).
Introduces LabelBondIPAMTestCases (bond-ipam) in tsparams for selective test runs once IPAM cases land.
Exposes bondSuiteWorkerNodeList and bondSuiteClusterIPFamily from the bond suite BeforeAll so a follow-up sriov-bond-ipam.go can reuse the same cluster setup without duplicating policy/network provisioning.
This PR prepares the second bond PR on top of add-sriov-bond-mode. The whereabouts IPAM test cases (ported from cnf-gotests sriov_bond-ipam.go) will be added in a follow-up change to sriov-bond-ipam.go.

Depends on: add-sriov-bond-mode (must merge first)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded active-backup SR-IOV bond test coverage with IPv6 Whereabouts IPAM, including additional node/PF combinations.
  * Added MTU-specific bond IP setup supporting both static and Whereabouts modes.
  * Extended traffic tests to optionally select the client/server network interface.
  * Made SR-IOV policy VF sizing explicitly configurable based on total available capacity.
* **Bug Fixes**
  * Improved bond network/NAD lifecycle handling by clearing stale IPAM state, regenerating outdated slave NADs, and ensuring fresh NAD creation before traffic validation.
  * Enhanced VF counting logic to better handle invalid or empty worker selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->