### PR TITLE
system-tests: fix race condition in verifyMsgInPodLogs function (#1504) (#1505)

### DIFF
--- a/tests/system-tests/rdscore/internal/rdscorecommon/sriov-validation.go
+++ b/tests/system-tests/rdscore/internal/rdscorecommon/sriov-validation.go
@@ -521,9 +521,8 @@ func verifyMsgInPodLogs(podObj *pod.Builder, msg, cName string, timeSpan time.Ti
 	klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Parsing duration %q", timeSpan)
 
 	var (
-		podLog string
-		err    error
-		ctx    SpecContext
+		err error
+		ctx SpecContext
 	)
 
 	Eventually(func() bool {
@@ -535,7 +534,7 @@ func verifyMsgInPodLogs(podObj *pod.Builder, msg, cName string, timeSpan time.Ti
 			Expect(err).ToNot(HaveOccurred(), "Failed to parse time duration")
 		}
 
-		podLog, err = podObj.GetLog(logStartTimestamp, cName)
+		podLog, err := podObj.GetLog(logStartTimestamp, cName)
 		if err != nil {
 			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Failed to get logs from pod %q: %v", podObj.Definition.Name, err)
 
@@ -544,11 +543,15 @@ func verifyMsgInPodLogs(podObj *pod.Builder, msg, cName string, timeSpan time.Ti
 
 		klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Logs from pod %s:\n%s", podObj.Definition.Name, podLog)
 
-		return true
-	}).WithContext(ctx).WithPolling(5*time.Second).WithTimeout(1*time.Minute).Should(BeTrue(),
-		fmt.Sprintf("Failed to get logs from pod %q", podObj.Definition.Name))
+		if !strings.Contains(podLog, msg) {
+			klog.V(rdscoreparams.RDSCoreLogLevel).Infof("Message %q not yet in logs, will retry", msg)
 
-	Expect(podLog).Should(ContainSubstring(msg))
+			return false
+		}
+
+		return true
+	}).WithContext(ctx).WithPolling(5*time.Second).WithTimeout(2*time.Minute).Should(BeTrue(),
+		fmt.Sprintf("Message %q not found in pod %q logs after 2 minutes", msg, podObj.Definition.Name))
 }
 
 func verifySRIOVConnectivity(nsOneName, nsTwoName, deployOneLabels, deployTwoLabels, targetAddr string) {


### PR DESCRIPTION
Fix timing bug in verifyMsgInPodLogs where message verification happened after the Eventually polling loop completed, causing intermittent test failures when messages arrived with slight delays (especially for IPv6).

Root cause:
- Eventually block polled for successful log retrieval (up to 1 minute)
- Once logs retrieved successfully, loop exited immediately
- Message check (Expect(podLog).Should(ContainSubstring(msg))) at line 590 happened OUTSIDE the loop as a single non-retrying assertion
- If message not yet in logs due to network/log propagation delay (common after pod termination/recreation), test failed immediately

(cherry picked from commit dfced9094cc3bd3b0e287334c4a75be6a97af120)

(cherry picked from commit 823c99885ed4ea92e4fe099cb2dc1600e31cf563)