### PR TITLE
system-tests: add retry logic for node uncordon operations

### DIFF
--- a/tests/system-tests/rdscore/internal/rdscorecommon/egress-ip.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/egress-ip.go
@@ -742,13 +742,9 @@ func gracefulNodeReboot(nodeName string) error {
 		return fmt.Errorf("node %s hasn't reached Ready state", nodeName)
 	}
 
-	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Uncordoning node %q", nodeName)
-
-	err = nodeObj.Uncordon()
+	err = UncordonNode(nodeObj, uncordonNodeInterval, uncordonNodeTimeout)
 	if err != nil {
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to uncordon %q due to %v", nodeName, err)
-
-		return fmt.Errorf("failed to uncordon %q due to %w", nodeName, err)
+		return err
 	}
 
 	time.Sleep(15 * time.Second)
@@ -913,10 +909,9 @@ func EnsureInNodeReadiness(ctx SpecContext) {
 			"Node hasn't reached Ready state")
 
 		if _node.Object.Spec.Unschedulable {
-			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Uncordoning node %q", _node.Definition.Name)
-			err = _node.Uncordon()
+			err := UncordonNode(_node, uncordonNodeInterval, uncordonNodeTimeout)
 			Expect(err).ToNot(HaveOccurred(),
-				fmt.Sprintf("Failed to uncordon %q due to %v", _node.Definition.Name, err))
+				fmt.Sprintf("Failed to uncordon %q", _node.Definition.Name))
 
 			time.Sleep(15 * time.Second)
 		}

--- a/tests/system-tests/rdscore/internal/rdscorecommon/hard-reboot.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/hard-reboot.go
@@ -208,7 +208,11 @@ func VerifySoftReboot(ctx SpecContext) {
 		Expect(err).ToNot(HaveOccurred(),
 			fmt.Sprintf("Failed to cordon %q due to %v", _node.Definition.Name, err))
 
-		defer UncordonNode(_node, uncordonNodeInterval, uncordonNodeTimeout)
+		defer func() {
+			if err := UncordonNode(_node, uncordonNodeInterval, uncordonNodeTimeout); err != nil {
+				klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Deferred uncordon failed: %v", err)
+			}
+		}()
 
 		time.Sleep(5 * time.Second)
 
@@ -284,10 +288,9 @@ func VerifySoftReboot(ctx SpecContext) {
 		}).WithTimeout(25*time.Minute).WithPolling(15*time.Second).WithContext(ctx).Should(BeTrue(),
 			"Node hasn't reached Ready state")
 
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Uncordoning node %q", _node.Definition.Name)
-		err = _node.Uncordon()
+		err = UncordonNode(_node, uncordonNodeInterval, uncordonNodeTimeout)
 		Expect(err).ToNot(HaveOccurred(),
-			fmt.Sprintf("Failed to uncordon %q due to %v", _node.Definition.Name, err))
+			fmt.Sprintf("Failed to uncordon %q", _node.Definition.Name))
 
 		time.Sleep(15 * time.Second)
 	}

