### PR TITLE
cnf network: add sriov operator reinstall tc

### DIFF
--- a/tests/cnf/core/network/sriov/internal/sriovenv/operator.go
+++ b/tests/cnf/core/network/sriov/internal/sriovenv/operator.go
@@ -1,0 +1,325 @@
+package sriovenv
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	admregv1 "k8s.io/api/admissionregistration/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/namespace"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/olm"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/sriov"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/webhook"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netinittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/sriov/internal/tsparams"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/sriovoperator"
+)
+
+// InstalledSriovOperator holds OLM resources required to reinstall the SR-IOV operator.
+type InstalledSriovOperator struct {
+	Namespace      *namespace.Builder
+	OperatorGroup  *olm.OperatorGroupBuilder
+	Subscription   *olm.SubscriptionBuilder
+	OperatorConfig *sriov.OperatorConfigBuilder
+}
+
+// CollectInstalledSriovOperatorInfo pulls the SR-IOV operator namespace, OperatorGroup, Subscription,
+// and SriovOperatorConfig for use during reinstall.
+func CollectInstalledSriovOperatorInfo() (*InstalledSriovOperator, error) {
+	sriovNs, err := namespace.Pull(APIClient, NetConfig.SriovOperatorNamespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to pull SR-IOV operator namespace: %w", err)
+	}
+
+	sriovOg, err := olm.PullOperatorGroup(APIClient, tsparams.OperatorGroupName, NetConfig.SriovOperatorNamespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to pull SR-IOV OperatorGroup: %w", err)
+	}
+
+	sriovSub, err := olm.PullSubscription(APIClient, tsparams.OperatorSubscriptionName, NetConfig.SriovOperatorNamespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to pull %s: %w", tsparams.OperatorSubscriptionName, err)
+	}
+
+	sriovCfg, err := sriov.PullOperatorConfig(APIClient, NetConfig.SriovOperatorNamespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to pull SriovOperatorConfig: %w", err)
+	}
+
+	return &InstalledSriovOperator{
+		Namespace:      sriovNs,
+		OperatorGroup:  sriovOg,
+		Subscription:   sriovSub,
+		OperatorConfig: sriovCfg,
+	}, nil
+}
+
+// RemoveSriovOperator removes SR-IOV configuration, operator config, webhooks, and the operator namespace.
+func RemoveSriovOperator(sriovNamespace *namespace.Builder) error {
+	if err := sriovoperator.RemoveSriovConfigurationAndWaitForSriovAndMCPStable(
+		APIClient,
+		NetConfig.WorkerLabelEnvVar,
+		NetConfig.SriovOperatorNamespace,
+		tsparams.MCOWaitTimeout,
+		tsparams.DefaultTimeout); err != nil {
+		return fmt.Errorf("failed to remove SR-IOV configuration: %w", err)
+	}
+
+	sriovOperatorConfig, err := sriov.PullOperatorConfig(APIClient, NetConfig.SriovOperatorNamespace)
+	if err != nil {
+		return fmt.Errorf("failed to pull SriovOperatorConfig: %w", err)
+	}
+
+	if _, err = sriovOperatorConfig.Delete(); err != nil {
+		return fmt.Errorf("failed to remove default SR-IOV operator config: %w", err)
+	}
+
+	if err := waitForSriovMutatingWebhooksRemoved(
+		tsparams.OperatorWebhookWaitTimeout, tsparams.RetryInterval); err != nil {
+		return err
+	}
+
+	if err := waitForSriovValidatingWebhookRemoved(
+		tsparams.OperatorWebhookWaitTimeout, tsparams.RetryInterval); err != nil {
+		return err
+	}
+
+	if err := sriovNamespace.DeleteAndWait(tsparams.DefaultTimeout); err != nil {
+		return fmt.Errorf("failed to delete SR-IOV namespace %s: %w", NetConfig.SriovOperatorNamespace, err)
+	}
+
+	return nil
+}
+
+// InstallSriovOperator deploys the SR-IOV operator namespace, OperatorGroup, Subscription, and config.
+// Existing OLM resources are left in place so the call is safe after a partial reinstall.
+// SriovOperatorConfig is recreated from the spec captured before removal when missing.
+func InstallSriovOperator(installed *InstalledSriovOperator) error {
+	ns := namespace.NewBuilder(APIClient, installed.Namespace.Definition.Name)
+	if !ns.Exists() {
+		if _, err := ns.Create(); err != nil {
+			return fmt.Errorf("failed to create SR-IOV namespace %s: %w", installed.Namespace.Definition.Name, err)
+		}
+	}
+
+	og := olm.NewOperatorGroupBuilder(
+		APIClient,
+		installed.OperatorGroup.Definition.Name,
+		installed.OperatorGroup.Definition.Namespace)
+	if !og.Exists() {
+		if _, err := og.Create(); err != nil {
+			return fmt.Errorf("failed to create SR-IOV OperatorGroup %s: %w", installed.OperatorGroup.Definition.Name, err)
+		}
+	}
+
+	sub := olm.NewSubscriptionBuilder(
+		APIClient,
+		installed.Subscription.Definition.Name,
+		installed.Subscription.Definition.Namespace,
+		installed.Subscription.Definition.Spec.CatalogSource,
+		installed.Subscription.Definition.Spec.CatalogSourceNamespace,
+		installed.Subscription.Definition.Spec.Package)
+	if channel := installed.Subscription.Definition.Spec.Channel; channel != "" {
+		sub = sub.WithChannel(channel)
+	}
+
+	if !sub.Exists() {
+		if _, err := sub.Create(); err != nil {
+			return fmt.Errorf("failed to create SR-IOV Subscription %s: %w", installed.Subscription.Definition.Name, err)
+		}
+	}
+
+	return restoreOperatorConfig(installed)
+}
+
+func restoreOperatorConfig(installed *InstalledSriovOperator) error {
+	cfg := sriov.NewOperatorConfigBuilder(APIClient, installed.Namespace.Definition.Name)
+	if cfg.Exists() {
+		return nil
+	}
+
+	if installed.OperatorConfig != nil && installed.OperatorConfig.Definition != nil {
+		cfg.Definition.Spec = *installed.OperatorConfig.Definition.Spec.DeepCopy()
+	} else {
+		cfg.WithOperatorWebhook(true).WithInjector(true)
+	}
+
+	if _, err := cfg.Create(); err != nil {
+		return fmt.Errorf("failed to create SR-IOV operator config: %w", err)
+	}
+
+	return nil
+}
+
+// WaitForSriovOperatorDeployed polls until SR-IOV operator daemonsets are present and ready.
+func WaitForSriovOperatorDeployed(timeout, interval time.Duration) error {
+	err := wait.PollUntilContextTimeout(context.TODO(), interval, timeout, true, func(ctx context.Context) (bool, error) {
+		deployErr := sriovoperator.IsSriovDeployed(APIClient, NetConfig.SriovOperatorNamespace)
+
+		return deployErr == nil, nil
+	})
+	if err != nil {
+		return fmt.Errorf("SR-IOV operator is not ready: %w", err)
+	}
+
+	return nil
+}
+
+// ValidateReinstalledSriovWebhookFailurePolicies checks mutating and validating webhook FailurePolicy values.
+func ValidateReinstalledSriovWebhookFailurePolicies() error {
+	resourceInjector, err := webhook.PullMutatingConfiguration(APIClient, tsparams.MutatingWebhookResourceInjectorConfig)
+	if err != nil {
+		return fmt.Errorf("failed to pull mutating webhook %s: %w", tsparams.MutatingWebhookResourceInjectorConfig, err)
+	}
+
+	if err := expectMutatingWebhookFailurePolicy(
+		resourceInjector.Object.Webhooks, tsparams.MutatingWebhookResourceInjectorEntry, admregv1.Ignore); err != nil {
+		return err
+	}
+
+	operatorMutating, err := webhook.PullMutatingConfiguration(APIClient, tsparams.MutatingWebhookSriovOperatorConfig)
+	if err != nil {
+		return fmt.Errorf("failed to pull mutating webhook %s: %w", tsparams.MutatingWebhookSriovOperatorConfig, err)
+	}
+
+	if err := expectMutatingWebhookFailurePolicy(
+		operatorMutating.Object.Webhooks, tsparams.SriovOperatorWebhookEntry, admregv1.Fail); err != nil {
+		return err
+	}
+
+	validating, err := webhook.PullValidatingConfiguration(APIClient, tsparams.ValidatingWebhookSriovOperatorConfig)
+	if err != nil {
+		return fmt.Errorf("failed to pull validating webhook %s: %w", tsparams.ValidatingWebhookSriovOperatorConfig, err)
+	}
+
+	return expectValidatingWebhookFailurePolicy(
+		validating.Object.Webhooks, tsparams.SriovOperatorWebhookEntry, admregv1.Fail)
+}
+
+func waitForSriovMutatingWebhooksRemoved(timeout, interval time.Duration) error {
+	for _, webhookName := range []string{
+		tsparams.MutatingWebhookResourceInjectorConfig,
+		tsparams.MutatingWebhookSriovOperatorConfig,
+	} {
+		name := webhookName
+
+		err := wait.PollUntilContextTimeout(context.TODO(), interval, timeout, true, func(ctx context.Context) (bool, error) {
+			return isMutatingWebhookConfigurationAbsent(name)
+		})
+		if err != nil {
+			return fmt.Errorf("mutating webhook %s was not removed: %w", name, err)
+		}
+	}
+
+	return nil
+}
+
+func waitForSriovValidatingWebhookRemoved(timeout, interval time.Duration) error {
+	err := wait.PollUntilContextTimeout(context.TODO(), interval, timeout, true, func(ctx context.Context) (bool, error) {
+		return isValidatingWebhookConfigurationAbsent(tsparams.ValidatingWebhookSriovOperatorConfig)
+	})
+	if err != nil {
+		return fmt.Errorf("validating webhook %s was not removed: %w", tsparams.ValidatingWebhookSriovOperatorConfig, err)
+	}
+
+	return nil
+}
+
+func isMutatingWebhookConfigurationAbsent(name string) (bool, error) {
+	if err := APIClient.AttachScheme(admregv1.AddToScheme); err != nil {
+		return false, fmt.Errorf("failed to attach admissionregistration scheme: %w", err)
+	}
+
+	mutatingWebhook := &admregv1.MutatingWebhookConfiguration{}
+
+	err := APIClient.Client.Get(context.TODO(), runtimeclient.ObjectKey{Name: name}, mutatingWebhook)
+	if k8serrors.IsNotFound(err) {
+		return true, nil
+	}
+
+	if err != nil {
+		return false, fmt.Errorf("failed to get mutating webhook %s: %w", name, err)
+	}
+
+	return false, nil
+}
+
+func isValidatingWebhookConfigurationAbsent(name string) (bool, error) {
+	if err := APIClient.AttachScheme(admregv1.AddToScheme); err != nil {
+		return false, fmt.Errorf("failed to attach admissionregistration scheme: %w", err)
+	}
+
+	validatingWebhook := &admregv1.ValidatingWebhookConfiguration{}
+
+	err := APIClient.Client.Get(context.TODO(), runtimeclient.ObjectKey{Name: name}, validatingWebhook)
+	if k8serrors.IsNotFound(err) {
+		return true, nil
+	}
+
+	if err != nil {
+		return false, fmt.Errorf("failed to get validating webhook %s: %w", name, err)
+	}
+
+	return false, nil
+}
+
+func expectMutatingWebhookFailurePolicy(
+	webhooks []admregv1.MutatingWebhook,
+	name string,
+	expected admregv1.FailurePolicyType) error {
+	webhook, found := findMutatingWebhookByName(webhooks, name)
+	if !found || webhook.FailurePolicy == nil {
+		return fmt.Errorf("webhook %s has no failure policy configured", name)
+	}
+
+	if *webhook.FailurePolicy != expected {
+		return fmt.Errorf("webhook %s failure policy is %q, want %q", name, *webhook.FailurePolicy, expected)
+	}
+
+	return nil
+}
+
+func expectValidatingWebhookFailurePolicy(
+	webhooks []admregv1.ValidatingWebhook,
+	name string,
+	expected admregv1.FailurePolicyType) error {
+	webhook, found := findValidatingWebhookByName(webhooks, name)
+	if !found || webhook.FailurePolicy == nil {
+		return fmt.Errorf("webhook %s has no failure policy configured", name)
+	}
+
+	if *webhook.FailurePolicy != expected {
+		return fmt.Errorf("webhook %s failure policy is %q, want %q", name, *webhook.FailurePolicy, expected)
+	}
+
+	return nil
+}
+
+func findMutatingWebhookByName(webhooks []admregv1.MutatingWebhook, name string) (admregv1.MutatingWebhook, bool) {
+	entryName := name + ".k8s.io"
+	for _, webhook := range webhooks {
+		if webhook.Name == name || webhook.Name == entryName {
+			return webhook, true
+		}
+	}
+
+	return admregv1.MutatingWebhook{}, false
+}
+
+func findValidatingWebhookByName(
+	webhooks []admregv1.ValidatingWebhook,
+	name string,
+) (admregv1.ValidatingWebhook, bool) {
+	entryName := name + ".k8s.io"
+	for _, webhook := range webhooks {
+		if webhook.Name == name || webhook.Name == entryName {
+			return webhook, true
+		}
+	}
+
+	return admregv1.ValidatingWebhook{}, false
+}

