### PR TITLE
cnf network: fix nftable-reboot

### DIFF
--- a/tests/cnf/core/network/security/tests/nftables-custom-firewall-test.go
+++ b/tests/cnf/core/network/security/tests/nftables-custom-firewall-test.go
@@ -250,6 +250,11 @@ var _ = Describe("nftables", Ordered, Label(tsparams.LabelNftablesTestCases), Co
 				By(fmt.Sprintf("Reboot %s", cnfWorkerNodeList[0].Definition.Name))
 				rebootNodeAndWaitForMcpStable(cnfWorkerNodeList[0].Definition.Name)
 
+				By("Recreate test pods on worker node after reboot")
+
+				testPodWorker0, testPodList = recreateWorker0PodsAfterReboot(
+					cnfWorkerNodeList[0], ipv4SecurityIPList, hubIPv4ExternalAddresses, portNum8888, portNum8088)
+
 				By("Recreate a static route to the external Pod network on worker node after reboot")
 
 				routeMap, err = netenv.BuildRoutesMapWithSpecificRoutes(testPodList, cnfWorkerNodeList, ipv4SecurityIPList)
@@ -434,6 +439,25 @@ func createTestPodOnWorkers(podName, nodeName string, portNum int) *pod.Builder 
 	Expect(err).ToNot(HaveOccurred(), "Failed to create test pod")
 
 	return testPod
+}
+
+func recreateWorker0PodsAfterReboot(
+	workerNode *nodes.Builder,
+	ipv4SecurityIPList, hubIPv4ExternalAddresses []string,
+	port8888, port8088 int,
+) (*pod.Builder, []*pod.Builder) {
+	workerNodeName := workerNode.Definition.Name
+
+	workerTestPod := createTestPodOnWorkers("testpod1", workerNodeName, port8888)
+	_ = createTestPodOnWorkers("testpod2", workerNodeName, port8088)
+
+	hub0StaticIPAnnotation := frrconfig.CreateStaticIPAnnotations(frrconfig.ExternalMacVlanNADName, "nad-hub",
+		[]string{fmt.Sprintf("%s/24", ipv4SecurityIPList[0])},
+		[]string{fmt.Sprintf("%s/24", hubIPv4ExternalAddresses[0])})
+
+	_ = createFrrPodTest("hub-pod-0", workerNode.Object.Name, "hub-node-config", hub0StaticIPAnnotation, false)
+
+	return workerTestPod, []*pod.Builder{workerTestPod}
 }
 
 func createMCAndWaitforMCPStable(fileContentString, mcNftablesName string) {


### PR DESCRIPTION
Summary
Fixes nftables reboot test 77144 (Verify a custom firewall nftables is reloaded after host reboot with all existing rules), which fails after worker node reboot with:

pod object testpod1 does not exist in namespace security-tests

After worker0 reboot and MCP stabilization, the test re-adds a static route by exec’ing into testpod1 (a hostNetwork pod). While the node is NotReady, Kubernetes evicts bare pods after the default toleration window (~5–6 minutes). On OCP 5.0 / RHEL 10, worker reboots take longer than on earlier releases, so this eviction window is now routinely exceeded and testpod1 (and hub-pod-0) are gone before the test continues. The test still held stale pod references and never recreated them.

After reboot, recreate testpod1, testpod2, and hub-pod-0 on worker0 (via recreateWorker0PodsAfterReboot()) before re-adding the static route and running post-reboot connectivity checks. Pod create is idempotent if a pod still exists on a fast reboot. Test coverage is unchanged: we still verify that MachineConfig nftables rules persist and continue to block ingress TCP 8888 after reboot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of firewall and routing validation after node reboot by ensuring the required test pods are recreated before follow-up checks run.
  * Updated the reboot test flow to use refreshed pod references, reducing stale-state failures in network security scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->