### PR TITLE
system-tests: sanitize output for pod-level bond test (#1055) (#1056)

### DIFF
--- a/tests/system-tests/rdscore/internal/rdscorecommon/sriov-pod-level-bond.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/sriov-pod-level-bond.go
@@ -483,7 +483,7 @@ func getBondActiveInterface(clientPod *pod.Builder) (string, error) {
 			glog.V(100).Infof("Successfully executed command from within a pod %q in namespace %q: %v",
 				clientPod.Definition.Name, clientPod.Definition.Namespace, err)
 
-			result = output.String()
+			result = SanitizeOutput(output.String())
 
 			glog.V(100).Infof("Command's output:\n\t%v", result)
 
@@ -1550,4 +1550,25 @@ func VerifyPodLevelBondWorkloadsAfterPodCrashing() {
 			RDSCoreConfig.PodLevelBondDeploymentTwoName, RDSCoreConfig.PodLevelBondNamespace, err))
 
 	verifyConnectivity()
+}
+
+// SanitizeOutput sanitizes the output of the pod-level bond test.
+// It strips the ANSI color codes and extracts the actual value (e.g., the last word or after the colon).
+// Periodically ANSI color codes are added to the output, so we need to strip them and extract the actual value:
+// \x1b[1;31m2026-01-09T12:04:08.312074Z: net1\r\n\x1b[0m -> net1 .
+func SanitizeOutput(input string) string {
+	// 1. Strip ANSI color codes
+	const ansi = `[\x1b\x9b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]`
+
+	re := regexp.MustCompile(ansi)
+	stripped := re.ReplaceAllString(input, "")
+
+	// 2. Extract the actual value (e.g., the last word or after the colon)
+	// In your case, looking for the word after the timestamp
+	parts := strings.Split(stripped, ": ")
+	if len(parts) > 1 {
+		return strings.TrimSpace(parts[1])
+	}
+
+	return strings.TrimSpace(stripped)
 }


### PR DESCRIPTION
(cherry picked from commit e9a3f689fc42e32a923f38f5fbad7a5a15193666) 
(cherry picked from commit 53609f0ee667c9279b449e9bc8d4cfb8dc2c360c)