### PR TITLE
cnf-network: updated sctp verification and metallb metric port

### DIFF
--- a/tests/cnf/core/network/metallb/internal/frr/frr.go
+++ b/tests/cnf/core/network/metallb/internal/frr/frr.go
@@ -384,8 +384,13 @@ func IsProtocolConfigured(frrPod *pod.Builder, protocol string) (bool, error) {
 }
 
 // GetMetricsByPrefix pulls all metrics from frr pods and sort them in the list by given prefix.
-func GetMetricsByPrefix(frrPod *pod.Builder, metricPrefix string) ([]string, error) {
-	stdout, err := frrPod.ExecCommand([]string{"curl", "localhost:7573/metrics"}, "frr")
+// The token parameter is a bearer token used to authenticate against the kube-rbac-proxy on the metrics endpoint.
+func GetMetricsByPrefix(frrPod *pod.Builder, metricPrefix, token string) ([]string, error) {
+	stdout, err := frrPod.ExecCommand([]string{
+		"curl", "-sk",
+		"-H", fmt.Sprintf("Authorization: Bearer %s", token),
+		"https://localhost:9141/metrics",
+	}, "frr")
 	if err != nil {
 		return nil, err
 	}

--- a/tests/cnf/core/network/metallb/tests/common.go
+++ b/tests/cnf/core/network/metallb/tests/common.go
@@ -20,6 +20,7 @@ import (
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/metallb/mlbtypes"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/schemes/metallb/mlbtypesv1beta2"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/service"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/serviceaccount"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/internal/coreparams"
 	netcmd "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/cmd"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/define"
@@ -591,6 +592,14 @@ func verifyMetricPresentInPrometheus(
 	frrk8sPods []*pod.Builder, prometheusPod *pod.Builder, metricPrefix string, expectedMetrics ...[]string) {
 	By("Verifying if metrics are present in Prometheus database")
 
+	By("Obtaining bearer token for FRR metrics endpoint")
+
+	promSA, err := serviceaccount.Pull(APIClient, "prometheus-k8s", NetConfig.PrometheusOperatorNamespace)
+	Expect(err).ToNot(HaveOccurred(), "Failed to pull prometheus-k8s service account")
+
+	metricsToken, err := promSA.CreateToken(10 * time.Minute)
+	Expect(err).ToNot(HaveOccurred(), "Failed to create token for prometheus-k8s service account")
+
 	for _, frrk8sPod := range frrk8sPods {
 		var (
 			metricsFromSpeaker []string
@@ -598,7 +607,7 @@ func verifyMetricPresentInPrometheus(
 		)
 
 		Eventually(func() error {
-			metricsFromSpeaker, err = frr.GetMetricsByPrefix(frrk8sPod, metricPrefix)
+			metricsFromSpeaker, err = frr.GetMetricsByPrefix(frrk8sPod, metricPrefix, metricsToken)
 
 			return err
 		}, time.Minute, tsparams.DefaultRetryInterval).ShouldNot(HaveOccurred(),

--- a/tests/cnf/core/network/metallb/tests/pool-selector.go
+++ b/tests/cnf/core/network/metallb/tests/pool-selector.go
@@ -302,7 +302,7 @@ func activateSCTPModuleOnMasterNodes() {
 	Expect(err).ToNot(HaveOccurred(), "Failed to verify sctp module status on master nodes")
 
 	for node, output := range nodeOutputs {
-		Expect(output).To(ContainSubstring("libcrc32c"), fmt.Sprintf("SCTP module is not active on %s", node))
+		Expect(output).To(ContainSubstring("sctp"), fmt.Sprintf("SCTP module is not active on %s", node))
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SCTP module verification on master nodes by checking for the expected SCTP output during validation, reducing incorrect pass/fail results.
  * Updated FRR Prometheus metrics retrieval to use authenticated access, improving reliability of metric-based checks during test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->