--- a/tests/cnf/core/network/sriov/internal/tsparams/consts.go
+++ b/tests/cnf/core/network/sriov/internal/tsparams/consts.go
@@ -36,6 +36,23 @@ const (
 	LabelLACPTestCases = "lacp"
 	// LabelBondModeTestCases represents SR-IOV Bond CNI mode tests that can be used for test cases selection.
 	LabelBondModeTestCases = "bond-mode"
+	// LabelSriovReinstallation represents SR-IOV operator reinstallation tests that can be used for test cases selection.
+	LabelSriovReinstallation = "sriovreinstall"
+
+	// MutatingWebhookResourceInjectorConfig is the SR-IOV network resource injector mutating webhook name.
+	MutatingWebhookResourceInjectorConfig = "network-resources-injector-config"
+	// MutatingWebhookSriovOperatorConfig is the SR-IOV operator mutating webhook name.
+	MutatingWebhookSriovOperatorConfig = "sriov-operator-webhook-config"
+	// ValidatingWebhookSriovOperatorConfig is the SR-IOV operator validating webhook name.
+	ValidatingWebhookSriovOperatorConfig = "sriov-operator-webhook-config"
+	// MutatingWebhookResourceInjectorEntry is the webhook entry name inside network-resources-injector-config.
+	MutatingWebhookResourceInjectorEntry = "network-resources-injector-config.k8s.io"
+	// SriovOperatorWebhookEntry is the webhook entry name inside sriov-operator-webhook-config (mutating and validating).
+	SriovOperatorWebhookEntry = "operator-webhook.sriovnetwork.openshift.io"
+	// OperatorGroupName is the default SR-IOV OperatorGroup resource name in the operator namespace.
+	OperatorGroupName = "sriov-network-operators"
+	// OperatorSubscriptionName is the default SR-IOV operator Subscription resource name.
+	OperatorSubscriptionName = "sriov-network-operator-subscription"
 
 	// Net1Interface is the name of the first secondary network interface attached to pods.
 	Net1Interface = "net1"

--- a/tests/cnf/core/network/sriov/internal/tsparams/sriovvars.go
+++ b/tests/cnf/core/network/sriov/internal/tsparams/sriovvars.go
@@ -29,6 +29,10 @@ var (
 	PollingIntervalBMC = 30 * time.Second
 	// NADWaitTimeout represents timeout for the most ginkgo Eventually functions for NAD creation.
 	NADWaitTimeout = 5 * time.Second
+	// OperatorInstallWaitTimeout is the timeout for OLM-based SR-IOV operator install and daemonset readiness.
+	OperatorInstallWaitTimeout = 5 * time.Minute
+	// OperatorWebhookWaitTimeout is the timeout for SR-IOV operator webhook creation or removal.
+	OperatorWebhookWaitTimeout = time.Minute
 	// ReporterCRDsToDump tells to the reporter what CRs to dump.
 	ReporterCRDsToDump = []k8sreporter.CRData{
 		{Cr: &mcfgv1.MachineConfigPoolList{}},

--- a/tests/cnf/core/network/sriov/tests/externalllymanaged.go
+++ b/tests/cnf/core/network/sriov/tests/externalllymanaged.go
@@ -16,11 +16,9 @@ import (
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/namespace"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nmstate"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nodes"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/olm"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/sriov"
-	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/webhook"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/cmd"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/define"
 	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netenv"
@@ -337,16 +335,21 @@ var _ = Describe("ExternallyManaged", Ordered, Label(tsparams.LabelExternallyMan
 
 				By("Collecting info about installed SR-IOV operator")
 
-				sriovNamespace, sriovOperatorgroup, sriovSubscription := collectingInfoSriovOperator()
+				installedOperator, err := sriovenv.CollectInstalledSriovOperatorInfo()
+				Expect(err).ToNot(HaveOccurred(), "Failed to collect SR-IOV operator installation info")
 
 				By("Removing SR-IOV operator")
-				removeSriovOperator(sriovNamespace)
+
+				err = sriovenv.RemoveSriovOperator(installedOperator.Namespace)
+				Expect(err).ToNot(HaveOccurred(), "Failed to remove SR-IOV operator")
 				Expect(
 					sriovoperator.IsSriovDeployed(APIClient, NetConfig.SriovOperatorNamespace)).To(HaveOccurred(),
 					"SR-IOV operator is not removed")
 
 				By("Installing SR-IOV operator")
-				installSriovOperator(sriovNamespace, sriovOperatorgroup, sriovSubscription)
+
+				err = sriovenv.InstallSriovOperator(installedOperator)
+				Expect(err).ToNot(HaveOccurred(), "Failed to install SR-IOV operator")
 				Eventually(func() error {
 					return sriovoperator.IsSriovDeployed(APIClient, NetConfig.SriovOperatorNamespace)
 				}, time.Minute, tsparams.RetryInterval).
@@ -569,105 +572,6 @@ func getVlanIDAndMaxTxRateForVf(nodeName, sriovInterfaceName string) (maxTxRate,
 	Expect(err).ToNot(HaveOccurred(), "Failed to get all SR-IOV VFs")
 
 	return *sriovVfs[0].MaxTxRate, *sriovVfs[0].VlanID
-}
-
-func collectingInfoSriovOperator() (
-	sriovNamespace *namespace.Builder,
-	sriovOperatorGroup *olm.OperatorGroupBuilder,
-	sriovSubscription *olm.SubscriptionBuilder) {
-	sriovNs, err := namespace.Pull(APIClient, NetConfig.SriovOperatorNamespace)
-	Expect(err).ToNot(HaveOccurred(), "Failed to pull SR-IOV operator namespace")
-	sriovOg, err := olm.PullOperatorGroup(APIClient, "sriov-network-operators", NetConfig.SriovOperatorNamespace)
-	Expect(err).ToNot(HaveOccurred(), "Failed to pull SR-IOV OperatorGroup")
-	sriovSub, err := olm.PullSubscription(
-		APIClient,
-		"sriov-network-operator-subscription",
-		NetConfig.SriovOperatorNamespace)
-	Expect(err).ToNot(HaveOccurred(), "Failed to pull sriov-network-operator-subscription")
-
-	return sriovNs, sriovOg, sriovSub
-}
-
-func removeSriovOperator(sriovNamespace *namespace.Builder) {
-	By("Clean all SR-IOV policies and networks")
-
-	err := sriovoperator.RemoveSriovConfigurationAndWaitForSriovAndMCPStable(
-		APIClient,
-		NetConfig.WorkerLabelEnvVar,
-		NetConfig.SriovOperatorNamespace,
-		tsparams.MCOWaitTimeout,
-		tsparams.DefaultTimeout)
-	Expect(err).ToNot(HaveOccurred(), "Failed to remove SR-IOV configuration")
-
-	By("Remove SR-IOV operator config")
-
-	sriovOperatorConfig, err := sriov.PullOperatorConfig(APIClient, NetConfig.SriovOperatorNamespace)
-	Expect(err).ToNot(HaveOccurred(), "Failed to pull SriovOperatorConfig")
-
-	_, err = sriovOperatorConfig.Delete()
-	Expect(err).ToNot(HaveOccurred(), "Failed to remove default SR-IOV operator config")
-
-	By("Validation that SR-IOV webhooks are not available")
-
-	for _, webhookname := range []string{"network-resources-injector-config", "sriov-operator-webhook-config"} {
-		Eventually(func() error {
-			_, err := webhook.PullMutatingConfiguration(APIClient, webhookname)
-
-			return err
-		}, time.Minute, tsparams.RetryInterval).Should(HaveOccurred(),
-			fmt.Sprintf("MutatingWebhook %s was not removed", webhookname))
-	}
-
-	Eventually(func() error {
-		_, err := webhook.PullValidatingConfiguration(APIClient, "sriov-operator-webhook-config")
-
-		return err
-	}, time.Minute, tsparams.RetryInterval).Should(HaveOccurred(),
-		"ValidatingWebhook sriov-operator-webhook-config was not removed")
-
-	By("Removing SR-IOV namespace")
-
-	err = sriovNamespace.DeleteAndWait(tsparams.DefaultTimeout)
-	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf(
-		"Failed to delete SR-IOV namespace %s", NetConfig.SriovOperatorNamespace))
-}
-
-func installSriovOperator(sriovNamespace *namespace.Builder,
-	sriovOperatorGroup *olm.OperatorGroupBuilder,
-	sriovSubscription *olm.SubscriptionBuilder) {
-	By("Creating SR-IOV operator namespace")
-
-	sriovNs := namespace.NewBuilder(APIClient, sriovNamespace.Definition.Name)
-	_, err := sriovNs.Create()
-	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Failed to create SR-IOV namespace %s", sriovNs.Definition.Name))
-
-	By("Creating SR-IOV OperatorGroup")
-
-	sriovOg := olm.NewOperatorGroupBuilder(
-		APIClient,
-		sriovOperatorGroup.Definition.Name,
-		sriovOperatorGroup.Definition.Namespace)
-	_, err = sriovOg.Create()
-	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Failed to create SR-IOV OperatorGroup %s", sriovOg.Definition.Name))
-
-	By("Creating SR-IOV operator Subscription")
-
-	sriovSub := olm.NewSubscriptionBuilder(
-		APIClient, sriovSubscription.Definition.Name,
-		sriovSubscription.Definition.Namespace,
-		sriovSubscription.Definition.Spec.CatalogSource,
-		sriovSubscription.Definition.Spec.CatalogSourceNamespace,
-		sriovSubscription.Definition.Spec.Package)
-	_, err = sriovSub.Create()
-	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Failed to create SR-IOV Subscription %s", sriovSub.Definition.Name))
-
-	By("Creating SR-IOV operator default configuration")
-
-	_, err = sriov.NewOperatorConfigBuilder(APIClient, sriovNamespace.Definition.Name).
-		WithOperatorWebhook(true).
-		WithInjector(true).
-		Create()
-	Expect(err).ToNot(HaveOccurred(), "Failed to create SR-IOV operator config")
 }
 
 func getVfsUnderTest(busyVfs []string) []string {

--- a/tests/cnf/core/network/sriov/tests/sriov-reinstallation.go
+++ b/tests/cnf/core/network/sriov/tests/sriov-reinstallation.go
@@ -1,0 +1,240 @@
+package tests
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/namespace"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/nodes"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/reportxml"
+	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/sriov"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netenv"
+	. "github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netinittools"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/internal/netparam"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/sriov/internal/sriovenv"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/cnf/core/network/sriov/internal/tsparams"
+	"github.com/rh-ecosystem-edge/eco-gotests/tests/internal/sriovoperator"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+const (
+	sriovReinstallResourceName = "sriovreinstall"
+	sriovReinstallNumVFs       = 5
+)
+
+var _ = Describe("SRIOV Operator re-installation", Ordered, Label(tsparams.LabelSriovReinstallation),
+	ContinueOnFailure, func() {
+		var (
+			sriovInterfacesUnderTest []string
+			workerNodeList           []*nodes.Builder
+			installedOperator        *sriovenv.InstalledSriovOperator
+		)
+
+		BeforeAll(func() {
+			By("Verifying if SR-IOV tests can be executed on given cluster")
+
+			err := netenv.DoesClusterHasEnoughNodes(APIClient, NetConfig, 1, 1)
+			if err != nil {
+				Skip(fmt.Sprintf(
+					"given cluster is not suitable for SR-IOV tests because it doesn't have enough nodes: %s", err.Error()))
+			}
+
+			By("Validating SR-IOV interfaces")
+
+			workerNodeList, err = nodes.List(APIClient,
+				metav1.ListOptions{LabelSelector: labels.Set(NetConfig.WorkerLabelMap).String()})
+			Expect(err).ToNot(HaveOccurred(), "Failed to discover worker nodes")
+
+			Expect(sriovenv.ValidateSriovInterfaces(workerNodeList, 1)).ToNot(HaveOccurred(),
+				"Failed to get required SR-IOV interfaces")
+
+			sriovInterfacesUnderTest, err = NetConfig.GetSriovInterfaces(1)
+			Expect(err).ToNot(HaveOccurred(), "Failed to retrieve SR-IOV interfaces for testing")
+
+			By("Collecting info about installed SR-IOV operator")
+
+			installedOperator, err = sriovenv.CollectInstalledSriovOperatorInfo()
+			Expect(err).ToNot(HaveOccurred(), "Failed to collect SR-IOV operator installation info")
+		})
+
+		AfterAll(func() {
+			if err := sriovoperator.IsSriovDeployed(APIClient, NetConfig.SriovOperatorNamespace); err != nil {
+				By("Restoring SR-IOV operator before cleanup")
+
+				installErr := sriovenv.InstallSriovOperator(installedOperator)
+				if installErr != nil {
+					AddReportEntry(
+						"SR-IOV operator restore failure",
+						fmt.Sprintf("Failed to restore SR-IOV operator after test suite: %v", installErr),
+						ReportEntryVisibilityFailureOrVerbose,
+					)
+				} else {
+					By("Waiting for restored SR-IOV operator to become ready")
+
+					waitErr := sriovenv.WaitForSriovOperatorDeployed(
+						tsparams.OperatorInstallWaitTimeout, tsparams.RetryInterval)
+					if waitErr != nil {
+						AddReportEntry(
+							"SR-IOV operator restore failure",
+							fmt.Sprintf("SR-IOV operator is not restored: %v", waitErr),
+							ReportEntryVisibilityFailureOrVerbose,
+						)
+					}
+				}
+			}
+
+			By("Removing SR-IOV configuration")
+
+			err := sriovoperator.RemoveSriovConfigurationAndWaitForSriovAndMCPStable(
+				APIClient,
+				NetConfig.WorkerLabelEnvVar,
+				NetConfig.SriovOperatorNamespace,
+				tsparams.MCOWaitTimeout,
+				tsparams.DefaultTimeout)
+			Expect(err).ToNot(HaveOccurred(), "Failed to remove SR-IOV configuration")
+		})
+
+		It("Operator re-installation. Verify SR-IOV operator control plane is operational before removal",
+			reportxml.ID("46528"), func() {
+				createReinstallSriovConfiguration(sriovInterfacesUnderTest[0])
+			})
+
+		It("Operator re-installation. Verify SR-IOV operator data plane is operational before removal",
+			reportxml.ID("46529"), func() {
+				By("Creating test pods and checking connectivity")
+
+				err := sriovenv.CreatePodsAndRunTraffic(workerNodeList[0].Object.Name, workerNodeList[0].Object.Name,
+					sriovReinstallResourceName, sriovReinstallResourceName, "", "",
+					[]string{tsparams.ClientIPv4IPAddress}, []string{tsparams.ServerIPv4IPAddress})
+				Expect(err).ToNot(HaveOccurred(), "Failed to test connectivity between test pods")
+			})
+
+		It("Operator re-installation. Verify all SR-IOV components are deleted when operator is removed",
+			reportxml.ID("46530"), func() {
+				By("Removing test pods before operator removal")
+
+				err := namespace.NewBuilder(APIClient, tsparams.TestNamespaceName).CleanObjects(
+					netparam.DefaultTimeout, pod.GetGVR())
+				Expect(err).ToNot(HaveOccurred(), "Failed to clean test pods")
+
+				By("Removing SR-IOV operator")
+
+				err = sriovenv.RemoveSriovOperator(installedOperator.Namespace)
+				Expect(err).ToNot(HaveOccurred(), "Failed to remove SR-IOV operator")
+
+				Expect(sriovoperator.IsSriovDeployed(APIClient, NetConfig.SriovOperatorNamespace)).
+					To(HaveOccurred(), "SR-IOV operator is not removed")
+			})
+
+		It("Operator re-installation. Validate that SR-IOV resources can not be deployed without SR-IOV operator",
+			reportxml.ID("46531"),
+			func() {
+				By("Validate that SR-IOV operator namespace was removed")
+
+				_, err := namespace.Pull(APIClient, NetConfig.SriovOperatorNamespace)
+				Expect(err).To(HaveOccurred(), "SR-IOV operator namespace still exists")
+
+				By("Validate that SR-IOV api doesn't work")
+
+				_, err = sriov.NewPolicyBuilder(
+					APIClient,
+					sriovReinstallResourceName,
+					NetConfig.SriovOperatorNamespace,
+					sriovReinstallResourceName,
+					sriovReinstallNumVFs,
+					[]string{sriovInterfacesUnderTest[0] + "#0-1"}, NetConfig.WorkerLabelMap).Create()
+				Expect(err).To(HaveOccurred(), "SriovNetworkNodePolicy is created unexpectedly")
+
+				_, err = sriov.NewNetworkBuilder(
+					APIClient,
+					sriovReinstallResourceName,
+					NetConfig.SriovOperatorNamespace,
+					tsparams.TestNamespaceName,
+					sriovReinstallResourceName).
+					WithStaticIpam().
+					WithMacAddressSupport().
+					WithIPAddressSupport().
+					WithLogLevel(netparam.LogLevelDebug).
+					Create()
+				Expect(err).To(HaveOccurred(), "SriovNetwork is created unexpectedly")
+			})
+
+		It("Operator re-installation. Validate that re-installed SR-IOV operator’s control plane is up and running.",
+			reportxml.ID("46532"),
+			func() {
+				By("Deploy SR-IOV operator")
+
+				err := sriovenv.InstallSriovOperator(installedOperator)
+				Expect(err).ToNot(HaveOccurred(), "Failed to install SR-IOV operator")
+
+				By("Waiting for SR-IOV operator to become ready")
+
+				err = sriovenv.WaitForSriovOperatorDeployed(
+					tsparams.OperatorInstallWaitTimeout, tsparams.RetryInterval)
+				Expect(err).ToNot(HaveOccurred(), "SR-IOV operator is not installed")
+
+				By("Validate that SR-IOV webhooks have expected failure policies")
+
+				Eventually(sriovenv.ValidateReinstalledSriovWebhookFailurePolicies,
+					tsparams.OperatorInstallWaitTimeout, tsparams.RetryInterval).
+					Should(Succeed(), "SR-IOV webhook failure policies are not configured as expected")
+
+				createReinstallSriovConfiguration(sriovInterfacesUnderTest[0])
+			})
+
+		It("Operator re-installation. Validate that re-installed SR-IOV operator’s data plane is up and running",
+			reportxml.ID("46533"),
+			func() {
+				By("Removing test pods before data plane retest")
+
+				err := namespace.NewBuilder(APIClient, tsparams.TestNamespaceName).CleanObjects(
+					netparam.DefaultTimeout, pod.GetGVR())
+				Expect(err).ToNot(HaveOccurred(), "Failed to clean test pods")
+
+				By("Creating test pods and checking connectivity")
+
+				err = sriovenv.CreatePodsAndRunTraffic(workerNodeList[0].Object.Name, workerNodeList[0].Object.Name,
+					sriovReinstallResourceName, sriovReinstallResourceName, "", "",
+					[]string{tsparams.ClientIPv4IPAddress}, []string{tsparams.ServerIPv4IPAddress})
+				Expect(err).ToNot(HaveOccurred(), "Failed to test connectivity between test pods")
+			})
+	})
+
+func createReinstallSriovConfiguration(pfName string) {
+	By("Applying SR-IOV NetworkNodePolicy")
+
+	sriovPolicy := sriov.NewPolicyBuilder(
+		APIClient,
+		sriovReinstallResourceName,
+		NetConfig.SriovOperatorNamespace,
+		sriovReinstallResourceName,
+		sriovReinstallNumVFs,
+		[]string{pfName + "#0-1"},
+		NetConfig.WorkerLabelMap)
+	err := sriovoperator.CreateSriovPolicyAndWaitUntilItsApplied(
+		APIClient,
+		NetConfig.WorkerLabelEnvVar,
+		NetConfig.SriovOperatorNamespace,
+		sriovPolicy,
+		tsparams.MCOWaitTimeout,
+		tsparams.DefaultStableDuration)
+	Expect(err).ToNot(HaveOccurred(), "Failed to configure SR-IOV policy")
+
+	By("Creating SR-IOV network")
+
+	sriovNetworkBuilder := sriov.NewNetworkBuilder(
+		APIClient,
+		sriovReinstallResourceName,
+		NetConfig.SriovOperatorNamespace,
+		tsparams.TestNamespaceName,
+		sriovReinstallResourceName).
+		WithStaticIpam().
+		WithMacAddressSupport().
+		WithIPAddressSupport().
+		WithLogLevel(netparam.LogLevelDebug)
+	err = sriovenv.CreateSriovNetworkAndWaitForNADCreation(sriovNetworkBuilder, tsparams.NADWaitTimeout)
+	Expect(err).ToNot(HaveOccurred(), "Failed to create SR-IOV network")
+}


### PR DESCRIPTION
Summary
Migrated the SR-IOV operator reinstallation test suite from cnf-gotests into tests/cnf/core/network/sriov/tests/sriov-reinstallation.go, covering Polarion cases 46528–46533.
Added shared operator lifecycle helpers in sriovenv/operator.go (CollectInstalledSriovOperatorInfo, RemoveSriovOperator, InstallSriovOperator, webhook validation) and refactored externalllymanaged.go to use them.
Introduced the sriovreinstall test label and SR-IOV webhook name constants in tsparams.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ordered end-to-end coverage for SR-IOV operator removal and reinstallation.
  * Validates operator readiness, SR-IOV control- and data-plane behavior, and that SR-IOV resources can’t be created when the operator is absent.
  * Verifies reinstalled webhook failure-policy expectations and confirms functionality returns after reinstall.
* **Test Improvements**
  * Improved SR-IOV operator lifecycle handling with shared helpers for discovery, teardown, reinstall, and readiness checks.
  * Added SR-IOV-specific identifiers and configurable wait timeouts to make webhook/operator transitions more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->