### PR TITLE
cnf ran oran: fix condition message for 78245

### DIFF
--- a/tests/cnf/ran/oran/internal/tsparams/oranvars.go
+++ b/tests/cnf/ran/oran/internal/tsparams/oranvars.go
@@ -83,6 +83,6 @@ var (
 		Type:    string(provisioningv1alpha1.CTconditionTypes.Validated),
 		Reason:  string(provisioningv1alpha1.CTconditionReasons.Failed),
 		Status:  metav1.ConditionFalse,
-		Message: "Error validating the clusterInstanceParameters schema",
+		Message: "ClusterTemplate must define hardware provisioning",
 	}
 )


### PR DESCRIPTION
Recently, the message for the condition this test checks has changed. This commit updates the message to contain the first bit of the full condition message. The rest of the test remains the same.

Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated a validation message to more clearly explain that a ClusterTemplate must define hardware provisioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->