### PR TITLE
ci: sign commits for eco-goinfra-bump

### DIFF
--- a/.github/workflows/eco-goinfra-bump.yml
+++ b/.github/workflows/eco-goinfra-bump.yml
@@ -43,10 +43,10 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         env:
-          GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           commit-message: "deps: bump github.com/rh-ecosystem-edge/eco-goinfra"
-          author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
+          sign-commits: true
           title: Bump eco-goinfra dependency
           branch: eco-goinfra-bump-${{ inputs.target_branch || github.event.repository.default_branch }}
           base: ${{ inputs.target_branch || github.event.repository.default_branch }}


### PR DESCRIPTION
This commit follows the approach in rh-ecosystem-edge/eco-goinfra#1511
to sign the commits created by the automated eco-goinfra-bump job. This
is a prerequisite to requiring all commits to have signatures.

Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated dependency update process to use the platform’s built-in authentication.
  * Enabled signed commits for generated update pull requests.
  * Simplified commit metadata for these automated changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->