### PR TITLE
cnf ran oran: make mock-smo helpers generic

### DIFF
--- a/tests/cnf/ran/oran/internal/helper/helper.go
+++ b/tests/cnf/ran/oran/internal/helper/helper.go
@@ -220,7 +220,8 @@ func WaitForAllNotifications(
 			// duplicates.
 			newStartTime := time.Now()
 
-			receivedNotifications, err := mocksmo.ListReceivedNotifications(client, namespace, startTime, observerID)
+			receivedNotifications, err := mocksmo.ListReceived[oranapi.AlarmEventNotification](
+				client, namespace, startTime, observerID)
 			if err != nil {
 				klog.V(tsparams.LogLevel).Infof("Failed to list received notifications: %v", err)
 

--- a/tests/cnf/ran/oran/tests/oran-alarms.go
+++ b/tests/cnf/ran/oran/tests/oran-alarms.go
@@ -159,10 +159,10 @@ var _ = Describe("ORAN Alarms Tests", Label(tsparams.LabelPostProvision, tsparam
 
 		By("waiting for the notification")
 
-		err = mocksmo.WaitForNotification(HubAPIClient, RANConfig.MockSMONamespace,
-			mocksmo.WithStart(timeBeforeAcknowledge),
-			mocksmo.WithObserverID(subscriptionID.String()),
-			mocksmo.WithMatchFunc(func(notification *oranapi.AlarmEventNotification) bool {
+		err = mocksmo.WaitFor[oranapi.AlarmEventNotification](HubAPIClient, RANConfig.MockSMONamespace,
+			mocksmo.WithStart[oranapi.AlarmEventNotification](timeBeforeAcknowledge),
+			mocksmo.WithObserverID[oranapi.AlarmEventNotification](subscriptionID.String()),
+			mocksmo.WithMatch(func(notification *oranapi.AlarmEventNotification) bool {
 				return notification.Extensions["tracker"] == tracker &&
 					notification.NotificationEventType == oranapi.AlarmEventNotificationTypeACKNOWLEDGE
 			}),

--- a/tests/internal/oran-mock-smo/observer.go
+++ b/tests/internal/oran-mock-smo/observer.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/clients"
-	oranapi "github.com/rh-ecosystem-edge/eco-goinfra/pkg/oran/api"
 	"github.com/rh-ecosystem-edge/eco-goinfra/pkg/pod"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -43,58 +42,6 @@ type observerEchoLogEntry struct {
 	Body       json.RawMessage `json:"body"`
 }
 
-// waitForNotificationOptions are all of the options for the wait for a matching notification. It is used for an
-// options pattern to the WaitForNotification function.
-type waitForNotificationOptions struct {
-	timeout    time.Duration
-	start      time.Time
-	observerID string
-	matchFunc  func(notification *oranapi.AlarmEventNotification) bool
-}
-
-// getDefaultWaitForNotificationOptions returns the default options for the wait for a matching notification. The
-// defaults are a 30 second timeout, start time of now (when this function is called) and a match function that returns
-// true if any notification is received.
-func getDefaultWaitForNotificationOptions() *waitForNotificationOptions {
-	return &waitForNotificationOptions{
-		timeout:   time.Second * 30,
-		start:     time.Now(),
-		matchFunc: func(notification *oranapi.AlarmEventNotification) bool { return true },
-	}
-}
-
-// waitForNotificationOption is a function that can be used to modify the options for the wait for a matching
-// notification.
-type waitForNotificationOption func(options *waitForNotificationOptions)
-
-// WithTimeout sets the timeout for the wait for a matching notification.
-func WithTimeout(timeout time.Duration) waitForNotificationOption {
-	return func(options *waitForNotificationOptions) {
-		options.timeout = timeout
-	}
-}
-
-// WithStart sets the start time for the wait for a matching notification.
-func WithStart(start time.Time) waitForNotificationOption {
-	return func(options *waitForNotificationOptions) {
-		options.start = start
-	}
-}
-
-// WithObserverID limits notifications to those received for the given observer ID.
-func WithObserverID(observerID string) waitForNotificationOption {
-	return func(options *waitForNotificationOptions) {
-		options.observerID = observerID
-	}
-}
-
-// WithMatchFunc sets the match function for the wait for a matching notification.
-func WithMatchFunc(matchFunc func(notification *oranapi.AlarmEventNotification) bool) waitForNotificationOption {
-	return func(options *waitForNotificationOptions) {
-		options.matchFunc = matchFunc
-	}
-}
-
 // PullPod pulls the mock SMO server pod from the cluster. It will fail if no pods matching the app label are found. If
 // more than one pod is found, it will log a warning and return the first one.
 func PullPod(client *clients.Settings, nsname string) (*pod.Builder, error) {
@@ -120,13 +67,59 @@ func PullPod(client *clients.Settings, nsname string) (*pod.Builder, error) {
 	return matchingPods[0], nil
 }
 
-// WaitForNotification waits for an observer echo notification in the mock SMO server logs. Callers may provide options,
+type waitOptions[T any] struct {
+	timeout    time.Duration
+	start      time.Time
+	observerID string
+	matchFunc  func(*T) bool
+}
+
+// WaitOption configures WaitFor.
+type WaitOption[T any] func(*waitOptions[T])
+
+func defaultWaitOptions[T any]() *waitOptions[T] {
+	return &waitOptions[T]{
+		timeout:   time.Second * 30,
+		start:     time.Now(),
+		matchFunc: func(*T) bool { return true },
+	}
+}
+
+// WithTimeout sets the timeout for WaitFor.
+func WithTimeout[T any](timeout time.Duration) WaitOption[T] {
+	return func(options *waitOptions[T]) {
+		options.timeout = timeout
+	}
+}
+
+// WithStart sets the start time for WaitFor.
+func WithStart[T any](start time.Time) WaitOption[T] {
+	return func(options *waitOptions[T]) {
+		options.start = start
+	}
+}
+
+// WithObserverID limits notifications to those received for the given observer ID.
+func WithObserverID[T any](observerID string) WaitOption[T] {
+	return func(options *waitOptions[T]) {
+		options.observerID = observerID
+	}
+}
+
+// WithMatch sets the match function for WaitFor.
+func WithMatch[T any](matchFunc func(*T) bool) WaitOption[T] {
+	return func(options *waitOptions[T]) {
+		options.matchFunc = matchFunc
+	}
+}
+
+// WaitFor waits for an observer echo notification in the mock SMO server logs. Callers may provide options,
 // otherwise the defaults of 30 seconds timeout, start time of now, and a match function that returns true if any
 // notification is received will be used.
-func WaitForNotification(client *clients.Settings, namespace string, options ...waitForNotificationOption) error {
-	appliedOptions := getDefaultWaitForNotificationOptions()
+func WaitFor[T any](client *clients.Settings, namespace string, opts ...WaitOption[T]) error {
+	appliedOptions := defaultWaitOptions[T]()
 
-	for _, option := range options {
+	for _, option := range opts {
 		option(appliedOptions)
 	}
 
@@ -151,7 +144,7 @@ func WaitForNotification(client *clients.Settings, namespace string, options ...
 			// more efficient.
 			appliedOptions.start = newStart
 
-			parsedNotifications, err := parseNotifications(notificationsRaw, appliedOptions.observerID)
+			parsedNotifications, err := parseNotifications[T](notificationsRaw, appliedOptions.observerID)
 			if err != nil {
 				return false, fmt.Errorf("failed to parse notifications: %w", err)
 			}
@@ -160,14 +153,14 @@ func WaitForNotification(client *clients.Settings, namespace string, options ...
 		})
 }
 
-// ListReceivedNotifications lists observer echo notifications received since the given time. If sinceTime is zero, then
+// ListReceived lists observer echo notifications received since the given time. If sinceTime is zero, then
 // all notifications will be listed. If observerID is non-empty, only notifications for that observer are returned.
-func ListReceivedNotifications(
+func ListReceived[T any](
 	client *clients.Settings,
 	namespace string,
 	sinceTime time.Time,
 	observerID string,
-) ([]*oranapi.AlarmEventNotification, error) {
+) ([]*T, error) {
 	pod, err := PullPod(client, namespace)
 	if err != nil {
 		return nil, fmt.Errorf("failed to pull mock SMO server pod: %w", err)
@@ -185,7 +178,7 @@ func ListReceivedNotifications(
 		return nil, fmt.Errorf("failed to get mock SMO server pod logs: %w", err)
 	}
 
-	parsedNotifications, err := parseNotifications(notificationsRaw, observerID)
+	parsedNotifications, err := parseNotifications[T](notificationsRaw, observerID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse notifications: %w", err)
 	}
@@ -197,11 +190,11 @@ func ListReceivedNotifications(
 // in parsing. If an error is returned, the notifications will be empty. Elements of the returned slice are guaranteed
 // not to be nil.
 //
-// Notifications are expected as slog JSON log lines with msg "Observer echo notification". The alarm body is nested
-// under the body field. The parsing will look for the opening curly brace to determine the start of the JSON. Anything
-// prior to it on the line will be ignored.
-func parseNotifications(notificationsRaw []byte, observerID string) ([]*oranapi.AlarmEventNotification, error) {
-	var notifications []*oranapi.AlarmEventNotification
+// Notifications are expected as slog JSON log lines with msg "Observer echo notification". The notification body is
+// nested under the body field. The parsing will look for the opening curly brace to determine the start of the JSON.
+// Anything prior to it on the line will be ignored.
+func parseNotifications[T any](notificationsRaw []byte, observerID string) ([]*T, error) {
+	var notifications []*T
 
 	scanner := bufio.NewScanner(bytes.NewReader(notificationsRaw))
 	for scanner.Scan() {
@@ -234,7 +227,7 @@ func parseNotifications(notificationsRaw []byte, observerID string) ([]*oranapi.
 			continue
 		}
 
-		var notification oranapi.AlarmEventNotification
+		var notification T
 
 		err = json.Unmarshal(logEntry.Body, &notification)
 		if err != nil {

--- a/tests/internal/oran-mock-smo/observer_test.go
+++ b/tests/internal/oran-mock-smo/observer_test.go
@@ -34,7 +34,7 @@ func TestParseNotifications(t *testing.T) {
 			`"observerId":"sub-2","body":null}` + "\n",
 	)
 
-	notifications, err := parseNotifications(logs, "")
+	notifications, err := parseNotifications[oranapi.AlarmEventNotification](logs, "")
 	require.NoError(t, err)
 	require.Len(t, notifications, 1)
 
@@ -53,8 +53,26 @@ func TestParseNotificationsFiltersByObserverID(t *testing.T) {
 			`"observerId":"other","body":{"notificationEventType":0,"extensions":{"tracker":"two"}}}` + "\n",
 	)
 
-	notifications, err := parseNotifications(logs, "wanted")
+	notifications, err := parseNotifications[oranapi.AlarmEventNotification](logs, "wanted")
 	require.NoError(t, err)
 	require.Len(t, notifications, 1)
 	assert.Equal(t, "one", notifications[0].Extensions["tracker"])
+}
+
+func TestParseNotificationsGenericType(t *testing.T) {
+	t.Parallel()
+
+	type stubNotification struct {
+		ID string `json:"id"`
+	}
+
+	logs := []byte(
+		`{"time":"2026-07-28T12:25:10.000000000Z","level":"INFO","msg":"Observer echo notification",` +
+			`"observerId":"sub-1","body":{"id":"inventory-42"}}` + "\n",
+	)
+
+	notifications, err := parseNotifications[stubNotification](logs, "")
+	require.NoError(t, err)
+	require.Len(t, notifications, 1)
+	assert.Equal(t, "inventory-42", notifications[0].ID)
 }


### PR DESCRIPTION
## Summary

- Convert `oran-mock-smo` observer helpers (`WaitFor`, `WithStart`, `WithObserverID`, `WithMatch`) to generics so they can be reused across O2IMS APIs with different notification types.
- Update `oran-alarms` and `helper` call sites to use the generic forms.
- No functional changes; prepares for testing subscriptions from multiple O2IMS APIs.

## Test plan

- [x] Jenkins `ocp-far-edge-vran-tests` #7203 — `oran-post-provision` with `alarms` label on `cnfdf34` (OCP 5.0): **SUCCESS** (7 passed, 0 failed)
  - https://jenkins-csb-kniqe-ci.dno.corp.redhat.com/job/ocp-far-edge-vran-tests/7203/
- [x] Branch: `oran-mock-smo-generic` from `klaskosk/eco-gotests`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated alarm notification tests to use typed notification handling.
  * Added coverage for parsing custom notification types and extracting identifiers.

* **Refactor**
  * Generalized notification waiting and listing to support multiple notification types.
  * Preserved existing filtering, matching, error handling, polling, and timeout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->