### PR TITLE
cnf ran ptp: fix event API version check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ run-ran-pkg-unit-tests:
 	@echo "Executing eco-gotests RAN package unit tests"
 	UNIT_TEST=true go test -tags=unit_test -v ./tests/cnf/ran/ptp/internal/iface
 	UNIT_TEST=true go test -tags=unit_test -v ./tests/cnf/ran/ptp/internal/profiles
+	UNIT_TEST=true go test -tags=unit_test -v ./tests/cnf/ran/ptp/internal/consumer
 
 run-system-tests-pkg-unit-tests:
 	@echo "Executing eco-gotests internal package unit tests"

--- a/tests/cnf/ran/ptp/internal/consumer/bothversions.go
+++ b/tests/cnf/ran/ptp/internal/consumer/bothversions.go
@@ -81,16 +81,12 @@ func CleanupConsumersOnNodes(client *clients.Settings) error {
 }
 
 // getEventAPIVersion retrieves the event API version from the PTP operator config. If the PTP version on spoke 1 is at
-// least 4.19, the version will always be [eventAPIVersionV2].
+// least 4.19, the version will always be [eventAPIVersionV2]. On versions before 4.16 the apiVersion field does not
+// exist in ptpEventConfig and v1 is used.
 func getEventAPIVersion(client *clients.Settings) (ptpEventAPIVersion, error) {
 	ptpVersion := RANConfig.Spoke1OperatorVersions[ranparam.PTP]
 	if ptpVersion == "" {
 		return "", fmt.Errorf("PTP operator version not found in spoke 1 operator versions")
-	}
-
-	atLeast419, err := version.IsVersionStringInRange(ptpVersion, "4.19.0-0", "")
-	if err != nil {
-		return "", fmt.Errorf("failed to check if PTP version is at least 4.19: %w", err)
 	}
 
 	ptpOperatorConfig, err := ptp.PullPtpOperatorConfig(client)
@@ -108,17 +104,37 @@ func getEventAPIVersion(client *clients.Settings) (ptpEventAPIVersion, error) {
 		return "", errEventsNotEnabled
 	}
 
+	return resolveEventAPIVersion(ptpVersion, ptpOperatorConfig.Definition.Spec.EventConfig.ApiVersion)
+}
+
+// resolveEventAPIVersion resolves the event API version based on the PTP version and the config API version.
+func resolveEventAPIVersion(ptpVersion, configAPIVersion string) (ptpEventAPIVersion, error) {
+	atLeast419, err := version.IsVersionStringInRange(ptpVersion, "4.19.0-0", "")
+	if err != nil {
+		return "", fmt.Errorf("failed to check if PTP version is at least 4.19: %w", err)
+	}
+
 	// If the PTP version is at least 4.19, the event API version is always v2.
 	if atLeast419 {
 		return eventAPIVersionV2, nil
 	}
 
-	switch apiVersion := ptpOperatorConfig.Definition.Spec.EventConfig.ApiVersion; apiVersion {
+	atLeast416, err := version.IsVersionStringInRange(ptpVersion, "4.16.0-0", "")
+	if err != nil {
+		return "", fmt.Errorf("failed to check if PTP version is at least 4.16: %w", err)
+	}
+
+	// The apiVersion field was added in PTP 4.16; earlier versions only support v1.
+	if !atLeast416 {
+		return eventAPIVersionV1, nil
+	}
+
+	switch configAPIVersion {
 	case string(eventAPIVersionV1):
 		return eventAPIVersionV1, nil
 	case string(eventAPIVersionV2):
 		return eventAPIVersionV2, nil
 	default:
-		return "", fmt.Errorf("unknown event API version %s in PTP operator config", apiVersion)
+		return "", fmt.Errorf("unknown event API version %s in PTP operator config", configAPIVersion)
 	}
 }

--- a/tests/cnf/ran/ptp/internal/consumer/bothversions_test.go
+++ b/tests/cnf/ran/ptp/internal/consumer/bothversions_test.go
@@ -1,0 +1,75 @@
+//go:build unit_test
+
+package consumer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveEventAPIVersion(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name              string
+		ptpVersion        string
+		configAPIVersion  string
+		wantAPIVersion    ptpEventAPIVersion
+		wantErrorContains string
+	}{
+		{
+			name:             "PTP 4.14 without apiVersion field defaults to v1",
+			ptpVersion:       "4.14.0",
+			configAPIVersion: "",
+			wantAPIVersion:   eventAPIVersionV1,
+		},
+		{
+			name:              "PTP 4.16 with unset apiVersion returns error",
+			ptpVersion:        "4.16.0",
+			configAPIVersion:  "",
+			wantErrorContains: "unknown event API version  in PTP operator config",
+		},
+		{
+			name:             "PTP 4.16 with explicit v1 uses v1",
+			ptpVersion:       "4.16.0",
+			configAPIVersion: "1.0",
+			wantAPIVersion:   eventAPIVersionV1,
+		},
+		{
+			name:             "PTP 4.18 with explicit v2 uses v2",
+			ptpVersion:       "4.18.0",
+			configAPIVersion: "2.0",
+			wantAPIVersion:   eventAPIVersionV2,
+		},
+		{
+			name:             "PTP 4.19 always uses v2 even when config says v1",
+			ptpVersion:       "4.19.0",
+			configAPIVersion: "1.0",
+			wantAPIVersion:   eventAPIVersionV2,
+		},
+		{
+			name:              "unknown apiVersion returns error",
+			ptpVersion:        "4.17.0",
+			configAPIVersion:  "3.0",
+			wantErrorContains: "unknown event API version 3.0 in PTP operator config",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotAPIVersion, err := resolveEventAPIVersion(testCase.ptpVersion, testCase.configAPIVersion)
+			if testCase.wantErrorContains != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), testCase.wantErrorContains)
+
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.wantAPIVersion, gotAPIVersion)
+		})
+	}
+}


### PR DESCRIPTION
This commit fixes an issue where 4.15 and earlier PTP versions would fail to run tests because the API version in the event config does not exist in the CR. The fix defaults to v1 for versions less than 4.16.

Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event API version selection across supported PTP versions.
  * Added validation and clearer error handling for unsupported API version settings.
  * Preserved automatic compatibility behavior for older and newer PTP releases.

* **Tests**
  * Added coverage for supported versions, defaults, and invalid configuration values.
  * Included the consumer package in the automated Go unit test run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->