--- a/tests/system-tests/rdscore/internal/rdscorecommon/rdscore-helpers.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/rdscore-helpers.go
@@ -27,25 +27,43 @@ const (
 
 // UncordonNode uncordons a node referenced by nodeToUncordon parameter.
 // It retries uncordoning for the specified timeout duration at regular intervals.
-func UncordonNode(nodeToUncordon *nodes.Builder, interval, timeout time.Duration) {
+// Returns error if uncordon fails after timeout to allow caller to handle appropriately.
+func UncordonNode(nodeToUncordon *nodes.Builder, interval, timeout time.Duration) error {
 	By(fmt.Sprintf("Uncordoning node %q", nodeToUncordon.Definition.Name))
 
 	err := wait.PollUntilContextTimeout(context.TODO(), interval, timeout, true,
 		func(context.Context) (bool, error) {
 			err := nodeToUncordon.Uncordon()
 			if err != nil {
-				klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to uncordon %q: %v", nodeToUncordon.Definition.Name, err)
+				errorMsg := err.Error()
+				// Log retryable errors differently from permanent failures
+				if strings.Contains(errorMsg, "ManagedNode infra config cache not synchronized") ||
+					strings.Contains(errorMsg, "connection reset") ||
+					strings.Contains(errorMsg, "connection refused") {
+					klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+						"Uncordon failed with retryable error, will retry: %v", err)
 
-				return false, nil
+					return false, nil
+				}
+
+				klog.V(rdscoreparams.RDSCoreLogLevel).Infof(
+					"Failed to uncordon %q: %v", nodeToUncordon.Definition.Name, err)
+
+				return false, err
 			}
 
 			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Successfully uncordon %q", nodeToUncordon.Definition.Name)
 
-			return err == nil, nil
+			return true, nil
 		})
 	if err != nil {
-		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to uncordon %q: %v", nodeToUncordon.Definition.Name, err)
+		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to uncordon %q after %v: %v",
+			nodeToUncordon.Definition.Name, timeout, err)
+
+		return fmt.Errorf("failed to uncordon %q within %v: %w", nodeToUncordon.Definition.Name, timeout, err)
 	}
+
+	return nil
 }
 
 // DrainNodeWithRetry drains a node with retry logic for transient failures.

--- a/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-deployment.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-deployment.go
@@ -844,7 +844,11 @@ func VerifyConnectivityAfterNodeDrain(
 	Expect(err).ToNot(HaveOccurred(),
 		fmt.Sprintf("Failed to cordon node %s due to: %v", nodeToDrain, err))
 
-	defer UncordonNode(nodeObj, uncordonNodeInterval, uncordonNodeTimeout)
+	defer func() {
+		if err := UncordonNode(nodeObj, uncordonNodeInterval, uncordonNodeTimeout); err != nil {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Deferred uncordon failed: %v", err)
+		}
+	}()
 
 	By(fmt.Sprintf("Draining node %q", nodeToDrain))
 

--- a/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-statefulset.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/whereabouts-statefulset.go
@@ -1165,7 +1165,11 @@ func ensurePodConnectivityAfterNodeDrain(
 	Expect(err).ToNot(HaveOccurred(),
 		fmt.Sprintf("Failed to cordon node %s due to: %v", nodeToDrain, err))
 
-	defer UncordonNode(nodeObj, uncordonNodeInterval, uncordonNodeTimeout)
+	defer func() {
+		if err := UncordonNode(nodeObj, uncordonNodeInterval, uncordonNodeTimeout); err != nil {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Deferred uncordon failed: %v", err)
+		}
+	}()
 
 	time.Sleep(5 * time.Second)
 


### PR DESCRIPTION
Node uncordon was failing intermittently on production RDS clusters due to cluster-autoscaler admission webhook cache synchronization delays.

Changes:
- Enhance UncordonNode() helper to return error (matching DrainNodeWithRetry pattern)
- Add error categorization for autoscaler cache sync and network transient errors
- Replace direct .Uncordon() calls with UncordonNode() helper in hard-reboot.go
- Replace direct .Uncordon() calls with UncordonNode() helper in egress-ip.go (2 locations)
- Update defer UncordonNode() calls to handle returned errors with anonymous functions
- Add detailed logging for retry attempts and timeout failures

Root cause:
- After node reboot, cluster-autoscaler admission webhook needs 15-30s to synchronize internal cache before accepting node modifications
- Direct uncordon calls fail immediately on first transient error
- UncordonNode() helper retries for 3 minutes with 15-second interval

Error handling:
- UncordonNode now returns error like DrainNodeWithRetry for consistency
- Callers use Expect() for test failures or return error for propagation
- Deferred cleanup wraps calls in anonymous functions to log failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced system test node cleanup (uncordon) to reliably detect and report failures.
  * Updated uncordon helper behavior to return errors, stop immediately on non-retryable issues, and provide clearer timeout failure context.
  * Improved deferred uncordon handling to log errors during teardown, and adjusted reboot readiness flows to assert uncordon success consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->