### PR TITLE
lca ibu: make upgrade y+2 work on demand.

### DIFF
--- a/tests/lca/imagebasedupgrade/mgmt/README.md
+++ b/tests/lca/imagebasedupgrade/mgmt/README.md
@@ -12,3 +12,4 @@
 | `ECO_LCA_IBU_MGMT_ADDITIONAL_NTP_SOURCES` | _(empty)_ | Additional NTP sources for the cluster |
 | `ECO_LCA_IBU_MGMT_STATE_TRANSITIONS` | `false` | Enable state transition testing before upgrade |
 | `ECO_LCA_IBU_MGMT_SECOND_UPGRADE` | `false` | Perform a second upgrade after the first completes |
+| `ECO_LCA_IBU_MGMT_JUMP_RELEASE` | `false` | Jump a release to upgrade to the subsequent version |

--- a/tests/lca/imagebasedupgrade/mgmt/internal/mgmtconfig/config.go
+++ b/tests/lca/imagebasedupgrade/mgmt/internal/mgmtconfig/config.go
@@ -22,6 +22,7 @@ type MGMTConfig struct {
 	AdditionalNTPSources string `envconfig:"ECO_LCA_IBU_MGMT_ADDITIONAL_NTP_SOURCES" default:""`
 	StateTransitions     bool   `envconfig:"ECO_LCA_IBU_MGMT_STATE_TRANSITIONS" default:"false"`
 	SecondUpgrade        bool   `envconfig:"ECO_LCA_IBU_MGMT_SECOND_UPGRADE" default:"false"`
+	JumpRelease          bool   `envconfig:"ECO_LCA_IBU_MGMT_JUMP_RELEASE" default:"false"`
 }
 
 // NewMGMTConfig returns instance of MGMTConfig type.

--- a/tests/lca/imagebasedupgrade/mgmt/upgrade/tests/e2e-upgrade-test.go
+++ b/tests/lca/imagebasedupgrade/mgmt/upgrade/tests/e2e-upgrade-test.go
@@ -560,7 +560,7 @@ var _ = Describe(
 			seedYInt, _ := strconv.Atoi(strings.Split(seedImageClusterVersionXY, ".")[1])
 
 			originalYInt, _ := strconv.Atoi(strings.Split(originalClusterVersionXY, ".")[1])
-			if seedYInt-originalYInt == 2 {
+			if seedYInt-originalYInt == 2 || MGMTConfig.JumpRelease {
 				Skip("The y-stream version of the seed is 2 releases apart from the target")
 			}
 
@@ -594,7 +594,7 @@ var _ = Describe(
 			seedYInt, _ := strconv.Atoi(strings.Split(seedImageClusterVersionXY, ".")[1])
 
 			originalYInt, _ := strconv.Atoi(strings.Split(originalClusterVersionXY, ".")[1])
-			if seedYInt-originalYInt != 2 {
+			if seedYInt-originalYInt != 2 && !MGMTConfig.JumpRelease {
 				Skip("The y-stream version of the seed is not 2 releases apart from the target")
 			}
 


### PR DESCRIPTION
The switch to 5.y version makes it hard to predict the versions to jump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional upgrade mode that allows certain release jumps to be enabled through configuration.
* **Bug Fixes**
  * Updated upgrade scenario handling so compatibility checks respect the new jump-release setting.
  * Improved test coverage for upgrade paths with different version gaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->