### PR TITLE
cnf network: wait for NMState policy availability before using interfaces

### DIFF
--- a/tests/cnf/core/network/metallb/tests/bgp-unnumbered.go
+++ b/tests/cnf/core/network/metallb/tests/bgp-unnumbered.go
@@ -243,7 +243,7 @@ func enableEthernetInterfaceWithIP(policyName, nodeName, interfaceName string) {
 
 	ethernetInterface.WithEthernetIPv6LinkLocalInterface(interfaceName)
 
-	_, err := ethernetInterface.Create()
+	err := netnmstate.CreatePolicyAndWaitUntilItsAvailable(netparam.DefaultTimeout, ethernetInterface)
 	Expect(err).ToNot(HaveOccurred(),
 		fmt.Sprintf("fail to add an IP address to interface: %s", interfaceName))
 }

--- a/tests/cnf/core/network/metallb/tests/frrk8-tests.go
+++ b/tests/cnf/core/network/metallb/tests/frrk8-tests.go
@@ -763,7 +763,7 @@ func createSecondaryInterfaceOnNode(policyName, nodeName, interfaceName, ipv4Add
 
 	secondaryInterface.WithVlanInterfaceIP(interfaceName, ipv4Address, ipv6Address, vlanID)
 
-	_, err := secondaryInterface.Create()
+	err := netnmstate.CreatePolicyAndWaitUntilItsAvailable(netparam.DefaultTimeout, secondaryInterface)
 	Expect(err).ToNot(HaveOccurred(),
 		"fail to create secondary interface: %s.+%d", interfaceName, vlanID)
 }


### PR DESCRIPTION


enableEthernetInterfaceWithIP and createSecondaryInterfaceOnNode were fire-and-forget: they created NMState policies but never waited for them to be applied. NMState policies take ~2.5-3 minutes to apply, but subsequent test steps expected the interfaces to be ready within 30-60 seconds.

Use netnmstate.CreatePolicyAndWaitUntilItsAvailable to block until the policy reaches Available state. Also increase the getLinkLocalAddress timeout from 30s to 5m and the static route retry from 1m to 5m as safety margins.

Fixes tests 80393 (BGP Unnumbered) and 75248 (iBGP multihop over secondary interface).