### PR TITLE
cnf network: fix security reboot

### DIFF
--- a/tests/cnf/core/network/internal/netenv/netenv.go
+++ b/tests/cnf/core/network/internal/netenv/netenv.go
@@ -341,7 +341,7 @@ func ConfigureSriovMlnxFirmwareOnWorkers(
 		// Reboot is issued separately: the exec session is expected to drop when the node reboots.
 		_, rebootErr := runCommandOnConfigDaemon(apiClient, sriovOperatorNamespace, workerNode.Object.Name,
 			[]string{"bash", "-c", "chroot /host reboot"})
-		if rebootErr != nil && !isRebootExecDisconnectError(rebootErr) {
+		if rebootErr != nil && !IsRebootExecDisconnectError(rebootErr) {
 			return fmt.Errorf("failed to reboot node %s after Mellanox firmware configuration: %s",
 				workerNode.Object.Name, rebootErr.Error())
 		}
@@ -384,8 +384,8 @@ func ConfigureSriovMlnxFirmwareOnWorkersAndWaitMCP(
 	return nil
 }
 
-// isRebootExecDisconnectError reports whether err is the expected exec failure when reboot closes the session.
-func isRebootExecDisconnectError(err error) bool {
+// IsRebootExecDisconnectError reports whether err is the expected exec failure when reboot closes the session.
+func IsRebootExecDisconnectError(err error) bool {
 	if err == nil {
 		return false
 	}
@@ -398,6 +398,9 @@ func isRebootExecDisconnectError(err error) bool {
 		strings.Contains(msg, "broken pipe") ||
 		strings.Contains(msg, "unable to upgrade connection") ||
 		strings.Contains(msg, "command terminated") ||
+		strings.Contains(msg, "i/o timeout") ||
+		strings.Contains(msg, "error reading from error stream") ||
+		strings.Contains(msg, "use of closed network connection") ||
 		errors.Is(err, context.Canceled) ||
 		errors.Is(err, context.DeadlineExceeded)
 }

--- a/tests/cnf/core/network/security/tests/nftables-custom-firewall-test.go
+++ b/tests/cnf/core/network/security/tests/nftables-custom-firewall-test.go
@@ -655,8 +655,11 @@ func rebootNodeAndWaitForMcpStable(nodeName string) {
 	_, err := cluster.ExecCmdWithStdout(APIClient,
 		"reboot -f",
 		metav1.ListOptions{LabelSelector: fmt.Sprintf("kubernetes.io/hostname=%s", nodeName)})
-	Expect(err).ToNot(HaveOccurred(),
-		"Failed to reboot worker node with label %s", nodeName)
+	// reboot -f drops the exec stream; treat disconnect/timeout as expected.
+	if err != nil && !netenv.IsRebootExecDisconnectError(err) {
+		Expect(err).ToNot(HaveOccurred(),
+			"Failed to reboot worker node with label %s", nodeName)
+	}
 
 	err = cluster.WaitForMcpStable(APIClient, 35*time.Minute, 1*time.Minute, NetConfig.CnfMcpLabel)
 	Expect(err).ToNot(HaveOccurred(), "Failed to wait for MCP to be stable")


### PR DESCRIPTION
Summary

- Reuse existing netenv reboot disconnect helper for nftables reboot -f (test 77144).
- Export IsRebootExecDisconnectError and use it in rebootNodeAndWaitForMcpStable so expected exec stream drops are ignored; MCP wait remains the success check.
- Extend the helper to also match i/o timeout, error reading from error stream, and use of closed network connection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reboot handling for SR-IOV and firewall validation flows.
  * Recognized additional expected disconnect, timeout, and closed-connection errors during forced reboots.
  * Prevented tests from failing when reboot interrupts the command connection as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->