### PR TITLE
tests/ocp/sriov: bump DPDK test container to v4.16.0

### DIFF
--- a/tests/ocp/sriov/internal/ocpsriovconfig/default.yaml
+++ b/tests/ocp/sriov/internal/ocpsriovconfig/default.yaml
@@ -1,7 +1,7 @@
 ---
 # OCP SR-IOV default configurations.
 ocp_sriov_test_container: quay.io/ocp-edge-qe/eco-gotests-sriov-client:v4.15.2
-dpdk_test_container: quay.io/ocp-edge-qe/eco-gotests-rootless-dpdk:v4.15.0
+dpdk_test_container: quay.io/ocp-edge-qe/eco-gotests-rootless-dpdk:v4.16.0
 sriov_operator_namespace: openshift-sriov-network-operator
 prometheus_operator_namespace: openshift-monitoring
 mcp_label: sriov


### PR DESCRIPTION
## Summary
- Bump `eco-gotests-rootless-dpdk` default image from `v4.15.0` to `v4.16.0`
- `v4.15.0` lacks `tcpdump`, causing the QinQ DPDK client pod (test 72638) to exit immediately with code 127; the test then fails trying to exec into a dead container

## Test plan
- [ ] QinQ DPDK test 72638 passes on next CI run with E810 hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the SR-IOV test environment to use the `dpdk_test_container` image version `v4.16.0`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->