### PR TITLE
cnf network: add fix for metallb poolselector sctp check

### DIFF
--- a/tests/cnf/core/network/metallb/tests/pool-selector.go
+++ b/tests/cnf/core/network/metallb/tests/pool-selector.go
@@ -302,7 +302,7 @@ func activateSCTPModuleOnMasterNodes() {
 	Expect(err).ToNot(HaveOccurred(), "Failed to verify sctp module status on master nodes")
 
 	for node, output := range nodeOutputs {
-		Expect(output).To(ContainSubstring("libcrc32c"), fmt.Sprintf("SCTP module is not active on %s", node))
+		Expect(output).To(MatchRegexp(`(?m)^sctp\s`), fmt.Sprintf("SCTP module is not active on %s", node))
 	}
 }
 


### PR DESCRIPTION
Summary
Fix MetalLB pool-selector SCTP verification for OCP 5.0. The BeforeAll check expected libcrc32c in lsmod | grep sctp output, which no longer appears on newer kernels even when SCTP is loaded. Verify the sctp module directly instead.

Test plan
 Run MetalLB pool-selector tests on OCP 5.0
 Confirm BeforeAll SCTP activation passes on master nodes
 Confirm SCTP traffic validation in pool-selector tests still passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved SCTP module verification so it now checks for the expected `sctp` kernel module entry more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->